### PR TITLE
feat: rich HTTP errors

### DIFF
--- a/kong/consumer_service.go
+++ b/kong/consumer_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 )
 
 // ConsumerService handles Consumers in Kong.
@@ -87,7 +88,7 @@ func (s *ConsumerService) GetByCustomID(ctx context.Context,
 	}
 
 	if len(resp.Data) == 0 {
-		return nil, err404{}
+		return nil, &kongAPIError{httpCode: http.StatusNotFound, message: "Not found"}
 	}
 
 	return &resp.Data[0], nil

--- a/kong/error.go
+++ b/kong/error.go
@@ -1,13 +1,8 @@
 package kong
 
-import "fmt"
-
-type err404 struct {
-}
-
-func (e err404) Error() string {
-	return "Not found"
-}
+import (
+	"fmt"
+)
 
 type kongAPIError struct {
 	httpCode int

--- a/kong/error.go
+++ b/kong/error.go
@@ -1,5 +1,7 @@
 package kong
 
+import "fmt"
+
 type err404 struct {
 }
 
@@ -7,12 +9,22 @@ func (e err404) Error() string {
 	return "Not found"
 }
 
+type kongAPIError struct {
+	httpCode int
+	message  string
+}
+
+func (e *kongAPIError) Error() string {
+	return fmt.Sprintf("HTTP status %d (message: %q)", e.httpCode, e.message)
+}
+
 // IsNotFoundErr returns true if the error or it's cause is
 // a 404 response from Kong.
 func IsNotFoundErr(e error) bool {
-	if e == nil {
+	switch e := e.(type) {
+	case *kongAPIError:
+		return e.httpCode == 404
+	default:
 		return false
 	}
-	_, ok := e.(err404)
-	return ok
 }

--- a/kong/error_test.go
+++ b/kong/error_test.go
@@ -10,7 +10,7 @@ import (
 func TestIsNotFoundErr(T *testing.T) {
 
 	assert := assert.New(T)
-	var e err404
+	var e error = &kongAPIError{httpCode: 404}
 	assert.True(IsNotFoundErr(e))
 	assert.False(IsNotFoundErr(nil))
 

--- a/kong/kong_test.go
+++ b/kong/kong_test.go
@@ -58,7 +58,7 @@ func TestDo(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(req)
 	resp, err := client.Do(context.Background(), req, nil)
-	assert.Equal(err, err404{})
+	assert.True(IsNotFoundErr(err))
 	assert.NotNil(resp)
 	assert.Equal(404, resp.StatusCode)
 

--- a/kong/response.go
+++ b/kong/response.go
@@ -17,18 +17,6 @@ func newResponse(res *http.Response) *Response {
 	return &Response{Response: res}
 }
 
-func hasError(res *http.Response) error {
-	if res.StatusCode >= 200 && res.StatusCode <= 399 {
-		return nil
-	}
-
-	body, _ := ioutil.ReadAll(res.Body) // TODO error in error?
-	return &kongAPIError{
-		httpCode: res.StatusCode,
-		message:  messageFromBody(body),
-	}
-}
-
 func messageFromBody(b []byte) string {
 	s := struct {
 		Message string
@@ -39,4 +27,16 @@ func messageFromBody(b []byte) string {
 	}
 
 	return s.Message
+}
+
+func hasError(res *http.Response) error {
+	if res.StatusCode >= 200 && res.StatusCode <= 399 {
+		return nil
+	}
+
+	body, _ := ioutil.ReadAll(res.Body) // TODO error in error?
+	return &kongAPIError{
+		httpCode: res.StatusCode,
+		message:  messageFromBody(body),
+	}
 }

--- a/kong/response_test.go
+++ b/kong/response_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMessageFromBody(T *testing.T) {
+func TestHasError(T *testing.T) {
 	for _, tt := range []struct {
 		name     string
 		response http.Response
@@ -31,6 +31,39 @@ func TestMessageFromBody(T *testing.T) {
 			want: &kongAPIError{
 				httpCode: 404,
 				message:  "potayto pohtato",
+			},
+		},
+		{
+			name: "code 404, message field missing",
+			response: http.Response{
+				StatusCode: 404,
+				Body:       ioutil.NopCloser(strings.NewReader(`{"nothing": "nothing"}`)),
+			},
+			want: &kongAPIError{
+				httpCode: 404,
+				message:  "",
+			},
+		},
+		{
+			name: "code 404, empty body",
+			response: http.Response{
+				StatusCode: 404,
+				Body:       ioutil.NopCloser(strings.NewReader(``)),
+			},
+			want: &kongAPIError{
+				httpCode: 404,
+				message:  "<failed to parse response body: unexpected end of JSON input>",
+			},
+		},
+		{
+			name: "code 404, unparseable json",
+			response: http.Response{
+				StatusCode: 404,
+				Body:       ioutil.NopCloser(strings.NewReader(`This is not json`)),
+			},
+			want: &kongAPIError{
+				httpCode: 404,
+				message:  "<failed to parse response body: invalid character 'T' looking for beginning of value>",
 			},
 		},
 	} {

--- a/kong/response_test.go
+++ b/kong/response_test.go
@@ -1,0 +1,42 @@
+package kong
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMessageFromBody(T *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		response http.Response
+		want     error
+	}{
+		{
+			name: "code 200",
+			response: http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(strings.NewReader("")),
+			},
+		},
+		{
+			name: "code 404",
+			response: http.Response{
+				StatusCode: 404,
+				Body:       ioutil.NopCloser(strings.NewReader(`{"message": "potayto pohtato", "some": "other field"}`)),
+			},
+			want: &kongAPIError{
+				httpCode: 404,
+				message:  "potayto pohtato",
+			},
+		},
+	} {
+		T.Run(tt.name, func(T *testing.T) {
+			got := hasError(&tt.response)
+			assert.Equal(T, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This PR:
- improves error messages returned by HTTP calls to Kong Admin API by including the `message` from the response body,
- ensures that all users test errors for being equal to 404 by means of the public API.

Inspired by https://github.com/Kong/deck/issues/218#issuecomment-712192401.