### PR TITLE
Update CI package locations and test versions

### DIFF
--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -7,13 +7,19 @@ sudo apt-get update
 sudo apt-get install openssl libpcre3 procps perl wget zlibc
 
 function setup_kong(){
-  SWITCH="1.3.100"
+  SWITCH="1.3.000"
+  SWITCH2="2.0.000"
 
-  URL="https://kong.bintray.com/kong-deb/kong-${KONG_VERSION}.xenial.all.deb"
+  URL="https://download.konghq.com/gateway-1.x-ubuntu-xenial/pool/all/k/kong/kong_${KONG_VERSION}_all.deb"
 
   if [[ "$KONG_VERSION" > "$SWITCH" ]];
   then
-  URL="https://kong.bintray.com/kong-deb/kong-${KONG_VERSION}.xenial.amd64.deb"
+  URL="https://download.konghq.com/gateway-1.x-ubuntu-xenial/pool/all/k/kong/kong_${KONG_VERSION}_amd64.deb"
+  fi
+
+  if [[ "$KONG_VERSION" > "$SWITCH2" ]];
+  then
+  URL="https://download.konghq.com/gateway-2.x-ubuntu-xenial/pool/all/k/kong/kong_${KONG_VERSION}_amd64.deb"
   fi
 
   /usr/bin/curl -sL $URL -o kong.deb
@@ -21,7 +27,21 @@ function setup_kong(){
 
 function setup_kong_enterprise(){
   KONG_VERSION="${KONG_VERSION#enterprise-}"
-  URL="https://kong.bintray.com/kong-enterprise-edition-deb/dists/kong-enterprise-edition-${KONG_VERSION}.xenial.all.deb"
+  SWITCH="1.5.0.100"
+  SWITCH2="2.0.0.000"
+
+  URL="https://download.konghq.com/private/gateway-1.x-ubuntu-xenial/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_${KONG_VERSION}_all.deb"
+
+  if [[ "$KONG_VERSION" > "$SWITCH" ]];
+  then
+  URL="https://download.konghq.com/gateway-1.x-ubuntu-xenial/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_${KONG_VERSION}_all.deb"
+  fi
+
+  if [[ "$KONG_VERSION" > "$SWITCH2" ]];
+  then
+  URL="https://download.konghq.com/gateway-2.x-ubuntu-xenial/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_${KONG_VERSION}_all.deb"
+  fi
+
   RESPONSE_CODE=$(/usr/bin/curl -sL \
     -w "%{http_code}" \
     -u $KONG_ENTERPRISE_REPO_USERNAME:$KONG_ENTERPRISE_REPO_PASSSWORD \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,15 +22,16 @@ jobs:
     strategy:
       matrix:
         kong_version:
-        - '1.0.3'
-        - '1.1.2'
-        - '1.2.0'
-        - '1.3.0'
-        - '1.4.0'
-        - '2.0.4'
-        - '2.1.0'
-        - '2.2.0'
-        - '2.3.0'
+        - '1.0.4'
+        - '1.1.3'
+        - '1.2.3'
+        - '1.3.1'
+        - '1.4.3'
+        - '2.0.5'
+        - '2.1.4'
+        - '2.2.2'
+        - '2.3.3'
+        - '2.4.0'
     env:
       KONG_VERSION: ${{ matrix.kong_version }}
       KONG_ENTERPRISE_REPO_USERNAME: ${{ secrets.KONG_ENTERPRISE_REPO_USERNAME }}
@@ -68,10 +69,10 @@ jobs:
       matrix:
         kong_version:
         - 'enterprise-1.3.0.2'
-        - 'enterprise-1.5.0.9'
-        - 'enterprise-2.1.4.4'
-        - 'enterprise-2.2.1.0'
-        - 'enterprise-2.3.2.0'
+        - 'enterprise-1.5.0.11'
+        - 'enterprise-2.1.4.6'
+        - 'enterprise-2.2.1.3'
+        - 'enterprise-2.3.3.2'
     env:
       KONG_VERSION: ${{ matrix.kong_version }}
       KONG_ENTERPRISE_REPO_USERNAME: ${{ secrets.KONG_ENTERPRISE_REPO_USERNAME }}


### PR DESCRIPTION
Updates version lists and package locations to make CI work with our new package repository. Our repository has some structural differences from Bintray, and the new version gates in setup_kong.sh account for this.

Test runs (with some additional diagnostic modifications) can be seen on https://github.com/rainest/go-kong/pull/6

1.3.0.2 Enterprise will still fail with this change. Our current credentials are for Bintray, not download.konghq.com. However, download.konghq.com also uses basic auth, so I don't expect we'll need changes to the script, only to the repo secret.