### PR TITLE
Add DevRole/RBAC pagination and ListAll; require the Portal for Portal tests

### DIFF
--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -43,6 +43,7 @@ echo $KONG_LICENSE_DATA | sudo tee /etc/kong/license.json
 export KONG_LICENSE_PATH=/tmp/license.json
 export KONG_PASSWORD=kong
 export KONG_ENFORCE_RBAC=on
+export KONG_PORTAL=on
 
 sudo kong migrations bootstrap
 sudo kong version

--- a/kong/admin_service_test.go
+++ b/kong/admin_service_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAdminService(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", false)
+	runWhenEnterprise(T, ">=0.33.0", false, false)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -43,7 +43,7 @@ func TestAdminService(T *testing.T) {
 }
 
 func TestAdminServiceWorkspace(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", false)
+	runWhenEnterprise(T, ">=0.33.0", false, false)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -93,7 +93,7 @@ func TestAdminServiceWorkspace(T *testing.T) {
 func TestAdminServiceList(T *testing.T) {
 	assert := assert.New(T)
 	client, err := NewTestClient(nil, nil)
-	runWhenEnterprise(T, ">=0.33.0", false)
+	runWhenEnterprise(T, ">=0.33.0", false, false)
 
 	assert.Nil(err)
 	assert.NotNil(client)
@@ -142,7 +142,7 @@ func TestAdminServiceList(T *testing.T) {
 // XXX:
 // This test requires RBAC to be enabled.
 func TestAdminServiceRegisterCredentials(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true)
+	runWhenEnterprise(T, ">=0.33.0", true, false)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/admin_service_test.go
+++ b/kong/admin_service_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAdminService(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", false, false)
+	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -43,7 +43,7 @@ func TestAdminService(T *testing.T) {
 }
 
 func TestAdminServiceWorkspace(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", false, false)
+	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -93,7 +93,7 @@ func TestAdminServiceWorkspace(T *testing.T) {
 func TestAdminServiceList(T *testing.T) {
 	assert := assert.New(T)
 	client, err := NewTestClient(nil, nil)
-	runWhenEnterprise(T, ">=0.33.0", false, false)
+	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{})
 
 	assert.Nil(err)
 	assert.NotNil(client)
@@ -142,7 +142,7 @@ func TestAdminServiceList(T *testing.T) {
 // XXX:
 // This test requires RBAC to be enabled.
 func TestAdminServiceRegisterCredentials(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true, false)
+	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/developer_role_service.go
+++ b/kong/developer_role_service.go
@@ -36,10 +36,6 @@ func (s *DeveloperRoleService) Create(ctx context.Context,
 
 	endpoint := "/developers/roles"
 	method := "POST"
-	if role.ID != nil {
-		endpoint = endpoint + "/" + *role.ID
-		method = "PUT"
-	}
 	req, err := s.client.NewRequest(method, endpoint, nil, role)
 
 	if err != nil {

--- a/kong/developer_role_service_test.go
+++ b/kong/developer_role_service_test.go
@@ -71,14 +71,97 @@ func TestDeveloperRoleServiceList(T *testing.T) {
 	createdRoleB, err := client.DeveloperRoles.Create(defaultCtx, roleB)
 	assert.Nil(err)
 
-	roles, err := client.DeveloperRoles.List(defaultCtx)
+	roles, next, err := client.DeveloperRoles.List(defaultCtx, nil)
 	assert.Nil(err)
+	assert.Nil(next)
 	assert.NotNil(roles)
-	// Counts default roles (super-admin, admin, read-only)
-	assert.Equal(5, len(roles))
+	assert.Equal(2, len(roles))
 
 	err = client.DeveloperRoles.Delete(defaultCtx, createdRoleA.ID)
 	assert.Nil(err)
 	err = client.DeveloperRoles.Delete(defaultCtx, createdRoleB.ID)
 	assert.Nil(err)
+}
+
+func TestDeveloperRoleListEndpoint(T *testing.T) {
+	runWhenEnterprise(T, ">=0.33.0", true)
+	assert := assert.New(T)
+
+	client, err := NewTestClient(nil, nil)
+	assert.Nil(err)
+	assert.NotNil(client)
+
+	// fixtures
+	roles := []*DeveloperRole{
+		{
+			Name: String("roleA"),
+		},
+		{
+			Name: String("roleB"),
+		},
+		{
+			Name: String("roleC"),
+		},
+	}
+
+	// create fixturs
+	for i := 0; i < len(roles); i++ {
+		role, err := client.DeveloperRoles.Create(defaultCtx, roles[i])
+		assert.Nil(err)
+		assert.NotNil(role)
+		roles[i] = role
+	}
+
+	rolesFromKong, next, err := client.DeveloperRoles.List(defaultCtx, nil)
+	assert.Nil(err)
+	assert.Nil(next)
+	assert.NotNil(rolesFromKong)
+	assert.Equal(3, len(rolesFromKong))
+
+	// check if we see all developerRoles
+	assert.True(compareDeveloperRoles(roles, rolesFromKong))
+
+	// Test pagination
+	rolesFromKong = []*DeveloperRole{}
+
+	// first page
+	page1, next, err := client.DeveloperRoles.List(defaultCtx, &ListOpt{Size: 1})
+	assert.Nil(err)
+	assert.NotNil(next)
+	assert.NotNil(page1)
+	assert.Equal(1, len(page1))
+	rolesFromKong = append(rolesFromKong, page1...)
+
+	// last page
+	next.Size = 2
+	page2, next, err := client.DeveloperRoles.List(defaultCtx, next)
+	assert.Nil(err)
+	assert.Nil(next)
+	assert.NotNil(page2)
+	assert.Equal(2, len(page2))
+	rolesFromKong = append(rolesFromKong, page2...)
+
+	assert.True(compareDeveloperRoles(roles, rolesFromKong))
+
+	roles, err = client.DeveloperRoles.ListAll(defaultCtx)
+	assert.Nil(err)
+	assert.NotNil(roles)
+	assert.Equal(3, len(roles))
+
+	for i := 0; i < len(roles); i++ {
+		assert.Nil(client.DeveloperRoles.Delete(defaultCtx, roles[i].ID))
+	}
+}
+
+func compareDeveloperRoles(expected, actual []*DeveloperRole) bool {
+	var expectedNames, actualNames []string
+	for _, role := range expected {
+		expectedNames = append(expectedNames, *role.Name)
+	}
+
+	for _, role := range actual {
+		actualNames = append(actualNames, *role.Name)
+	}
+
+	return (compareSlices(expectedNames, actualNames))
 }

--- a/kong/developer_role_service_test.go
+++ b/kong/developer_role_service_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDeveloperRoleService(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", false, true)
+	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{portal: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -62,7 +62,7 @@ func TestDeveloperRoleService(T *testing.T) {
 	assert.Nil(err)
 }
 func TestDeveloperRoleServiceList(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", false, true)
+	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{portal: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -104,7 +104,7 @@ func TestDeveloperRoleServiceList(T *testing.T) {
 }
 
 func TestDeveloperRoleListEndpoint(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", false, true)
+	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{portal: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/developer_role_service_test.go
+++ b/kong/developer_role_service_test.go
@@ -8,12 +8,18 @@ import (
 )
 
 func TestDeveloperRoleService(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true)
+	runWhenEnterprise(T, ">=0.33.0", false, true)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
 	assert.Nil(err)
 	assert.NotNil(client)
+
+	defaultWorkspace, err := client.Workspaces.Get(defaultCtx, String("default"))
+	assert.Nil(err)
+	defaultWorkspace.Config = map[string]interface{}{"portal": true}
+	_, err = client.Workspaces.Update(defaultCtx, defaultWorkspace)
+	assert.Nil(err)
 
 	role := &DeveloperRole{
 		Name: String("roleA"),
@@ -50,14 +56,24 @@ func TestDeveloperRoleService(T *testing.T) {
 
 	err = client.DeveloperRoles.Delete(defaultCtx, createdRole.ID)
 	assert.Nil(err)
+
+	defaultWorkspace.Config = map[string]interface{}{"portal": false}
+	_, err = client.Workspaces.Update(defaultCtx, defaultWorkspace)
+	assert.Nil(err)
 }
 func TestDeveloperRoleServiceList(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true)
+	runWhenEnterprise(T, ">=0.33.0", false, true)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
 	assert.Nil(err)
 	assert.NotNil(client)
+
+	defaultWorkspace, err := client.Workspaces.Get(defaultCtx, String("default"))
+	assert.Nil(err)
+	defaultWorkspace.Config = map[string]interface{}{"portal": true}
+	_, err = client.Workspaces.Update(defaultCtx, defaultWorkspace)
+	assert.Nil(err)
 
 	roleA := &DeveloperRole{
 		Name: String("roleA"),
@@ -81,15 +97,25 @@ func TestDeveloperRoleServiceList(T *testing.T) {
 	assert.Nil(err)
 	err = client.DeveloperRoles.Delete(defaultCtx, createdRoleB.ID)
 	assert.Nil(err)
+
+	defaultWorkspace.Config = map[string]interface{}{"portal": false}
+	_, err = client.Workspaces.Update(defaultCtx, defaultWorkspace)
+	assert.Nil(err)
 }
 
 func TestDeveloperRoleListEndpoint(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true)
+	runWhenEnterprise(T, ">=0.33.0", false, true)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
 	assert.Nil(err)
 	assert.NotNil(client)
+
+	defaultWorkspace, err := client.Workspaces.Get(defaultCtx, String("default"))
+	assert.Nil(err)
+	defaultWorkspace.Config = map[string]interface{}{"portal": true}
+	_, err = client.Workspaces.Update(defaultCtx, defaultWorkspace)
+	assert.Nil(err)
 
 	// fixtures
 	roles := []*DeveloperRole{
@@ -151,6 +177,10 @@ func TestDeveloperRoleListEndpoint(T *testing.T) {
 	for i := 0; i < len(roles); i++ {
 		assert.Nil(client.DeveloperRoles.Delete(defaultCtx, roles[i].ID))
 	}
+
+	defaultWorkspace.Config = map[string]interface{}{"portal": false}
+	_, err = client.Workspaces.Update(defaultCtx, defaultWorkspace)
+	assert.Nil(err)
 }
 
 func compareDeveloperRoles(expected, actual []*DeveloperRole) bool {

--- a/kong/developer_role_service_test.go
+++ b/kong/developer_role_service_test.go
@@ -15,11 +15,9 @@ func TestDeveloperRoleService(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	defaultWorkspace, err := client.Workspaces.Get(defaultCtx, String("default"))
+	testWs, err := NewTestWorkspace(client, "default")
 	assert.Nil(err)
-	defaultWorkspace.Config = map[string]interface{}{"portal": true}
-	_, err = client.Workspaces.Update(defaultCtx, defaultWorkspace)
-	assert.Nil(err)
+	assert.NoError(testWs.UpdateConfig(map[string]interface{}{"portal": true}))
 
 	role := &DeveloperRole{
 		Name: String("roleA"),
@@ -57,9 +55,7 @@ func TestDeveloperRoleService(T *testing.T) {
 	err = client.DeveloperRoles.Delete(defaultCtx, createdRole.ID)
 	assert.Nil(err)
 
-	defaultWorkspace.Config = map[string]interface{}{"portal": false}
-	_, err = client.Workspaces.Update(defaultCtx, defaultWorkspace)
-	assert.Nil(err)
+	assert.NoError(testWs.Reset())
 }
 func TestDeveloperRoleServiceList(T *testing.T) {
 	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{portal: true})
@@ -69,11 +65,9 @@ func TestDeveloperRoleServiceList(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	defaultWorkspace, err := client.Workspaces.Get(defaultCtx, String("default"))
+	testWs, err := NewTestWorkspace(client, "default")
 	assert.Nil(err)
-	defaultWorkspace.Config = map[string]interface{}{"portal": true}
-	_, err = client.Workspaces.Update(defaultCtx, defaultWorkspace)
-	assert.Nil(err)
+	assert.NoError(testWs.UpdateConfig(map[string]interface{}{"portal": true}))
 
 	roleA := &DeveloperRole{
 		Name: String("roleA"),
@@ -98,9 +92,7 @@ func TestDeveloperRoleServiceList(T *testing.T) {
 	err = client.DeveloperRoles.Delete(defaultCtx, createdRoleB.ID)
 	assert.Nil(err)
 
-	defaultWorkspace.Config = map[string]interface{}{"portal": false}
-	_, err = client.Workspaces.Update(defaultCtx, defaultWorkspace)
-	assert.Nil(err)
+	assert.NoError(testWs.Reset())
 }
 
 func TestDeveloperRoleListEndpoint(T *testing.T) {
@@ -111,11 +103,9 @@ func TestDeveloperRoleListEndpoint(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	defaultWorkspace, err := client.Workspaces.Get(defaultCtx, String("default"))
+	testWs, err := NewTestWorkspace(client, "default")
 	assert.Nil(err)
-	defaultWorkspace.Config = map[string]interface{}{"portal": true}
-	_, err = client.Workspaces.Update(defaultCtx, defaultWorkspace)
-	assert.Nil(err)
+	assert.NoError(testWs.UpdateConfig(map[string]interface{}{"portal": true}))
 
 	// fixtures
 	roles := []*DeveloperRole{
@@ -178,9 +168,7 @@ func TestDeveloperRoleListEndpoint(T *testing.T) {
 		assert.Nil(client.DeveloperRoles.Delete(defaultCtx, roles[i].ID))
 	}
 
-	defaultWorkspace.Config = map[string]interface{}{"portal": false}
-	_, err = client.Workspaces.Update(defaultCtx, defaultWorkspace)
-	assert.Nil(err)
+	assert.NoError(testWs.Reset())
 }
 
 func compareDeveloperRoles(expected, actual []*DeveloperRole) bool {

--- a/kong/endpoint_permission_service_test.go
+++ b/kong/endpoint_permission_service_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRBACEndpointPermissionservice(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true, false)
+	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/endpoint_permission_service_test.go
+++ b/kong/endpoint_permission_service_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRBACEndpointPermissionservice(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true)
+	runWhenEnterprise(T, ">=0.33.0", true, false)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/entity_permission_service_test.go
+++ b/kong/entity_permission_service_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRBACEntityPermissionservice(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true, false)
+	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -76,7 +76,7 @@ func TestRBACEntityPermissionservice(T *testing.T) {
 }
 
 func TestRBACEntityPermissionserviceList(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true, false)
+	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/entity_permission_service_test.go
+++ b/kong/entity_permission_service_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRBACEntityPermissionservice(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true)
+	runWhenEnterprise(T, ">=0.33.0", true, false)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -76,7 +76,7 @@ func TestRBACEntityPermissionservice(T *testing.T) {
 }
 
 func TestRBACEntityPermissionserviceList(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true)
+	runWhenEnterprise(T, ">=0.33.0", true, false)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/kong_test.go
+++ b/kong/kong_test.go
@@ -134,7 +134,7 @@ func runWhenKong(t *testing.T, semverRange string) {
 // fall within the semver range. If a test requires
 // RBAC and RBAC is not enabled on Kong the test
 // will be skipped
-func runWhenEnterprise(t *testing.T, semverRange string, rbacRequired bool) {
+func runWhenEnterprise(t *testing.T, semverRange string, rbacRequired bool, portalRequired bool) {
 	client, err := NewTestClient(nil, nil)
 	if err != nil {
 		t.Error(err)
@@ -155,12 +155,18 @@ func runWhenEnterprise(t *testing.T, semverRange string, rbacRequired bool) {
 		t.Skip()
 	}
 
+	p := res["configuration"].(map[string]interface{})["portal"]
+
+	if portalRequired && p != true {
+		t.Skip()
+	}
+
 	runWhenKong(t, semverRange)
 
 }
 
 func TestRunWhenEnterprise(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", false)
+	runWhenEnterprise(T, ">=0.33.0", false, false)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/kong_test.go
+++ b/kong/kong_test.go
@@ -151,18 +151,21 @@ func runWhenEnterprise(t *testing.T, semverRange string, required requiredFeatur
 	v := res["version"].(string)
 
 	if !strings.Contains(v, "enterprise-edition") {
+		t.Log("non-Enterprise test Kong instance, skipping")
 		t.Skip()
 	}
 
 	r := res["configuration"].(map[string]interface{})["rbac"].(string)
 
 	if required.rbac && r != "on" {
+		t.Log("RBAC not enabled on test Kong instance, skipping")
 		t.Skip()
 	}
 
 	p := res["configuration"].(map[string]interface{})["portal"]
 
 	if required.portal && p != true {
+		t.Log("Portal not enabled on test Kong instance, skipping")
 		t.Skip()
 	}
 

--- a/kong/kong_test.go
+++ b/kong/kong_test.go
@@ -128,13 +128,18 @@ func runWhenKong(t *testing.T, semverRange string) {
 
 }
 
+type requiredFeatures struct {
+	portal bool
+	rbac   bool
+}
+
 // runWhenEnterprise skips a test if the version
 // of Kong running is not enterprise edition. Skips
 // the current test if the version of Kong doesn't
 // fall within the semver range. If a test requires
 // RBAC and RBAC is not enabled on Kong the test
 // will be skipped
-func runWhenEnterprise(t *testing.T, semverRange string, rbacRequired bool, portalRequired bool) {
+func runWhenEnterprise(t *testing.T, semverRange string, required requiredFeatures) {
 	client, err := NewTestClient(nil, nil)
 	if err != nil {
 		t.Error(err)
@@ -151,13 +156,13 @@ func runWhenEnterprise(t *testing.T, semverRange string, rbacRequired bool, port
 
 	r := res["configuration"].(map[string]interface{})["rbac"].(string)
 
-	if rbacRequired && r != "on" {
+	if required.rbac && r != "on" {
 		t.Skip()
 	}
 
 	p := res["configuration"].(map[string]interface{})["portal"]
 
-	if portalRequired && p != true {
+	if required.portal && p != true {
 		t.Skip()
 	}
 
@@ -166,7 +171,7 @@ func runWhenEnterprise(t *testing.T, semverRange string, rbacRequired bool, port
 }
 
 func TestRunWhenEnterprise(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", false, false)
+	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/rbac_role_service_test.go
+++ b/kong/rbac_role_service_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRBACRoleService(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true, false)
+	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -52,7 +52,7 @@ func TestRBACRoleService(T *testing.T) {
 	assert.Nil(err)
 }
 func TestRBACRoleServiceList(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true, false)
+	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -85,7 +85,7 @@ func TestRBACRoleServiceList(T *testing.T) {
 }
 
 func TestRBACRoleListEndpoint(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true, false)
+	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/rbac_role_service_test.go
+++ b/kong/rbac_role_service_test.go
@@ -71,8 +71,9 @@ func TestRBACRoleServiceList(T *testing.T) {
 	createdRoleB, err := client.RBACRoles.Create(defaultCtx, roleB)
 	assert.Nil(err)
 
-	roles, err := client.RBACRoles.List(defaultCtx)
+	roles, next, err := client.RBACRoles.List(defaultCtx, nil)
 	assert.Nil(err)
+	assert.Nil(next)
 	assert.NotNil(roles)
 	// Counts default roles (super-admin, admin, read-only)
 	assert.Equal(5, len(roles))
@@ -81,4 +82,87 @@ func TestRBACRoleServiceList(T *testing.T) {
 	assert.Nil(err)
 	err = client.RBACRoles.Delete(defaultCtx, createdRoleB.ID)
 	assert.Nil(err)
+}
+
+func TestRBACRoleListEndpoint(T *testing.T) {
+	runWhenEnterprise(T, ">=0.33.0", true)
+	assert := assert.New(T)
+
+	client, err := NewTestClient(nil, nil)
+	assert.Nil(err)
+	assert.NotNil(client)
+
+	// fixtures
+	roles := []*RBACRole{
+		{
+			Name: String("roleA"),
+		},
+		{
+			Name: String("roleB"),
+		},
+		{
+			Name: String("roleC"),
+		},
+	}
+
+	// create fixturs
+	for i := 0; i < len(roles); i++ {
+		role, err := client.RBACRoles.Create(defaultCtx, roles[i])
+		assert.Nil(err)
+		assert.NotNil(role)
+		roles[i] = role
+	}
+
+	rolesFromKong, next, err := client.RBACRoles.List(defaultCtx, nil)
+	assert.Nil(err)
+	assert.Nil(next)
+	assert.NotNil(rolesFromKong)
+	assert.Equal(3, len(rolesFromKong))
+
+	// check if we see all roles
+	assert.True(compareRBACRoles(roles, rolesFromKong))
+
+	// Test pagination
+	rolesFromKong = []*RBACRole{}
+
+	// first page
+	page1, next, err := client.RBACRoles.List(defaultCtx, &ListOpt{Size: 1})
+	assert.Nil(err)
+	assert.NotNil(next)
+	assert.NotNil(page1)
+	assert.Equal(1, len(page1))
+	rolesFromKong = append(rolesFromKong, page1...)
+
+	// last page
+	next.Size = 2
+	page2, next, err := client.RBACRoles.List(defaultCtx, next)
+	assert.Nil(err)
+	assert.Nil(next)
+	assert.NotNil(page2)
+	assert.Equal(2, len(page2))
+	rolesFromKong = append(rolesFromKong, page2...)
+
+	assert.True(compareRBACRoles(roles, rolesFromKong))
+
+	roles, err = client.RBACRoles.ListAll(defaultCtx)
+	assert.Nil(err)
+	assert.NotNil(roles)
+	assert.Equal(3, len(roles))
+
+	for i := 0; i < len(roles); i++ {
+		assert.Nil(client.RBACRoles.Delete(defaultCtx, roles[i].ID))
+	}
+}
+
+func compareRBACRoles(expected, actual []*RBACRole) bool {
+	var expectedNames, actualNames []string
+	for _, role := range expected {
+		expectedNames = append(expectedNames, *role.Name)
+	}
+
+	for _, role := range actual {
+		actualNames = append(actualNames, *role.Name)
+	}
+
+	return (compareSlices(expectedNames, actualNames))
 }

--- a/kong/rbac_role_service_test.go
+++ b/kong/rbac_role_service_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRBACRoleService(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true)
+	runWhenEnterprise(T, ">=0.33.0", true, false)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -52,7 +52,7 @@ func TestRBACRoleService(T *testing.T) {
 	assert.Nil(err)
 }
 func TestRBACRoleServiceList(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true)
+	runWhenEnterprise(T, ">=0.33.0", true, false)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -85,7 +85,7 @@ func TestRBACRoleServiceList(T *testing.T) {
 }
 
 func TestRBACRoleListEndpoint(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true)
+	runWhenEnterprise(T, ">=0.33.0", true, false)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/rbac_user_service_test.go
+++ b/kong/rbac_user_service_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRBACUserService(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true, false)
+	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -42,7 +42,7 @@ func TestRBACUserService(T *testing.T) {
 }
 
 func TestRBACUserServiceWorkspace(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true, false)
+	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -93,7 +93,7 @@ func TestRBACUserServiceWorkspace(T *testing.T) {
 }
 
 func TestUserRoles(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true, false)
+	runWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
 	assert := assert.New(T)
 	client, err := NewTestClient(nil, nil)
 

--- a/kong/rbac_user_service_test.go
+++ b/kong/rbac_user_service_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRBACUserService(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true)
+	runWhenEnterprise(T, ">=0.33.0", true, false)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -42,7 +42,7 @@ func TestRBACUserService(T *testing.T) {
 }
 
 func TestRBACUserServiceWorkspace(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true)
+	runWhenEnterprise(T, ">=0.33.0", true, false)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -93,7 +93,7 @@ func TestRBACUserServiceWorkspace(T *testing.T) {
 }
 
 func TestUserRoles(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0", true)
+	runWhenEnterprise(T, ">=0.33.0", true, false)
 	assert := assert.New(T)
 	client, err := NewTestClient(nil, nil)
 

--- a/kong/workspace_service_test.go
+++ b/kong/workspace_service_test.go
@@ -132,7 +132,7 @@ func TestWorkspaceServiceListAll(T *testing.T) {
 // Workspace entities
 
 func TestWorkspaceService_Entities(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0 <=2.0.5", false)
+	runWhenEnterprise(T, ">=0.33.0 <=2.0.5", false, false)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/workspace_service_test.go
+++ b/kong/workspace_service_test.go
@@ -132,7 +132,7 @@ func TestWorkspaceServiceListAll(T *testing.T) {
 // Workspace entities
 
 func TestWorkspaceService_Entities(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0 <=2.0.5", false, false)
+	runWhenEnterprise(T, ">=0.33.0 <=2.0.5", requiredFeatures{})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)


### PR DESCRIPTION
Carried on from #29. Includes the original change from that and changes to require the Portal for Portal feature tests, as it is not set up by default, and further requires admin API requests to make it available on a workspace.

Removes the RBAC requirement from Portal tests, since they don't actually require RBAC. The original merge from #26 passed CI once in main, which suggests there's maybe something going wrong with CI RBAC setup--while my local test environment didn't have RBAC on and the tests did not run at all, it looks like RBAC-only tests [should run in CI](https://github.com/Kong/go-kong/blob/v0.16.0/.ci/setup_kong.sh#L45), so the Portal tests should have failed earlier.

See https://github.com/Kong/go-kong/pull/29#issuecomment-807396216 for a bit more background.