### PR TITLE
Add interface types for all go-kong services

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -28,7 +28,6 @@ github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tFY=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
-github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -45,7 +44,6 @@ github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -85,13 +83,11 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -106,9 +102,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -127,12 +121,10 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/kong/acl_service.go
+++ b/kong/acl_service.go
@@ -5,6 +5,25 @@ import (
 	"encoding/json"
 )
 
+// AbstractACLService handles consumer ACL groups in Kong.
+type AbstractACLService interface {
+	// Create adds a consumer to an ACL group in Kong
+	Create(ctx context.Context, consumerUsernameOrID *string, aclGroup *ACLGroup) (*ACLGroup, error)
+	// Get fetches an ACL group for a consumer in Kong.
+	Get(ctx context.Context, consumerUsernameOrID, groupOrID *string) (*ACLGroup, error)
+	// Update updates an ACL group for a consumer in Kong
+	Update(ctx context.Context, consumerUsernameOrID *string, aclGroup *ACLGroup) (*ACLGroup, error)
+	// Delete deletes an ACL group association for a consumer in Kong
+	Delete(ctx context.Context, consumerUsernameOrID, groupOrID *string) error
+	// List fetches a list of all ACL group and consumer associations in Kong.
+	List(ctx context.Context, opt *ListOpt) ([]*ACLGroup, *ListOpt, error)
+	// ListAll fetches all all ACL group associations in Kong.
+	ListAll(ctx context.Context) ([]*ACLGroup, error)
+	// ListForConsumer fetches a list of ACL groups
+	// in Kong associated with a specific consumer.
+	ListForConsumer(ctx context.Context, consumerUsernameOrID *string, opt *ListOpt) ([]*ACLGroup, *ListOpt, error)
+}
+
 // ACLService handles consumer ACL groups in Kong.
 type ACLService service
 

--- a/kong/admin_service.go
+++ b/kong/admin_service.go
@@ -8,6 +8,39 @@ import (
 	"strings"
 )
 
+// AbstractAdminService handles Admins in Kong.
+type AbstractAdminService interface {
+	// Invite creates an Admin in Kong.
+	Invite(ctx context.Context, admin *Admin) (*Admin, error)
+	// Create aliases the Invite function as it performs
+	// essentially the same operation.
+	Create(ctx context.Context, admin *Admin) (*Admin, error)
+	// Get fetches a Admin in Kong.
+	Get(ctx context.Context, nameOrID *string) (*Admin, error)
+	// GenerateRegisterURL fetches an Admin in Kong
+	// and returns a unique registration URL for the Admin
+	GenerateRegisterURL(ctx context.Context, nameOrID *string) (*Admin, error)
+	// Update updates an Admin in Kong.
+	Update(ctx context.Context, admin *Admin) (*Admin, error)
+	// Delete deletes an Admin in Kong
+	Delete(ctx context.Context, AdminOrID *string) error
+	// List fetches a list of all Admins in Kong.
+	List(ctx context.Context, opt *ListOpt) ([]*Admin, *ListOpt, error)
+	// RegisterCredentials registers credentials for existing Kong Admins
+	RegisterCredentials(ctx context.Context, admin *Admin) error
+	// ListWorkspaces lists the workspaces associated with an admin
+	ListWorkspaces(ctx context.Context, emailOrID *string) ([]*Workspace, error)
+	// ListRoles returns a slice of Kong RBAC roles associated with an Admin.
+	ListRoles(ctx context.Context, emailOrID *string, opt *ListOpt) ([]*RBACRole, error)
+	// UpdateRoles creates or updates roles associated with an Admin
+	UpdateRoles(ctx context.Context, emailOrID *string, roles []*RBACRole) ([]*RBACRole, error)
+	// DeleteRoles deletes roles associated with an Admin
+	DeleteRoles(ctx context.Context, emailOrID *string, roles []*RBACRole) error
+	// GetConsumer fetches the Consumer that gets generated for an Admin when
+	// the Admin is created.
+	GetConsumer(ctx context.Context, emailOrID *string) (*Consumer, error)
+}
+
 // AdminService handles Admins in Kong.
 type AdminService service
 

--- a/kong/basic_auth_service.go
+++ b/kong/basic_auth_service.go
@@ -5,6 +5,26 @@ import (
 	"encoding/json"
 )
 
+// AbstractBasicAuthService handles basic-auth credentials in Kong.
+type AbstractBasicAuthService interface {
+	// Create creates a basic-auth credential in Kong
+	// is auto-generated.
+	Create(ctx context.Context, consumerUsernameOrID *string, basicAuth *BasicAuth) (*BasicAuth, error)
+	// Get fetches a basic-auth credential from Kong.
+	Get(ctx context.Context, consumerUsernameOrID, usernameOrID *string) (*BasicAuth, error)
+	// Update updates a basic-auth credential in Kong
+	Update(ctx context.Context, consumerUsernameOrID *string, basicAuth *BasicAuth) (*BasicAuth, error)
+	// Delete deletes a basic-auth credential in Kong
+	Delete(ctx context.Context, consumerUsernameOrID, usernameOrID *string) error
+	// List fetches a list of basic-auth credentials in Kong.
+	List(ctx context.Context, opt *ListOpt) ([]*BasicAuth, *ListOpt, error)
+	// ListAll fetches all basic-auth credentials in Kong.
+	ListAll(ctx context.Context) ([]*BasicAuth, error)
+	// ListForConsumer fetches a list of basic-auth credentials
+	// in Kong associated with a specific consumer.
+	ListForConsumer(ctx context.Context, consumerUsernameOrID *string, opt *ListOpt) ([]*BasicAuth, *ListOpt, error)
+}
+
 // BasicAuthService handles basic-auth credentials in Kong.
 type BasicAuthService service
 

--- a/kong/ca_certificate_service.go
+++ b/kong/ca_certificate_service.go
@@ -7,6 +7,22 @@ import (
 	"fmt"
 )
 
+// AbstractCACertificateService handles Certificates in Kong.
+type AbstractCACertificateService interface {
+	// Create creates a CACertificate in Kong.
+	Create(ctx context.Context, certificate *CACertificate) (*CACertificate, error)
+	// Get fetches a CACertificate in Kong.
+	Get(ctx context.Context, ID *string) (*CACertificate, error)
+	// Update updates a CACertificate in Kong
+	Update(ctx context.Context, certificate *CACertificate) (*CACertificate, error)
+	// Delete deletes a CACertificate in Kong
+	Delete(ctx context.Context, ID *string) error
+	// List fetches a list of certificate in Kong.
+	List(ctx context.Context, opt *ListOpt) ([]*CACertificate, *ListOpt, error)
+	// ListAll fetches all Certificates in Kong.
+	ListAll(ctx context.Context) ([]*CACertificate, error)
+}
+
 // CACertificateService handles Certificates in Kong.
 type CACertificateService service
 

--- a/kong/certificate_service.go
+++ b/kong/certificate_service.go
@@ -7,6 +7,22 @@ import (
 	"fmt"
 )
 
+// AbstractCertificateService handles Certificates in Kong.
+type AbstractCertificateService interface {
+	// Create creates a Certificate in Kong.
+	Create(ctx context.Context, certificate *Certificate) (*Certificate, error)
+	// Get fetches a Certificate in Kong.
+	Get(ctx context.Context, usernameOrID *string) (*Certificate, error)
+	// Update updates a Certificate in Kong
+	Update(ctx context.Context, certificate *Certificate) (*Certificate, error)
+	// Delete deletes a Certificate in Kong
+	Delete(ctx context.Context, usernameOrID *string) error
+	// List fetches a list of certificate in Kong.
+	List(ctx context.Context, opt *ListOpt) ([]*Certificate, *ListOpt, error)
+	// ListAll fetches all Certificates in Kong.
+	ListAll(ctx context.Context) ([]*Certificate, error)
+}
+
 // CertificateService handles Certificates in Kong.
 type CertificateService service
 

--- a/kong/consumer_service.go
+++ b/kong/consumer_service.go
@@ -8,6 +8,16 @@ import (
 	"net/http"
 )
 
+type AbstractConsumerService interface {
+	Create(ctx context.Context, consumer *Consumer) (*Consumer, error)
+	Get(ctx context.Context, usernameOrID *string) (*Consumer, error)
+	GetByCustomID(ctx context.Context, customID *string) (*Consumer, error)
+	Update(ctx context.Context, consumer *Consumer) (*Consumer, error)
+	Delete(ctx context.Context, usernameOrID *string) error
+	List(ctx context.Context, opt *ListOpt) ([]*Consumer, *ListOpt, error)
+	ListAll(ctx context.Context) ([]*Consumer, error)
+}
+
 // ConsumerService handles Consumers in Kong.
 type ConsumerService service
 

--- a/kong/consumer_service.go
+++ b/kong/consumer_service.go
@@ -8,13 +8,21 @@ import (
 	"net/http"
 )
 
+// AbstractConsumerService handles Consumers in Kong.
 type AbstractConsumerService interface {
+	// Create creates a Consumer in Kong.
 	Create(ctx context.Context, consumer *Consumer) (*Consumer, error)
+	// Get fetches a Consumer in Kong.
 	Get(ctx context.Context, usernameOrID *string) (*Consumer, error)
+	// GetByCustomID fetches a Consumer in Kong.
 	GetByCustomID(ctx context.Context, customID *string) (*Consumer, error)
+	// Update updates a Consumer in Kong
 	Update(ctx context.Context, consumer *Consumer) (*Consumer, error)
+	// Delete deletes a Consumer in Kong
 	Delete(ctx context.Context, usernameOrID *string) error
+	// List fetches a list of Consumers in Kong.
 	List(ctx context.Context, opt *ListOpt) ([]*Consumer, *ListOpt, error)
+	// ListAll fetches all Consumers in Kong.
 	ListAll(ctx context.Context) ([]*Consumer, error)
 }
 

--- a/kong/consumer_service.go
+++ b/kong/consumer_service.go
@@ -88,7 +88,7 @@ func (s *ConsumerService) GetByCustomID(ctx context.Context,
 	}
 
 	if len(resp.Data) == 0 {
-		return nil, &APIError{httpCode: http.StatusNotFound, message: "Not found"}
+		return nil, NewAPIError(http.StatusNotFound, "Not found")
 	}
 
 	return &resp.Data[0], nil

--- a/kong/credentials_service.go
+++ b/kong/credentials_service.go
@@ -8,7 +8,22 @@ import (
 	"reflect"
 )
 
-// credentialService handles key-auth credentials in Kong.
+// abstractCredentialService handles credentials in Kong.
+type abstractCredentialService interface {
+	// Create creates a credential in Kong of type credType.
+	Create(ctx context.Context, credType string, consumerUsernameOrID *string,
+		credential interface{}) (json.RawMessage, error)
+	// Get fetches a credential of credType with credIdentifier from Kong.
+	Get(ctx context.Context, credType string, consumerUsernameOrID *string,
+		credIdentifier *string) (json.RawMessage, error)
+	// Update updates credential in Kong
+	Update(ctx context.Context, credType string, consumerUsernameOrID *string,
+		credential interface{}) (json.RawMessage, error)
+	// Delete deletes a credential in Kong
+	Delete(ctx context.Context, credType string, consumerUsernameOrID, credIdentifier *string) error
+}
+
+// credentialService handles credentials in Kong.
 type credentialService service
 
 var (

--- a/kong/custom_entity_service.go
+++ b/kong/custom_entity_service.go
@@ -8,6 +8,24 @@ import (
 	"github.com/kong/go-kong/kong/custom"
 )
 
+// AbstractCustomEntityService handles custom entities in Kong.
+type AbstractCustomEntityService interface {
+	// Get fetches a custom entity. The primary key and all relations of the
+	// entity must be populated in entity.
+	Get(ctx context.Context, entity custom.Entity) (custom.Entity, error)
+	// Create creates a custom entity based on entity.
+	// All required fields must be present in entity.
+	Create(ctx context.Context, entity custom.Entity) (custom.Entity, error)
+	// Update updates a custom entity in Kong.
+	Update(ctx context.Context, entity custom.Entity) (custom.Entity, error)
+	// Delete deletes a custom entity in Kong.
+	Delete(ctx context.Context, entity custom.Entity) error
+	// List fetches all custom entities based on relations
+	List(ctx context.Context, opt *ListOpt, entity custom.Entity) ([]custom.Entity, *ListOpt, error)
+	// ListAll fetches all custom entities based on relations
+	ListAll(ctx context.Context, entity custom.Entity) ([]custom.Entity, error)
+}
+
 // CustomEntityService handles custom entities in Kong.
 type CustomEntityService service
 

--- a/kong/endpoint_permission_service.go
+++ b/kong/endpoint_permission_service.go
@@ -7,6 +7,21 @@ import (
 	"fmt"
 )
 
+// AbstractRBACEndpointPermissionService handles RBACEndpointPermissions in Kong.
+type AbstractRBACEndpointPermissionService interface {
+	// Create creates a RBACEndpointPermission in Kong.
+	Create(ctx context.Context, ep *RBACEndpointPermission) (*RBACEndpointPermission, error)
+	// Get fetches a RBACEndpointPermission in Kong.
+	Get(ctx context.Context, roleNameOrID *string, workspaceNameOrID *string,
+		endpointName *string) (*RBACEndpointPermission, error)
+	// Update updates a RBACEndpointPermission in Kong.
+	Update(ctx context.Context, ep *RBACEndpointPermission) (*RBACEndpointPermission, error)
+	// Delete deletes a EndpointPermission in Kong
+	Delete(ctx context.Context, roleNameOrID *string, workspaceNameOrID *string, endpoint *string) error
+	// ListAllForRole fetches a list of all RBACEndpointPermissions in Kong for a given role.
+	ListAllForRole(ctx context.Context, roleNameOrID *string) ([]*RBACEndpointPermission, error)
+}
+
 // RBACEndpointPermissionService handles RBACEndpointPermissions in Kong.
 type RBACEndpointPermissionService service
 

--- a/kong/entity_permission_service.go
+++ b/kong/entity_permission_service.go
@@ -7,6 +7,20 @@ import (
 	"fmt"
 )
 
+// AbstractRBACEntityPermissionService handles RBACEntityPermissions in Kong.
+type AbstractRBACEntityPermissionService interface {
+	// Create creates an RBACEntityPermission in Kong.
+	Create(ctx context.Context, ep *RBACEntityPermission) (*RBACEntityPermission, error)
+	// Get fetches an EntityPermission in Kong.
+	Get(ctx context.Context, roleNameOrID *string, entityName *string) (*RBACEntityPermission, error)
+	// Update updates an EntityPermission in Kong.
+	Update(ctx context.Context, ep *RBACEntityPermission) (*RBACEntityPermission, error)
+	// Delete deletes an EntityPermission in Kong
+	Delete(ctx context.Context, roleNameOrID *string, entityID *string) error
+	// ListAllForRole fetches a list of all RBACEntityPermissions in Kong for a given role.
+	ListAllForRole(ctx context.Context, roleNameOrID *string) ([]*RBACEntityPermission, error)
+}
+
 // RBACEntityPermissionService handles RBACEntityPermissions in Kong.
 type RBACEntityPermissionService service
 

--- a/kong/error.go
+++ b/kong/error.go
@@ -10,6 +10,13 @@ type APIError struct {
 	message  string
 }
 
+func NewAPIError(code int, msg string) *APIError {
+	return &APIError{
+		httpCode: code,
+		message:  msg,
+	}
+}
+
 func (e *APIError) Error() string {
 	return fmt.Sprintf("HTTP status %d (message: %q)", e.httpCode, e.message)
 }

--- a/kong/error_test.go
+++ b/kong/error_test.go
@@ -10,7 +10,7 @@ import (
 func TestIsNotFoundErr(T *testing.T) {
 
 	assert := assert.New(T)
-	var e error = &APIError{httpCode: 404}
+	var e error = NewAPIError(404, "")
 	assert.True(IsNotFoundErr(e))
 	assert.False(IsNotFoundErr(nil))
 

--- a/kong/hmac_auth_service.go
+++ b/kong/hmac_auth_service.go
@@ -5,6 +5,25 @@ import (
 	"encoding/json"
 )
 
+// AbstractHMACAuthService handles hmac-auth credentials in Kong.
+type AbstractHMACAuthService interface {
+	// Create creates a hmac-auth credential in Kong
+	Create(ctx context.Context, consumerUsernameOrID *string, hmacAuth *HMACAuth) (*HMACAuth, error)
+	// Get fetches a hmac-auth credential from Kong.
+	Get(ctx context.Context, consumerUsernameOrID, usernameOrID *string) (*HMACAuth, error)
+	// Update updates a hmac-auth credential in Kong
+	Update(ctx context.Context, consumerUsernameOrID *string, hmacAuth *HMACAuth) (*HMACAuth, error)
+	// Delete deletes a hmac-auth credential in Kong
+	Delete(ctx context.Context, consumerUsernameOrID, usernameOrID *string) error
+	// List fetches a list of hmac-auth credentials in Kong.
+	List(ctx context.Context, opt *ListOpt) ([]*HMACAuth, *ListOpt, error)
+	// ListAll fetches all hmac-auth credentials in Kong.
+	ListAll(ctx context.Context) ([]*HMACAuth, error)
+	// ListForConsumer fetches a list of hmac-auth credentials
+	// in Kong associated with a specific consumer.
+	ListForConsumer(ctx context.Context, consumerUsernameOrID *string, opt *ListOpt) ([]*HMACAuth, *ListOpt, error)
+}
+
 // HMACAuthService handles hmac-auth credentials in Kong.
 type HMACAuthService service
 

--- a/kong/jwt_auth_service.go
+++ b/kong/jwt_auth_service.go
@@ -5,6 +5,25 @@ import (
 	"encoding/json"
 )
 
+// AbstractJWTAuthService handles JWT credentials in Kong.
+type AbstractJWTAuthService interface {
+	// Create creates a JWT credential in Kong
+	Create(ctx context.Context, consumerUsernameOrID *string, jwtAuth *JWTAuth) (*JWTAuth, error)
+	// Get fetches a JWT credential from Kong.
+	Get(ctx context.Context, consumerUsernameOrID, keyOrID *string) (*JWTAuth, error)
+	// Update updates a JWT credential in Kong
+	Update(ctx context.Context, consumerUsernameOrID *string, jwtAuth *JWTAuth) (*JWTAuth, error)
+	// Delete deletes a JWT credential in Kong
+	Delete(ctx context.Context, consumerUsernameOrID, keyOrID *string) error
+	// List fetches a list of JWT credentials in Kong.
+	List(ctx context.Context, opt *ListOpt) ([]*JWTAuth, *ListOpt, error)
+	// ListAll fetches all JWT credentials in Kong.
+	ListAll(ctx context.Context) ([]*JWTAuth, error)
+	// ListForConsumer fetches a list of jwt credentials
+	// in Kong associated with a specific consumer.
+	ListForConsumer(ctx context.Context, consumerUsernameOrID *string, opt *ListOpt) ([]*JWTAuth, *ListOpt, error)
+}
+
 // JWTAuthService handles JWT credentials in Kong.
 type JWTAuthService service
 

--- a/kong/key_auth_service.go
+++ b/kong/key_auth_service.go
@@ -5,6 +5,24 @@ import (
 	"encoding/json"
 )
 
+// AbstractKeyAuthService handles key-auth credentials in Kong.
+type AbstractKeyAuthService interface {
+	// Create creates a key-auth credential in Kong
+	Create(ctx context.Context, consumerUsernameOrID *string, keyAuth *KeyAuth) (*KeyAuth, error)
+	// Get fetches a key-auth credential from Kong.
+	Get(ctx context.Context, consumerUsernameOrID, keyOrID *string) (*KeyAuth, error)
+	// Update updates a key-auth credential in Kong
+	Update(ctx context.Context, consumerUsernameOrID *string, keyAuth *KeyAuth) (*KeyAuth, error)
+	// Delete deletes a key-auth credential in Kong
+	Delete(ctx context.Context, consumerUsernameOrID, keyOrID *string) error
+	// List fetches a list of key-auth credentials in Kong.
+	List(ctx context.Context, opt *ListOpt) ([]*KeyAuth, *ListOpt, error)
+	// ListAll fetches all key-auth credentials in Kong.
+	ListAll(ctx context.Context) ([]*KeyAuth, error)
+	// ListForConsumer fetches a list of key-auth credentials
+	ListForConsumer(ctx context.Context, consumerUsernameOrID *string, opt *ListOpt) ([]*KeyAuth, *ListOpt, error)
+}
+
 // KeyAuthService handles key-auth credentials in Kong.
 type KeyAuthService service
 

--- a/kong/kong.go
+++ b/kong/kong.go
@@ -33,35 +33,35 @@ type Client struct {
 	baseURL                 string
 	common                  service
 	Consumers               AbstractConsumerService
-	Services                *Svcservice
-	Routes                  *RouteService
-	CACertificates          *CACertificateService
-	Certificates            *CertificateService
+	Services                AbstractSvcService
+	Routes                  AbstractRouteService
+	CACertificates          AbstractCACertificateService
+	Certificates            AbstractCertificateService
 	Plugins                 AbstractPluginService
-	SNIs                    *SNIService
-	Upstreams               *UpstreamService
-	UpstreamNodeHealth      *UpstreamNodeHealthService
-	Targets                 *TargetService
-	Workspaces              *WorkspaceService
-	Admins                  *AdminService
-	RBACUsers               *RBACUserService
-	RBACRoles               *RBACRoleService
-	RBACEndpointPermissions *RBACEndpointPermissionService
-	RBACEntityPermissions   *RBACEntityPermissionService
+	SNIs                    AbstractSNIService
+	Upstreams               AbstractUpstreamService
+	UpstreamNodeHealth      AbstractUpstreamNodeHealthService
+	Targets                 AbstractTargetService
+	Workspaces              AbstractWorkspaceService
+	Admins                  AbstractAdminService
+	RBACUsers               AbstractRBACUserService
+	RBACRoles               AbstractRBACRoleService
+	RBACEndpointPermissions AbstractRBACEndpointPermissionService
+	RBACEntityPermissions   AbstractRBACEntityPermissionService
 
-	credentials *credentialService
-	KeyAuths    *KeyAuthService
-	BasicAuths  *BasicAuthService
-	HMACAuths   *HMACAuthService
-	JWTAuths    *JWTAuthService
-	MTLSAuths   *MTLSAuthService
-	ACLs        *ACLService
+	credentials abstractCredentialService
+	KeyAuths    AbstractKeyAuthService
+	BasicAuths  AbstractBasicAuthService
+	HMACAuths   AbstractHMACAuthService
+	JWTAuths    AbstractJWTAuthService
+	MTLSAuths   AbstractMTLSAuthService
+	ACLs        AbstractACLService
 
-	Oauth2Credentials *Oauth2Service
+	Oauth2Credentials AbstractOauth2Service
 
 	logger         io.Writer
 	debug          bool
-	CustomEntities *CustomEntityService
+	CustomEntities AbstractCustomEntityService
 
 	custom.Registry
 }

--- a/kong/kong.go
+++ b/kong/kong.go
@@ -26,16 +26,6 @@ var (
 	defaultCtx = context.Background()
 )
 
-type AbstractConsumerService interface {
-	Create(ctx context.Context, consumer *Consumer) (*Consumer, error)
-	Get(ctx context.Context, usernameOrID *string) (*Consumer, error)
-	GetByCustomID(ctx context.Context, customID *string) (*Consumer, error)
-	Update(ctx context.Context, consumer *Consumer) (*Consumer, error)
-	Delete(ctx context.Context, usernameOrID *string) error
-	List(ctx context.Context, opt *ListOpt) ([]*Consumer, *ListOpt, error)
-	ListAll(ctx context.Context) ([]*Consumer, error)
-}
-
 // Client talks to the Admin API or control plane of a
 // Kong cluster
 type Client struct {
@@ -47,7 +37,7 @@ type Client struct {
 	Routes                  *RouteService
 	CACertificates          *CACertificateService
 	Certificates            *CertificateService
-	Plugins                 *PluginService
+	Plugins                 AbstractPluginService
 	SNIs                    *SNIService
 	Upstreams               *UpstreamService
 	UpstreamNodeHealth      *UpstreamNodeHealthService

--- a/kong/kong.go
+++ b/kong/kong.go
@@ -26,13 +26,23 @@ var (
 	defaultCtx = context.Background()
 )
 
+type AbstractConsumerService interface {
+	Create(ctx context.Context, consumer *Consumer) (*Consumer, error)
+	Get(ctx context.Context, usernameOrID *string) (*Consumer, error)
+	GetByCustomID(ctx context.Context, customID *string) (*Consumer, error)
+	Update(ctx context.Context, consumer *Consumer) (*Consumer, error)
+	Delete(ctx context.Context, usernameOrID *string) error
+	List(ctx context.Context, opt *ListOpt) ([]*Consumer, *ListOpt, error)
+	ListAll(ctx context.Context) ([]*Consumer, error)
+}
+
 // Client talks to the Admin API or control plane of a
 // Kong cluster
 type Client struct {
 	client                  *http.Client
 	baseURL                 string
 	common                  service
-	Consumers               *ConsumerService
+	Consumers               AbstractConsumerService
 	Services                *Svcservice
 	Routes                  *RouteService
 	CACertificates          *CACertificateService

--- a/kong/mtls_auth_service.go
+++ b/kong/mtls_auth_service.go
@@ -5,6 +5,25 @@ import (
 	"encoding/json"
 )
 
+// AbstractMTLSAuthService handles MTLS credentials in Kong.
+type AbstractMTLSAuthService interface {
+	// Create creates an MTLS credential in Kong
+	Create(ctx context.Context, consumerUsernameOrID *string, mtlsAuth *MTLSAuth) (*MTLSAuth, error)
+	// Get fetches an MTLS credential from Kong.
+	Get(ctx context.Context, consumerUsernameOrID, keyOrID *string) (*MTLSAuth, error)
+	// Update updates an MTLS credential in Kong
+	Update(ctx context.Context, consumerUsernameOrID *string, mtlsAuth *MTLSAuth) (*MTLSAuth, error)
+	// Delete deletes an MTLS credential in Kong
+	Delete(ctx context.Context, consumerUsernameOrID, keyOrID *string) error
+	// List fetches a list of MTLS credentials in Kong.
+	List(ctx context.Context, opt *ListOpt) ([]*MTLSAuth, *ListOpt, error)
+	// ListAll fetches all MTLS credentials in Kong.
+	ListAll(ctx context.Context) ([]*MTLSAuth, error)
+	// ListForConsumer fetches a list of mtls credentials
+	// in Kong associated with a specific consumer.
+	ListForConsumer(ctx context.Context, consumerUsernameOrID *string, opt *ListOpt) ([]*MTLSAuth, *ListOpt, error)
+}
+
 // MTLSAuthService handles MTLS credentials in Kong.
 type MTLSAuthService service
 

--- a/kong/oauth2_auth_service.go
+++ b/kong/oauth2_auth_service.go
@@ -5,6 +5,25 @@ import (
 	"encoding/json"
 )
 
+// AbstractOauth2Service handles oauth2 credentials in Kong.
+type AbstractOauth2Service interface {
+	// Create creates an oauth2 credential in Kong
+	Create(ctx context.Context, consumerUsernameOrID *string, oauth2Cred *Oauth2Credential) (*Oauth2Credential, error)
+	// Get fetches an oauth2 credential from Kong.
+	Get(ctx context.Context, consumerUsernameOrID, clientIDorID *string) (*Oauth2Credential, error)
+	// Update updates an oauth2 credential in Kong.
+	Update(ctx context.Context, consumerUsernameOrID *string, oauth2Cred *Oauth2Credential) (*Oauth2Credential, error)
+	// Delete deletes an oauth2 credential in Kong.
+	Delete(ctx context.Context, consumerUsernameOrID, clientIDorID *string) error
+	// List fetches a list of oauth2 credentials in Kong.
+	List(ctx context.Context, opt *ListOpt) ([]*Oauth2Credential, *ListOpt, error)
+	// ListAll fetches all oauth2 credentials in Kong.
+	ListAll(ctx context.Context) ([]*Oauth2Credential, error)
+	// ListForConsumer fetches a list of oauth2 credentials
+	// in Kong associated with a specific consumer.
+	ListForConsumer(ctx context.Context, consumerUsernameOrID *string, opt *ListOpt) ([]*Oauth2Credential, *ListOpt, error)
+}
+
 // Oauth2Service handles oauth2 credentials in Kong.
 type Oauth2Service service
 

--- a/kong/plugin_service.go
+++ b/kong/plugin_service.go
@@ -8,16 +8,27 @@ import (
 	"net/http"
 )
 
+// AbstractPluginService handles Plugins in Kong.
 type AbstractPluginService interface {
+	// Create creates a Plugin in Kong.
 	Create(ctx context.Context, plugin *Plugin) (*Plugin, error)
+	// Get fetches a Plugin in Kong.
 	Get(ctx context.Context, usernameOrID *string) (*Plugin, error)
+	// Update updates a Plugin in Kong
 	Update(ctx context.Context, plugin *Plugin) (*Plugin, error)
+	// Delete deletes a Plugin in Kong
 	Delete(ctx context.Context, usernameOrID *string) error
+	// List fetches a list of Plugins in Kong.
 	List(ctx context.Context, opt *ListOpt) ([]*Plugin, *ListOpt, error)
+	// ListAll fetches all Plugins in Kong.
 	ListAll(ctx context.Context) ([]*Plugin, error)
+	// ListAllForConsumer fetches all Plugins in Kong enabled for a consumer.
 	ListAllForConsumer(ctx context.Context, consumerIDorName *string) ([]*Plugin, error)
+	// ListAllForService fetches all Plugins in Kong enabled for a service.
 	ListAllForService(ctx context.Context, serviceIDorName *string) ([]*Plugin, error)
+	// ListAllForRoute fetches all Plugins in Kong enabled for a service.
 	ListAllForRoute(ctx context.Context, routeID *string) ([]*Plugin, error)
+	// Validate validates a Plugin against its schema
 	Validate(ctx context.Context, plugin *Plugin) (bool, error)
 }
 

--- a/kong/plugin_service.go
+++ b/kong/plugin_service.go
@@ -7,6 +7,18 @@ import (
 	"fmt"
 )
 
+type AbstractPluginService interface {
+	Create(ctx context.Context, plugin *Plugin) (*Plugin, error)
+	Get(ctx context.Context, usernameOrID *string) (*Plugin, error)
+	Update(ctx context.Context, plugin *Plugin) (*Plugin, error)
+	Delete(ctx context.Context, usernameOrID *string) error
+	List(ctx context.Context, opt *ListOpt) ([]*Plugin, *ListOpt, error)
+	ListAll(ctx context.Context) ([]*Plugin, error)
+	ListAllForConsumer(ctx context.Context, consumerIDorName *string) ([]*Plugin, error)
+	ListAllForService(ctx context.Context, serviceIDorName *string) ([]*Plugin, error)
+	ListAllForRoute(ctx context.Context, routeID *string) ([]*Plugin, error)
+}
+
 // PluginService handles Plugins in Kong.
 type PluginService service
 

--- a/kong/rbac_role_service.go
+++ b/kong/rbac_role_service.go
@@ -7,6 +7,20 @@ import (
 	"fmt"
 )
 
+// AbstractRBACRoleService handles Roles in Kong.
+type AbstractRBACRoleService interface {
+	// Create creates a Role in Kong.
+	Create(ctx context.Context, role *RBACRole) (*RBACRole, error)
+	// Get fetches a Role in Kong.
+	Get(ctx context.Context, nameOrID *string) (*RBACRole, error)
+	// Update updates a Role in Kong.
+	Update(ctx context.Context, role *RBACRole) (*RBACRole, error)
+	// Delete deletes a Role in Kong
+	Delete(ctx context.Context, RoleOrID *string) error
+	// List fetches a list of all Roles in Kong.
+	List(ctx context.Context) ([]*RBACRole, error)
+}
+
 // RBACRoleService handles Roles in Kong.
 type RBACRoleService service
 

--- a/kong/rbac_user_service.go
+++ b/kong/rbac_user_service.go
@@ -8,6 +8,31 @@ import (
 	"strings"
 )
 
+// AbstractRBACUserService handles Users in Kong.
+type AbstractRBACUserService interface {
+	// Create creates an RBAC User in Kong.
+	Create(ctx context.Context, user *RBACUser) (*RBACUser, error)
+	// Get fetches a User in Kong.
+	Get(ctx context.Context, nameOrID *string) (*RBACUser, error)
+	// Update updates a User in Kong.
+	Update(ctx context.Context, user *RBACUser) (*RBACUser, error)
+	// Delete deletes a User in Kong
+	Delete(ctx context.Context, userOrID *string) error
+	// List fetches a list of Users in Kong.
+	// opt can be used to control pagination.
+	List(ctx context.Context, opt *ListOpt) ([]*RBACUser, *ListOpt, error)
+	// ListAll fetches all users in Kong.
+	ListAll(ctx context.Context) ([]*RBACUser, error)
+	// AddRoles adds a comma separated list of roles to a User.
+	AddRoles(ctx context.Context, nameOrID *string, roles []*RBACRole) ([]*RBACRole, error)
+	// DeleteRoles deletes roles associated with a User
+	DeleteRoles(ctx context.Context, nameOrID *string, roles []*RBACRole) error
+	// ListRoles returns a slice of Kong RBAC roles associated with a User.
+	ListRoles(ctx context.Context, nameOrID *string) ([]*RBACRole, error)
+	// ListPermissions returns the entity and endpoint permissions associated with a user.
+	ListPermissions(ctx context.Context, nameOrID *string) (*RBACPermissionsList, error)
+}
+
 // RBACUserService handles Users in Kong.
 type RBACUserService service
 

--- a/kong/response.go
+++ b/kong/response.go
@@ -35,8 +35,5 @@ func hasError(res *http.Response) error {
 	}
 
 	body, _ := ioutil.ReadAll(res.Body) // TODO error in error?
-	return &APIError{
-		httpCode: res.StatusCode,
-		message:  messageFromBody(body),
-	}
+	return NewAPIError(res.StatusCode, messageFromBody(body))
 }

--- a/kong/route_service.go
+++ b/kong/route_service.go
@@ -7,6 +7,26 @@ import (
 	"fmt"
 )
 
+// AbstractRouteService handles routes in Kong.
+type AbstractRouteService interface {
+	// Create creates a Route in Kong
+	Create(ctx context.Context, route *Route) (*Route, error)
+	// CreateInService creates a route associated with serviceID
+	CreateInService(ctx context.Context, serviceID *string, route *Route) (*Route, error)
+	// Get fetches a Route in Kong.
+	Get(ctx context.Context, nameOrID *string) (*Route, error)
+	// Update updates a Route in Kong
+	Update(ctx context.Context, route *Route) (*Route, error)
+	// Delete deletes a Route in Kong
+	Delete(ctx context.Context, nameOrID *string) error
+	// List fetches a list of Routes in Kong.
+	List(ctx context.Context, opt *ListOpt) ([]*Route, *ListOpt, error)
+	// ListAll fetches all Routes in Kong.
+	ListAll(ctx context.Context) ([]*Route, error)
+	// ListForService fetches a list of Routes in Kong associated with a service.
+	ListForService(ctx context.Context, serviceNameOrID *string, opt *ListOpt) ([]*Route, *ListOpt, error)
+}
+
 // RouteService handles routes in Kong.
 type RouteService service
 

--- a/kong/service_service.go
+++ b/kong/service_service.go
@@ -7,6 +7,24 @@ import (
 	"fmt"
 )
 
+// AbstractSvcService handles services in Kong.
+type AbstractSvcService interface {
+	// Create creates an Service in Kong
+	Create(ctx context.Context, service *Service) (*Service, error)
+	// Get fetches an Service in Kong.
+	Get(ctx context.Context, nameOrID *string) (*Service, error)
+	// GetForRoute fetches a Service associated with routeID in Kong.
+	GetForRoute(ctx context.Context, routeID *string) (*Service, error)
+	// Update updates an Service in Kong
+	Update(ctx context.Context, service *Service) (*Service, error)
+	// Delete deletes an Service in Kong
+	Delete(ctx context.Context, nameOrID *string) error
+	// List fetches a list of Services in Kong.
+	List(ctx context.Context, opt *ListOpt) ([]*Service, *ListOpt, error)
+	// ListAll fetches all Services in Kong.
+	ListAll(ctx context.Context) ([]*Service, error)
+}
+
 // Svcservice handles services in Kong.
 type Svcservice service
 

--- a/kong/sni_service.go
+++ b/kong/sni_service.go
@@ -7,6 +7,24 @@ import (
 	"fmt"
 )
 
+// AbstractSNIService handles SNIs in Kong.
+type AbstractSNIService interface {
+	// Create creates a SNI in Kong.
+	Create(ctx context.Context, sni *SNI) (*SNI, error)
+	// Get fetches a SNI in Kong.
+	Get(ctx context.Context, usernameOrID *string) (*SNI, error)
+	// Update updates a SNI in Kong
+	Update(ctx context.Context, sni *SNI) (*SNI, error)
+	// Delete deletes a SNI in Kong
+	Delete(ctx context.Context, usernameOrID *string) error
+	// List fetches a list of SNIs in Kong.
+	List(ctx context.Context, opt *ListOpt) ([]*SNI, *ListOpt, error)
+	// ListForCertificate fetches a list of SNIs
+	ListForCertificate(ctx context.Context, certificateID *string, opt *ListOpt) ([]*SNI, *ListOpt, error)
+	// ListAll fetches all SNIs in Kong.
+	ListAll(ctx context.Context) ([]*SNI, error)
+}
+
 // SNIService handles SNIs in Kong.
 type SNIService service
 

--- a/kong/target_service.go
+++ b/kong/target_service.go
@@ -7,6 +7,24 @@ import (
 	"fmt"
 )
 
+// AbstractTargetService handles Targets in Kong.
+type AbstractTargetService interface {
+	// Create creates a Target in Kong under upstreamID.
+	Create(ctx context.Context, upstreamNameOrID *string, target *Target) (*Target, error)
+	// Delete deletes a Target in Kong
+	Delete(ctx context.Context, upstreamNameOrID *string, targetOrID *string) error
+	// List fetches a list of Targets in Kong.
+	List(ctx context.Context, upstreamNameOrID *string, opt *ListOpt) ([]*Target, *ListOpt, error)
+	// ListAll fetches all Targets in Kong for an upstream.
+	ListAll(ctx context.Context, upstreamNameOrID *string) ([]*Target, error)
+	// MarkHealthy marks target belonging to upstreamNameOrID as healthy in
+	// Kong's load balancer.
+	MarkHealthy(ctx context.Context, upstreamNameOrID *string, target *Target) error
+	// MarkUnhealthy marks target belonging to upstreamNameOrID as unhealthy in
+	// Kong's load balancer.
+	MarkUnhealthy(ctx context.Context, upstreamNameOrID *string, target *Target) error
+}
+
 // TargetService handles Targets in Kong.
 type TargetService service
 

--- a/kong/upstream_node_health_service.go
+++ b/kong/upstream_node_health_service.go
@@ -6,6 +6,14 @@ import (
 	"fmt"
 )
 
+// AbstractUpstreamNodeHealthService handles Upstream Node Healths in Kong.
+type AbstractUpstreamNodeHealthService interface {
+	// List fetches a list of Upstream Node Healths in Kong.
+	List(ctx context.Context, upstreamNameOrID *string, opt *ListOpt) ([]*UpstreamNodeHealth, *ListOpt, error)
+	// ListAll fetches all Upstream Node Healths in Kong.
+	ListAll(ctx context.Context, upstreamNameOrID *string) ([]*UpstreamNodeHealth, error)
+}
+
 // UpstreamNodeHealthService handles Upstream Node Healths in Kong.
 type UpstreamNodeHealthService service
 

--- a/kong/upstream_service.go
+++ b/kong/upstream_service.go
@@ -7,6 +7,22 @@ import (
 	"fmt"
 )
 
+// AbstractUpstreamService handles Upstreams in Kong.
+type AbstractUpstreamService interface {
+	// Create creates a Upstream in Kong.
+	Create(ctx context.Context, upstream *Upstream) (*Upstream, error)
+	// Get fetches a Upstream in Kong.
+	Get(ctx context.Context, upstreamNameOrID *string) (*Upstream, error)
+	// Update updates a Upstream in Kong
+	Update(ctx context.Context, upstream *Upstream) (*Upstream, error)
+	// Delete deletes a Upstream in Kong
+	Delete(ctx context.Context, upstreamNameOrID *string) error
+	// List fetches a list of Upstreams in Kong.
+	List(ctx context.Context, opt *ListOpt) ([]*Upstream, *ListOpt, error)
+	// ListAll fetches all Upstreams in Kong.
+	ListAll(ctx context.Context) ([]*Upstream, error)
+}
+
 // UpstreamService handles Upstreams in Kong.
 type UpstreamService service
 

--- a/kong/workspace_service.go
+++ b/kong/workspace_service.go
@@ -7,6 +7,37 @@ import (
 	"fmt"
 )
 
+// AbstractWorkspaceService handles Workspaces in Kong.
+type AbstractWorkspaceService interface {
+	// Create creates a Workspace in Kong.
+	Create(ctx context.Context, workspace *Workspace) (*Workspace, error)
+	// Get fetches a Workspace in Kong.
+	Get(ctx context.Context, nameOrID *string) (*Workspace, error)
+	// Update updates a Workspace in Kong.
+	Update(ctx context.Context, workspace *Workspace) (*Workspace, error)
+	// Delete deletes a Workspace in Kong
+	Delete(ctx context.Context, WorkspaceOrID *string) error
+	// List fetches a list of all Workspaces in Kong.
+	List(ctx context.Context, opt *ListOpt) ([]*Workspace, *ListOpt, error)
+	// ListAll fetches all workspaces in Kong.
+	ListAll(ctx context.Context) ([]*Workspace, error)
+	// AddEntities adds entity ids given as a a comma delimited string
+	// to a given workspace in Kong. The response is a representation
+	// of the entity that was added to the workspace.
+	//
+	// Deprecated: Kong 2.x removed this endpoint.
+	AddEntities(ctx context.Context, workspaceNameOrID *string, entityIds *string) (*[]map[string]interface{}, error)
+	// DeleteEntities deletes entity ids given as a a comma delimited string
+	// to a given workspace in Kong.
+	//
+	// Deprecated: Kong 2.x removed this endpoint.
+	DeleteEntities(ctx context.Context, workspaceNameOrID *string, entityIds *string) error
+	// ListEntities fetches a list of all workspace entities in Kong.
+	//
+	// Deprecated: Kong 2.x removed this endpoint.
+	ListEntities(ctx context.Context, workspaceNameOrID *string) ([]*WorkspaceEntity, error)
+}
+
 // WorkspaceService handles Workspaces in Kong.
 type WorkspaceService service
 


### PR DESCRIPTION
Add interface types for the various Kong endpoint services and a function to generate Kong API errors. This allows code using this library to define mock types that implement the service without interacting with a Kong instance and instead return canned responses for unit tests.

For example usage, see the WIP branches at
https://github.com/Kong/kubernetes-ingress-controller/tree/refactor/validator-mocking
https://github.com/Kong/kubernetes-ingress-controller/tree/refactor/validator-mocking-plugin