### PR TITLE
Release v0.16.0. Add Service.URL. Add changelog for v0.15.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v0.15.0](#v0150---20210122)
 - [v0.14.0](#v0140---20210112)
 - [v0.13.0](#v0130---20200804)
 - [v0.12.0](#v0120---20200730)
@@ -18,6 +19,18 @@
 - [0.3.0](#030---20181219)
 - [0.2.0](#020---20181219)
 - [0.1.0](#010---20181201)
+
+## [v0.16.0] - 2021/03/03
+
+### Added
+
+- `Service` now includes `URL`.
+
+## [v0.15.0] - 2021/01/22
+
+### Added
+
+- `Route` now includes `RequestBuffering` and `ResponseBuffering`.
 
 ## [v0.14.0] - 2021/01/12
 
@@ -277,6 +290,8 @@ authentication credentials in Kong.
   releases of Kong since every release of Kong is introducing breaking changes
   to the Admin API.
 
+[v0.16.0]: https://github.com/Kong/go-kong/compare/v0.15.0...v0.16.0
+[v0.15.0]: https://github.com/Kong/go-kong/compare/v0.14.0...v0.15.0
 [v0.14.0]: https://github.com/Kong/go-kong/compare/v0.13.0...v0.14.0
 [v0.13.0]: https://github.com/Kong/go-kong/compare/v0.12.0...v0.13.0
 [v0.12.0]: https://github.com/Kong/go-kong/compare/v0.11.0...v0.12.0

--- a/kong/types.go
+++ b/kong/types.go
@@ -21,6 +21,7 @@ type Service struct {
 	ReadTimeout       *int         `json:"read_timeout,omitempty" yaml:"read_timeout,omitempty"`
 	Retries           *int         `json:"retries,omitempty" yaml:"retries,omitempty"`
 	UpdatedAt         *int         `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+	URL               *string      `json:"url,omitempty" yaml:"url,omitempty"`
 	WriteTimeout      *int         `json:"write_timeout,omitempty" yaml:"write_timeout,omitempty"`
 	Tags              []*string    `json:"tags,omitempty" yaml:"tags,omitempty"`
 	TLSVerify         *bool        `json:"tls_verify,omitempty" yaml:"tls_verify,omitempty"`

--- a/kong/zz_generated.deepcopy.go
+++ b/kong/zz_generated.deepcopy.go
@@ -1481,6 +1481,11 @@ func (in *Service) DeepCopyInto(out *Service) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.URL != nil {
+		in, out := &in.URL, &out.URL
+		*out = new(string)
+		**out = **in
+	}
 	if in.WriteTimeout != nil {
 		in, out := &in.WriteTimeout, &out.WriteTimeout
 		*out = new(int)


### PR DESCRIPTION
`Service.URL` is a prerequisite for https://github.com/Kong/kubernetes-ingress-controller/issues/925. The `v0.16.0` release aims at adding the `URL` field.

Also, v0.15.0 was released without a changelog. This PR fixes that.