### PR TITLE
feat: export KongAPIError and expose HTTP status code

### DIFF
--- a/kong/consumer_service.go
+++ b/kong/consumer_service.go
@@ -88,7 +88,7 @@ func (s *ConsumerService) GetByCustomID(ctx context.Context,
 	}
 
 	if len(resp.Data) == 0 {
-		return nil, &kongAPIError{httpCode: http.StatusNotFound, message: "Not found"}
+		return nil, &KongAPIError{httpCode: http.StatusNotFound, message: "Not found"}
 	}
 
 	return &resp.Data[0], nil

--- a/kong/consumer_service.go
+++ b/kong/consumer_service.go
@@ -88,7 +88,7 @@ func (s *ConsumerService) GetByCustomID(ctx context.Context,
 	}
 
 	if len(resp.Data) == 0 {
-		return nil, &KongAPIError{httpCode: http.StatusNotFound, message: "Not found"}
+		return nil, &APIError{httpCode: http.StatusNotFound, message: "Not found"}
 	}
 
 	return &resp.Data[0], nil

--- a/kong/error.go
+++ b/kong/error.go
@@ -4,20 +4,24 @@ import (
 	"fmt"
 )
 
-type kongAPIError struct {
+type KongAPIError struct {
 	httpCode int
 	message  string
 }
 
-func (e *kongAPIError) Error() string {
+func (e *KongAPIError) Error() string {
 	return fmt.Sprintf("HTTP status %d (message: %q)", e.httpCode, e.message)
+}
+
+func (e *KongAPIError) Code() int {
+	return e.httpCode
 }
 
 // IsNotFoundErr returns true if the error or it's cause is
 // a 404 response from Kong.
 func IsNotFoundErr(e error) bool {
 	switch e := e.(type) {
-	case *kongAPIError:
+	case *KongAPIError:
 		return e.httpCode == 404
 	default:
 		return false

--- a/kong/error.go
+++ b/kong/error.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 )
 
+// APIError is used for Kong Admin API errors.
 type APIError struct {
 	httpCode int
 	message  string
@@ -13,6 +14,7 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("HTTP status %d (message: %q)", e.httpCode, e.message)
 }
 
+// Code returns the HTTP status code for the error.
 func (e *APIError) Code() int {
 	return e.httpCode
 }

--- a/kong/error.go
+++ b/kong/error.go
@@ -4,16 +4,16 @@ import (
 	"fmt"
 )
 
-type KongAPIError struct {
+type APIError struct {
 	httpCode int
 	message  string
 }
 
-func (e *KongAPIError) Error() string {
+func (e *APIError) Error() string {
 	return fmt.Sprintf("HTTP status %d (message: %q)", e.httpCode, e.message)
 }
 
-func (e *KongAPIError) Code() int {
+func (e *APIError) Code() int {
 	return e.httpCode
 }
 
@@ -21,7 +21,7 @@ func (e *KongAPIError) Code() int {
 // a 404 response from Kong.
 func IsNotFoundErr(e error) bool {
 	switch e := e.(type) {
-	case *KongAPIError:
+	case *APIError:
 		return e.httpCode == 404
 	default:
 		return false

--- a/kong/error_test.go
+++ b/kong/error_test.go
@@ -10,7 +10,7 @@ import (
 func TestIsNotFoundErr(T *testing.T) {
 
 	assert := assert.New(T)
-	var e error = &KongAPIError{httpCode: 404}
+	var e error = &APIError{httpCode: 404}
 	assert.True(IsNotFoundErr(e))
 	assert.False(IsNotFoundErr(nil))
 
@@ -32,7 +32,7 @@ func TestIsNotFoundErrE2E(T *testing.T) {
 	assert.True(IsNotFoundErr(err))
 }
 
-func TestKongAPIError_Code(T *testing.T) {
+func TestAPIError_Code(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -43,7 +43,7 @@ func TestKongAPIError_Code(T *testing.T) {
 	assert.Nil(consumer)
 	assert.NotNil(err)
 
-	kongErr, ok := err.(*KongAPIError)
+	kongErr, ok := err.(*APIError)
 	assert.True(ok)
 	assert.True(kongErr.Code() == 404)
 }

--- a/kong/error_test.go
+++ b/kong/error_test.go
@@ -10,7 +10,7 @@ import (
 func TestIsNotFoundErr(T *testing.T) {
 
 	assert := assert.New(T)
-	var e error = &kongAPIError{httpCode: 404}
+	var e error = &KongAPIError{httpCode: 404}
 	assert.True(IsNotFoundErr(e))
 	assert.False(IsNotFoundErr(nil))
 
@@ -30,4 +30,20 @@ func TestIsNotFoundErrE2E(T *testing.T) {
 	assert.Nil(consumer)
 	assert.NotNil(err)
 	assert.True(IsNotFoundErr(err))
+}
+
+func TestKongAPIError_Code(T *testing.T) {
+	assert := assert.New(T)
+
+	client, err := NewTestClient(nil, nil)
+	assert.Nil(err)
+	assert.NotNil(client)
+
+	consumer, err := client.Consumers.Get(defaultCtx, String("does-not-exists"))
+	assert.Nil(consumer)
+	assert.NotNil(err)
+
+	kongErr, ok := err.(*KongAPIError)
+	assert.True(ok)
+	assert.True(kongErr.Code() == 404)
 }

--- a/kong/response.go
+++ b/kong/response.go
@@ -35,7 +35,7 @@ func hasError(res *http.Response) error {
 	}
 
 	body, _ := ioutil.ReadAll(res.Body) // TODO error in error?
-	return &kongAPIError{
+	return &KongAPIError{
 		httpCode: res.StatusCode,
 		message:  messageFromBody(body),
 	}

--- a/kong/response.go
+++ b/kong/response.go
@@ -35,7 +35,7 @@ func hasError(res *http.Response) error {
 	}
 
 	body, _ := ioutil.ReadAll(res.Body) // TODO error in error?
-	return &KongAPIError{
+	return &APIError{
 		httpCode: res.StatusCode,
 		message:  messageFromBody(body),
 	}

--- a/kong/response_test.go
+++ b/kong/response_test.go
@@ -28,7 +28,7 @@ func TestHasError(T *testing.T) {
 				StatusCode: 404,
 				Body:       ioutil.NopCloser(strings.NewReader(`{"message": "potayto pohtato", "some": "other field"}`)),
 			},
-			want: &kongAPIError{
+			want: &KongAPIError{
 				httpCode: 404,
 				message:  "potayto pohtato",
 			},
@@ -39,7 +39,7 @@ func TestHasError(T *testing.T) {
 				StatusCode: 404,
 				Body:       ioutil.NopCloser(strings.NewReader(`{"nothing": "nothing"}`)),
 			},
-			want: &kongAPIError{
+			want: &KongAPIError{
 				httpCode: 404,
 				message:  "",
 			},
@@ -50,7 +50,7 @@ func TestHasError(T *testing.T) {
 				StatusCode: 404,
 				Body:       ioutil.NopCloser(strings.NewReader(``)),
 			},
-			want: &kongAPIError{
+			want: &KongAPIError{
 				httpCode: 404,
 				message:  "<failed to parse response body: unexpected end of JSON input>",
 			},
@@ -61,7 +61,7 @@ func TestHasError(T *testing.T) {
 				StatusCode: 404,
 				Body:       ioutil.NopCloser(strings.NewReader(`This is not json`)),
 			},
-			want: &kongAPIError{
+			want: &KongAPIError{
 				httpCode: 404,
 				message:  "<failed to parse response body: invalid character 'T' looking for beginning of value>",
 			},

--- a/kong/response_test.go
+++ b/kong/response_test.go
@@ -28,7 +28,7 @@ func TestHasError(T *testing.T) {
 				StatusCode: 404,
 				Body:       ioutil.NopCloser(strings.NewReader(`{"message": "potayto pohtato", "some": "other field"}`)),
 			},
-			want: &KongAPIError{
+			want: &APIError{
 				httpCode: 404,
 				message:  "potayto pohtato",
 			},
@@ -39,7 +39,7 @@ func TestHasError(T *testing.T) {
 				StatusCode: 404,
 				Body:       ioutil.NopCloser(strings.NewReader(`{"nothing": "nothing"}`)),
 			},
-			want: &KongAPIError{
+			want: &APIError{
 				httpCode: 404,
 				message:  "",
 			},
@@ -50,7 +50,7 @@ func TestHasError(T *testing.T) {
 				StatusCode: 404,
 				Body:       ioutil.NopCloser(strings.NewReader(``)),
 			},
-			want: &KongAPIError{
+			want: &APIError{
 				httpCode: 404,
 				message:  "<failed to parse response body: unexpected end of JSON input>",
 			},
@@ -61,7 +61,7 @@ func TestHasError(T *testing.T) {
 				StatusCode: 404,
 				Body:       ioutil.NopCloser(strings.NewReader(`This is not json`)),
 			},
-			want: &KongAPIError{
+			want: &APIError{
 				httpCode: 404,
 				message:  "<failed to parse response body: invalid character 'T' looking for beginning of value>",
 			},


### PR DESCRIPTION
Exports KongAPIError and a method `Code` is added to it which returns the HTTP status code

Closes #10 