### PR TITLE
chore(ci) drop testing against older versions of Kong

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,11 +22,6 @@ jobs:
     strategy:
       matrix:
         kong_version:
-        - '1.0.4'
-        - '1.1.3'
-        - '1.2.3'
-        - '1.3.1'
-        - '1.4.3'
         - '2.0.5'
         - '2.1.4'
         - '2.2.2'
@@ -68,7 +63,6 @@ jobs:
     strategy:
       matrix:
         kong_version:
-        - 'enterprise-1.3.0.2'
         - 'enterprise-1.5.0.11'
         - 'enterprise-2.1.4.6'
         - 'enterprise-2.2.1.3'


### PR DESCRIPTION
1.x series is no longer supported and maintained by Kong Inc so removing
testing against those.

See #47