### PR TITLE
docs: Upstream docstring: fix a copy-paste error

### DIFF
--- a/kong/types.go
+++ b/kong/types.go
@@ -143,7 +143,7 @@ type Healthcheck struct {
 	Threshold *float64            `json:"threshold,omitempty" yaml:"threshold,omitempty"`
 }
 
-// Upstream represents a Consumer in Kong.
+// Upstream represents an Upstream in Kong.
 // +k8s:deepcopy-gen=true
 type Upstream struct {
 	ID                 *string      `json:"id,omitempty" yaml:"id,omitempty"`


### PR DESCRIPTION
Fixes a copy-paste error in a docstring for `type Upstream`.