### PR TITLE
Check existence of tags or a workspace with the HEAD http verb instead of GET

### DIFF
--- a/kong/client.go
+++ b/kong/client.go
@@ -51,15 +51,15 @@ type Client struct {
 	RBACEndpointPermissions AbstractRBACEndpointPermissionService
 	RBACEntityPermissions   AbstractRBACEntityPermissionService
 
-	credentials abstractCredentialService
-	KeyAuths    AbstractKeyAuthService
-	BasicAuths  AbstractBasicAuthService
-	HMACAuths   AbstractHMACAuthService
-	JWTAuths    AbstractJWTAuthService
-	MTLSAuths   AbstractMTLSAuthService
-	ACLs        AbstractACLService
-
+	credentials       abstractCredentialService
+	KeyAuths          AbstractKeyAuthService
+	BasicAuths        AbstractBasicAuthService
+	HMACAuths         AbstractHMACAuthService
+	JWTAuths          AbstractJWTAuthService
+	MTLSAuths         AbstractMTLSAuthService
+	ACLs              AbstractACLService
 	Oauth2Credentials AbstractOauth2Service
+	Tags              AbstractTagService
 
 	logger         io.Writer
 	debug          bool
@@ -132,6 +132,7 @@ func NewClient(baseURL *string, client *http.Client) (*Client, error) {
 	kong.ACLs = (*ACLService)(&kong.common)
 
 	kong.Oauth2Credentials = (*Oauth2Service)(&kong.common)
+	kong.Tags = (*TagService)(&kong.common)
 
 	kong.CustomEntities = (*CustomEntityService)(&kong.common)
 	kong.Registry = custom.NewDefaultRegistry()

--- a/kong/exists.go
+++ b/kong/exists.go
@@ -7,19 +7,17 @@ import (
 
 // exists check the existence  with a HEAD HTTP verb
 func (c *Client) exists(ctx context.Context,
-	endpoint string) (*bool, error) {
+	endpoint string) (bool, error) {
 	req, err := c.NewRequest("HEAD", endpoint, nil, nil)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
-	var status = false
 	resp, err := c.Do(ctx, req, nil)
 	if err != nil {
 		if IsNotFoundErr(err) {
-			return &status, nil
+			return false, nil
 		}
-		return nil, err
+		return false, err
 	}
-	status = resp.StatusCode == http.StatusOK
-	return &status, nil
+	return resp.StatusCode == http.StatusOK, nil
 }

--- a/kong/exists.go
+++ b/kong/exists.go
@@ -1,0 +1,25 @@
+package kong
+
+import (
+	"context"
+	"net/http"
+)
+
+// exists check the existence  with a HEAD HTTP verb
+func (c *Client) exists(ctx context.Context,
+	endpoint string) (*bool, error) {
+	req, err := c.NewRequest("HEAD", endpoint, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	var status = false
+	resp, err := c.Do(ctx, req, nil)
+	if err != nil {
+		if IsNotFoundErr(err) {
+			return &status, nil
+		}
+		return nil, err
+	}
+	status = resp.StatusCode == http.StatusOK
+	return &status, nil
+}

--- a/kong/tag_service.go
+++ b/kong/tag_service.go
@@ -1,0 +1,29 @@
+package kong
+
+import (
+	"context"
+	"net/http"
+)
+
+// AbstractTagService handles Tags in Kong.
+type AbstractTagService interface {
+	// Check if the tags exists
+	Exists(ctx context.Context) (*bool, error)
+}
+
+// TagService handles Tags in Kong.
+type TagService service
+
+// Exists check exitence of the Tags in Kong.
+func (s *TagService) Exists(ctx context.Context) (*bool, error) {
+	req, err := s.client.NewRequest("HEAD", "/tags", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return nil, err
+	}
+	var status = resp.StatusCode == http.StatusOK
+	return &status, nil
+}

--- a/kong/tag_service.go
+++ b/kong/tag_service.go
@@ -7,13 +7,13 @@ import (
 // AbstractTagService handles Tags in Kong.
 type AbstractTagService interface {
 	//Exists checks if the tags exists
-	Exists(ctx context.Context) (*bool, error)
+	Exists(ctx context.Context) (bool, error)
 }
 
 // TagService handles Tags in Kong.
 type TagService service
 
 // Exists checks exitence of the Tags in Kong.
-func (s *TagService) Exists(ctx context.Context) (*bool, error) {
+func (s *TagService) Exists(ctx context.Context) (bool, error) {
 	return s.client.exists(ctx, "/tags")
 }

--- a/kong/tag_service.go
+++ b/kong/tag_service.go
@@ -2,7 +2,6 @@ package kong
 
 import (
 	"context"
-	"net/http"
 )
 
 // AbstractTagService handles Tags in Kong.
@@ -16,18 +15,5 @@ type TagService service
 
 // Exists checks exitence of the Tags in Kong.
 func (s *TagService) Exists(ctx context.Context) (*bool, error) {
-	req, err := s.client.NewRequest("HEAD", "/tags", nil, nil)
-	if err != nil {
-		return nil, err
-	}
-	var status = false
-	resp, err := s.client.Do(ctx, req, nil)
-	if err != nil {
-		if IsNotFoundErr(err) {
-			return &status, nil
-		}
-		return nil, err
-	}
-	status = resp.StatusCode == http.StatusOK
-	return &status, nil
+	return s.client.exists(ctx, "/tags")
 }

--- a/kong/tag_service.go
+++ b/kong/tag_service.go
@@ -20,10 +20,14 @@ func (s *TagService) Exists(ctx context.Context) (*bool, error) {
 	if err != nil {
 		return nil, err
 	}
+	var status = false
 	resp, err := s.client.Do(ctx, req, nil)
 	if err != nil {
+		if IsNotFoundErr(err) {
+			return &status, nil
+		}
 		return nil, err
 	}
-	var status = resp.StatusCode == http.StatusOK
+	status = resp.StatusCode == http.StatusOK
 	return &status, nil
 }

--- a/kong/tag_service.go
+++ b/kong/tag_service.go
@@ -7,14 +7,14 @@ import (
 
 // AbstractTagService handles Tags in Kong.
 type AbstractTagService interface {
-	// Check if the tags exists
+	//Exists checks if the tags exists
 	Exists(ctx context.Context) (*bool, error)
 }
 
 // TagService handles Tags in Kong.
 type TagService service
 
-// Exists check exitence of the Tags in Kong.
+// Exists checks exitence of the Tags in Kong.
 func (s *TagService) Exists(ctx context.Context) (*bool, error) {
 	req, err := s.client.NewRequest("HEAD", "/tags", nil, nil)
 	if err != nil {

--- a/kong/tag_service_test.go
+++ b/kong/tag_service_test.go
@@ -16,7 +16,7 @@ func TestTagExists(T *testing.T) {
 
 	exists, err := client.Tags.Exists(defaultCtx)
 	assert.Nil(err)
-	assert.True(*exists)
+	assert.True(exists)
 }
 
 func TestTagDoesNotExists(T *testing.T) {
@@ -29,5 +29,5 @@ func TestTagDoesNotExists(T *testing.T) {
 
 	exists, err := client.Tags.Exists(defaultCtx)
 	assert.Nil(err)
-	assert.False(*exists)
+	assert.False(exists)
 }

--- a/kong/tag_service_test.go
+++ b/kong/tag_service_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestTagExists(T *testing.T) {
+	runWhenKong(T, ">=1.1.0")
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -16,4 +17,17 @@ func TestTagExists(T *testing.T) {
 	exists, err := client.Tags.Exists(defaultCtx)
 	assert.Nil(err)
 	assert.True(*exists)
+}
+
+func TestTagDoesNotExists(T *testing.T) {
+	runWhenKong(T, "<1.1.0")
+	assert := assert.New(T)
+
+	client, err := NewTestClient(nil, nil)
+	assert.Nil(err)
+	assert.NotNil(client)
+
+	exists, err := client.Tags.Exists(defaultCtx)
+	assert.Nil(err)
+	assert.False(*exists)
 }

--- a/kong/tag_service_test.go
+++ b/kong/tag_service_test.go
@@ -1,0 +1,19 @@
+package kong
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagExists(T *testing.T) {
+	assert := assert.New(T)
+
+	client, err := NewTestClient(nil, nil)
+	assert.Nil(err)
+	assert.NotNil(client)
+
+	exists, err := client.Tags.Exists(defaultCtx)
+	assert.Nil(err)
+	assert.True(*exists)
+}

--- a/kong/workspace_service.go
+++ b/kong/workspace_service.go
@@ -10,7 +10,7 @@ import (
 // AbstractWorkspaceService handles Workspaces in Kong.
 type AbstractWorkspaceService interface {
 	// Exists checks the exitence of a Workspace in Kong.
-	Exists(ctx context.Context, nameOrID *string) (*bool, error)
+	Exists(ctx context.Context, nameOrID *string) (bool, error)
 	// Create creates a Workspace in Kong.
 	Create(ctx context.Context, workspace *Workspace) (*Workspace, error)
 	// Get fetches a Workspace in Kong.
@@ -45,9 +45,9 @@ type WorkspaceService service
 
 // Exists checks the exitence of the Workspace in Kong.
 func (s *WorkspaceService) Exists(ctx context.Context,
-	nameOrID *string) (*bool, error) {
+	nameOrID *string) (bool, error) {
 	if isEmptyString(nameOrID) {
-		return nil, errors.New("nameOrID cannot be nil for Get operation")
+		return false, errors.New("nameOrID cannot be nil for Get operation")
 	}
 
 	endpoint := fmt.Sprintf("/workspaces/%v", *nameOrID)

--- a/kong/workspace_service.go
+++ b/kong/workspace_service.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 )
 
 // AbstractWorkspaceService handles Workspaces in Kong.
@@ -52,20 +51,7 @@ func (s *WorkspaceService) Exists(ctx context.Context,
 	}
 
 	endpoint := fmt.Sprintf("/workspaces/%v", *nameOrID)
-	req, err := s.client.NewRequest("HEAD", endpoint, nil, nil)
-	if err != nil {
-		return nil, err
-	}
-	var status = false
-	resp, err := s.client.Do(ctx, req, nil)
-	if err != nil {
-		if IsNotFoundErr(err) {
-			return &status, nil
-		}
-		return nil, err
-	}
-	status = resp.StatusCode == http.StatusOK
-	return &status, nil
+	return s.client.exists(ctx, endpoint)
 }
 
 // Create creates a Workspace in Kong.

--- a/kong/workspace_service.go
+++ b/kong/workspace_service.go
@@ -1,11 +1,11 @@
 package kong
 
 import (
-	"net/http"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 )
 
 // AbstractWorkspaceService handles Workspaces in Kong.
@@ -43,7 +43,6 @@ type AbstractWorkspaceService interface {
 
 // WorkspaceService handles Workspaces in Kong.
 type WorkspaceService service
-
 
 // Exists checks the exitence of the Workspace in Kong.
 func (s *WorkspaceService) Exists(ctx context.Context,

--- a/kong/workspace_service_test.go
+++ b/kong/workspace_service_test.go
@@ -32,6 +32,10 @@ func TestWorkspaceService(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(workspace)
 
+	exists, err = client.Workspaces.Exists(defaultCtx, createdWorkspace.ID)
+	assert.Nil(err)
+	assert.True(*exists)
+
 	workspace.Comment = String("new comment")
 	workspace, err = client.Workspaces.Update(defaultCtx, workspace)
 	assert.Nil(err)

--- a/kong/workspace_service_test.go
+++ b/kong/workspace_service_test.go
@@ -32,7 +32,7 @@ func TestWorkspaceService(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(workspace)
 
-	exists, err = client.Workspaces.Exists(defaultCtx, createdWorkspace.ID)
+	exists, err := client.Workspaces.Exists(defaultCtx, createdWorkspace.ID)
 	assert.Nil(err)
 	assert.True(exists)
 

--- a/kong/workspace_service_test.go
+++ b/kong/workspace_service_test.go
@@ -34,7 +34,7 @@ func TestWorkspaceService(T *testing.T) {
 
 	exists, err = client.Workspaces.Exists(defaultCtx, createdWorkspace.ID)
 	assert.Nil(err)
-	assert.True(*exists)
+	assert.True(exists)
 
 	workspace.Comment = String("new comment")
 	workspace, err = client.Workspaces.Update(defaultCtx, workspace)


### PR DESCRIPTION
This is to use a service instead of 

https://github.com/Kong/kubernetes-ingress-controller/blob/fa0afebe1ccd19551305c89008d829a10790a1a0/cli/ingress-controller/main.go#L293-L296

And

https://github.com/Kong/kubernetes-ingress-controller/blob/ed88ebee538681888f303c572c139410f4d686f8/cli/ingress-controller/util.go#L35-L42

The logic of HEAD testing shall be moved somewhere to be reuse but I don't see where for now