### PR TITLE
fix(rbac) include Negative when marshaling RBAC

### DIFF
--- a/kong/endpoint_permission_service_test.go
+++ b/kong/endpoint_permission_service_test.go
@@ -53,11 +53,14 @@ func TestRBACEndpointPermissionservice(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(ep)
 
+	negative := true
 	ep.Comment = String("new comment")
+	ep.Negative = &negative
 	ep, err = client.RBACEndpointPermissions.Update(defaultCtx, ep)
 	assert.Nil(err)
 	assert.NotNil(ep)
 	assert.Equal("new comment", *ep.Comment)
+	assert.Equal(negative, *ep.Negative)
 
 	err = client.RBACEndpointPermissions.Delete(
 		defaultCtx, createdRole.ID, createdWorkspace.ID, createdEndpointPermission.Endpoint)

--- a/kong/entity_permission_service_test.go
+++ b/kong/entity_permission_service_test.go
@@ -60,11 +60,14 @@ func TestRBACEntityPermissionservice(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(ep)
 
+	negative := true
 	ep.Comment = String("new comment")
+	ep.Negative = &negative
 	ep, err = workspaceClient.RBACEntityPermissions.Update(defaultCtx, ep)
 	assert.Nil(err)
 	assert.NotNil(ep)
 	assert.Equal("new comment", *ep.Comment)
+	assert.Equal(negative, *ep.Negative)
 
 	err = workspaceClient.RBACEntityPermissions.Delete(defaultCtx, createdRole.ID, createdEntityPermission.EntityID)
 	assert.Nil(err)

--- a/kong/types.go
+++ b/kong/types.go
@@ -363,6 +363,7 @@ func (e *RBACEndpointPermission) MarshalJSON() ([]byte, error) {
 		Workspace: e.Workspace,
 		Endpoint:  e.Endpoint,
 		Actions:   String(strings.Join(actions, ",")),
+		Negative:  e.Negative,
 		Comment:   e.Comment,
 	})
 }
@@ -399,6 +400,7 @@ func (e *RBACEntityPermission) MarshalJSON() ([]byte, error) {
 		EntityID:   e.EntityID,
 		EntityType: e.EntityType,
 		Actions:    String(strings.Join(actions, ",")),
+		Negative:   e.Negative,
 		Comment:    e.Comment,
 	})
 }

--- a/kong/types.go
+++ b/kong/types.go
@@ -333,6 +333,8 @@ type RBACRole struct {
 
 // RBACEndpointPermission represents an RBAC Endpoint Permission in Kong Enterprise
 // +k8s:deepcopy-gen=true
+// Note: this type implements a custom JSON marshaler. Review the associated MarshalJSON()
+// function if it does not marshal as expected.
 type RBACEndpointPermission struct {
 	CreatedAt *int      `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 	Workspace *string   `json:"workspace,omitempty" yaml:"workspace,omitempty"`
@@ -370,6 +372,8 @@ func (e *RBACEndpointPermission) MarshalJSON() ([]byte, error) {
 
 // RBACEntityPermission represents an RBAC Entity Permission in Kong Enterprise
 // +k8s:deepcopy-gen=true
+// Note: this type implements a custom JSON marshaler. Review the associated MarshalJSON()
+// function if it does not marshal as expected.
 type RBACEntityPermission struct {
 	CreatedAt  *int      `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 	EntityID   *string   `json:"entity_id,omitempty" yaml:"entity_id,omitempty"`


### PR DESCRIPTION
The custom JSON marshalers for these types omitted the Negative field, which prevented decK (or any other user of go-kong) from applying it. This was originally reported internally in FTI-2405. To recap/demonstrate, repeated syncs of [negative.yaml.txt](https://github.com/Kong/go-kong/files/6232800/negative.yaml.txt) would not never actually sync a negative permission, since the PATCH omitted that field:

```
./deck sync -s negative.yaml --rbac-resources-only --verbose 2
{"next":null,"data":[{"endpoint":"\/acls","created_at":1617146918,"workspace":"default","actions":["delete","create","update","read"],"negative":false,"comment":null,"role":{"id":"bb1522dc-e323-456a-bb9d-1d5f3fd07f6d"}}]}
updating rbac-endpointpermission bb1522dc-e323-456a-bb9d-1d5f3fd07f6d-default-/acls  {
   "actions": "delete,create,update,read",
   "endpoint": "/acls",
   "workspace": "default"
 }

PATCH /rbac/roles/bb1522dc-e323-456a-bb9d-1d5f3fd07f6d/endpoints/default//acls HTTP/1.1
{"workspace":"default","endpoint":"/acls","actions":"delete,create,update,read"}
HTTP/1.1 200 OK

{"endpoint":"\/acls","created_at":1617146918,"workspace":"default","actions":["delete","create","update","read"],"negative":false,"role":{"id":"bb1522dc-e323-456a-bb9d-1d5f3fd07f6d"}}
Summary:
  Created: 0
  Updated: 1
  Deleted: 0
```
With this change to go-kong, the PATCH will include that field, and the permissions will honor the `negative` field in the state file.