### PR TITLE
refactor: simplify error creation and wrapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.16
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/google/go-querystring v1.1.0
-	github.com/pkg/errors v0.9.1
 	github.com/satori/go.uuid v1.2.0
 	github.com/stretchr/testify v1.7.0
 	k8s.io/code-generator v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,6 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/kong/admin_service.go
+++ b/kong/admin_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 )
@@ -49,7 +48,7 @@ func (s *AdminService) Invite(ctx context.Context,
 	admin *Admin) (*Admin, error) {
 
 	if admin == nil {
-		return nil, errors.New("cannot create a nil admin")
+		return nil, fmt.Errorf("cannot create a nil admin")
 	}
 
 	endpoint := "/admins"
@@ -81,7 +80,7 @@ func (s *AdminService) Get(ctx context.Context,
 	nameOrID *string) (*Admin, error) {
 
 	if isEmptyString(nameOrID) {
-		return nil, errors.New("nameOrID cannot be nil for Get operation")
+		return nil, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
 
 	endpoint := fmt.Sprintf("/admins/%v", *nameOrID)
@@ -105,7 +104,7 @@ func (s *AdminService) GenerateRegisterURL(ctx context.Context,
 	nameOrID *string) (*Admin, error) {
 
 	if isEmptyString(nameOrID) {
-		return nil, errors.New("nameOrID cannot be nil for Get operation")
+		return nil, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
 
 	endpoint := fmt.Sprintf("/admins/%v?generate_register_url=true", *nameOrID)
@@ -128,11 +127,11 @@ func (s *AdminService) Update(ctx context.Context,
 	admin *Admin) (*Admin, error) {
 
 	if admin == nil {
-		return nil, errors.New("cannot update a nil Admin")
+		return nil, fmt.Errorf("cannot update a nil Admin")
 	}
 
 	if isEmptyString(admin.ID) {
-		return nil, errors.New("ID cannot be nil for Update operation")
+		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
 
 	endpoint := fmt.Sprintf("/admins/%v", *admin.ID)
@@ -154,7 +153,7 @@ func (s *AdminService) Delete(ctx context.Context,
 	AdminOrID *string) error {
 
 	if isEmptyString(AdminOrID) {
-		return errors.New("AdminOrID cannot be nil for Delete operation")
+		return fmt.Errorf("AdminOrID cannot be nil for Delete operation")
 	}
 
 	endpoint := fmt.Sprintf("/admins/%v", *AdminOrID)
@@ -197,17 +196,17 @@ func (s *AdminService) RegisterCredentials(ctx context.Context,
 	admin *Admin) error {
 
 	if admin == nil {
-		return errors.New("cannot register credentials for a nil Admin")
+		return fmt.Errorf("cannot register credentials for a nil Admin")
 	}
 
 	if isEmptyString(admin.Username) {
-		return errors.New("Username cannot be nil for a registration operation")
+		return fmt.Errorf("Username cannot be nil for a registration operation")
 	}
 	if isEmptyString(admin.Email) {
-		return errors.New("Email cannot be nil for a registration operation")
+		return fmt.Errorf("Email cannot be nil for a registration operation")
 	}
 	if isEmptyString(admin.Password) {
-		return errors.New("Password cannot be nil for a registration operation")
+		return fmt.Errorf("Password cannot be nil for a registration operation")
 	}
 
 	req, err := s.client.NewRequest("POST", "/admins/register", nil, admin)
@@ -328,7 +327,7 @@ func (s *AdminService) GetConsumer(ctx context.Context,
 	emailOrID *string) (*Consumer, error) {
 
 	if isEmptyString(emailOrID) {
-		return nil, errors.New("emailOrID cannot be nil for GetConsumer operation")
+		return nil, fmt.Errorf("emailOrID cannot be nil for GetConsumer operation")
 	}
 
 	endpoint := fmt.Sprintf("/admins/%v/consumer", *emailOrID)

--- a/kong/ca_certificate_service.go
+++ b/kong/ca_certificate_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -58,7 +57,7 @@ func (s *CACertificateService) Get(ctx context.Context,
 	ID *string) (*CACertificate, error) {
 
 	if isEmptyString(ID) {
-		return nil, errors.New("ID cannot be nil for Get operation")
+		return nil, fmt.Errorf("ID cannot be nil for Get operation")
 	}
 
 	endpoint := fmt.Sprintf("/ca_certificates/%v", *ID)
@@ -80,7 +79,7 @@ func (s *CACertificateService) Update(ctx context.Context,
 	certificate *CACertificate) (*CACertificate, error) {
 
 	if isEmptyString(certificate.ID) {
-		return nil, errors.New("ID cannot be nil for Update op           eration")
+		return nil, fmt.Errorf("ID cannot be nil for Update op           eration")
 	}
 
 	endpoint := fmt.Sprintf("/ca_certificates/%v", *certificate.ID)
@@ -102,7 +101,7 @@ func (s *CACertificateService) Delete(ctx context.Context,
 	ID *string) error {
 
 	if isEmptyString(ID) {
-		return errors.New("ID cannot be nil for Delete operation")
+		return fmt.Errorf("ID cannot be nil for Delete operation")
 	}
 
 	endpoint := fmt.Sprintf("/ca_certificates/%v", *ID)

--- a/kong/certificate_service.go
+++ b/kong/certificate_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -58,7 +57,7 @@ func (s *CertificateService) Get(ctx context.Context,
 	usernameOrID *string) (*Certificate, error) {
 
 	if isEmptyString(usernameOrID) {
-		return nil, errors.New("usernameOrID cannot be nil for Get operation")
+		return nil, fmt.Errorf("usernameOrID cannot be nil for Get operation")
 	}
 
 	endpoint := fmt.Sprintf("/certificates/%v", *usernameOrID)
@@ -80,7 +79,7 @@ func (s *CertificateService) Update(ctx context.Context,
 	certificate *Certificate) (*Certificate, error) {
 
 	if isEmptyString(certificate.ID) {
-		return nil, errors.New("ID cannot be nil for Update op           eration")
+		return nil, fmt.Errorf("ID cannot be nil for Update op           eration")
 	}
 
 	endpoint := fmt.Sprintf("/certificates/%v", *certificate.ID)
@@ -102,7 +101,7 @@ func (s *CertificateService) Delete(ctx context.Context,
 	usernameOrID *string) error {
 
 	if isEmptyString(usernameOrID) {
-		return errors.New("usernameOrID cannot be nil for Delete operation")
+		return fmt.Errorf("usernameOrID cannot be nil for Delete operation")
 	}
 
 	endpoint := fmt.Sprintf("/certificates/%v", *usernameOrID)

--- a/kong/client.go
+++ b/kong/client.go
@@ -3,6 +3,7 @@ package kong
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -10,8 +11,6 @@ import (
 	"net/url"
 	"os"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/kong/go-kong/kong/custom"
 )
@@ -115,7 +114,7 @@ func NewClient(baseURL *string, client *http.Client) (*Client, error) {
 	}
 	url, err := url.ParseRequestURI(rootURL)
 	if err != nil {
-		return nil, errors.Wrap(err, "parsing URL")
+		return nil, fmt.Errorf("parsing URL: %w", err)
 	}
 	kong.baseURL = url.String()
 
@@ -169,7 +168,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request,
 	v interface{}) (*Response, error) {
 	var err error
 	if req == nil {
-		return nil, errors.New("request cannot be nil")
+		return nil, fmt.Errorf("request cannot be nil")
 	}
 	if ctx == nil {
 		ctx = defaultCtx
@@ -185,7 +184,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request,
 	//Make the request
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "making HTTP request")
+		return nil, fmt.Errorf("making HTTP request: %w", err)
 	}
 
 	// log the response

--- a/kong/consumer_service.go
+++ b/kong/consumer_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 )
@@ -61,7 +60,7 @@ func (s *ConsumerService) Get(ctx context.Context,
 	usernameOrID *string) (*Consumer, error) {
 
 	if isEmptyString(usernameOrID) {
-		return nil, errors.New("usernameOrID cannot be nil for Get operation")
+		return nil, fmt.Errorf("usernameOrID cannot be nil for Get operation")
 	}
 
 	endpoint := fmt.Sprintf("/consumers/%v", *usernameOrID)
@@ -83,7 +82,7 @@ func (s *ConsumerService) GetByCustomID(ctx context.Context,
 	customID *string) (*Consumer, error) {
 
 	if isEmptyString(customID) {
-		return nil, errors.New("customID cannot be nil for Get operation")
+		return nil, fmt.Errorf("customID cannot be nil for Get operation")
 	}
 
 	type QS struct {
@@ -117,7 +116,7 @@ func (s *ConsumerService) Update(ctx context.Context,
 	consumer *Consumer) (*Consumer, error) {
 
 	if isEmptyString(consumer.ID) {
-		return nil, errors.New("ID cannot be nil for Update operation")
+		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
 
 	endpoint := fmt.Sprintf("/consumers/%v", *consumer.ID)
@@ -139,7 +138,7 @@ func (s *ConsumerService) Delete(ctx context.Context,
 	usernameOrID *string) error {
 
 	if isEmptyString(usernameOrID) {
-		return errors.New("usernameOrID cannot be nil for Delete operation")
+		return fmt.Errorf("usernameOrID cannot be nil for Delete operation")
 	}
 
 	endpoint := fmt.Sprintf("/consumers/%v", *usernameOrID)

--- a/kong/credentials_service.go
+++ b/kong/credentials_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"reflect"
 )
@@ -47,7 +46,7 @@ func (s *credentialService) Create(ctx context.Context, credType string,
 	credential interface{}) (json.RawMessage, error) {
 
 	if isEmptyString(consumerUsernameOrID) {
-		return nil, errors.New("consumerUsernameOrID cannot be nil")
+		return nil, fmt.Errorf("consumerUsernameOrID cannot be nil")
 	}
 
 	subPath, ok := credPath[credType]
@@ -87,10 +86,10 @@ func (s *credentialService) Get(ctx context.Context, credType string,
 	credIdentifier *string) (json.RawMessage, error) {
 
 	if isEmptyString(credIdentifier) {
-		return nil, errors.New("credIdentifier cannot be nil for Get operation")
+		return nil, fmt.Errorf("credIdentifier cannot be nil for Get operation")
 	}
 	if isEmptyString(consumerUsernameOrID) {
-		return nil, errors.New("consumerUsernameOrID cannot be nil")
+		return nil, fmt.Errorf("consumerUsernameOrID cannot be nil")
 	}
 
 	subPath, ok := credPath[credType]
@@ -118,7 +117,7 @@ func (s *credentialService) Update(ctx context.Context, credType string,
 	credential interface{}) (json.RawMessage, error) {
 
 	if isEmptyString(consumerUsernameOrID) {
-		return nil, errors.New("consumerUsernameOrID cannot be nil")
+		return nil, fmt.Errorf("consumerUsernameOrID cannot be nil")
 	}
 
 	subPath, ok := credPath[credType]
@@ -140,7 +139,7 @@ func (s *credentialService) Update(ctx context.Context, credType string,
 		}
 	}
 	if credID == "" {
-		return nil, errors.New("cannot update a credential without an ID")
+		return nil, fmt.Errorf("cannot update a credential without an ID")
 	}
 
 	endpoint = endpoint + credID
@@ -163,7 +162,7 @@ func (s *credentialService) Delete(ctx context.Context, credType string,
 	consumerUsernameOrID, credIdentifier *string) error {
 
 	if isEmptyString(credIdentifier) {
-		return errors.New("credIdentifier cannot be nil for Delete operation")
+		return fmt.Errorf("credIdentifier cannot be nil for Delete operation")
 	}
 
 	subPath, ok := credPath[credType]

--- a/kong/custom/entity_crud.go
+++ b/kong/custom/entity_crud.go
@@ -1,7 +1,7 @@
 package custom
 
 import (
-	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -53,7 +53,7 @@ func render(template string, entity Entity) (string, error) {
 		if v := entity.GetRelation(m[1]); v != "" {
 			result = strings.Replace(result, m[0], v, 1)
 		} else {
-			return "", errors.New("cannot substitute '" + m[1] +
+			return "", fmt.Errorf("cannot substitute '" + m[1] +
 				"' in URL: " + template)
 		}
 	}
@@ -67,11 +67,11 @@ func (e EntityCRUDDefinition) renderWithPK(entity Entity) (string, error) {
 	}
 	p, ok := entity.Object()[e.PrimaryKey]
 	if !ok {
-		return "", errors.New("primary key not found in entity")
+		return "", fmt.Errorf("primary key not found in entity")
 	}
 	key, ok := p.(string)
 	if !ok {
-		return "", errors.New("primary key can't be converted to string")
+		return "", fmt.Errorf("primary key can't be converted to string")
 	}
 	return endpoint + "/" + key, nil
 }

--- a/kong/custom/registry.go
+++ b/kong/custom/registry.go
@@ -1,6 +1,6 @@
 package custom
 
-import "errors"
+import "fmt"
 
 // Registry is a store of EntityCRUD objects
 type Registry interface {
@@ -37,7 +37,7 @@ func NewDefaultRegistry() Registry {
 // of Type is already registered.
 func (r *defaultRegistry) Register(typ Type, def EntityCRUD) error {
 	if _, ok := r.store[typ]; ok {
-		return errors.New("type already registered")
+		return fmt.Errorf("type already registered")
 	}
 	r.store[typ] = def
 	return nil
@@ -56,7 +56,7 @@ func (r *defaultRegistry) Lookup(typ Type) EntityCRUD {
 // before this call.
 func (r *defaultRegistry) Unregister(typ Type) error {
 	if _, ok := r.store[typ]; !ok {
-		return errors.New("type not registered")
+		return fmt.Errorf("type not registered")
 	}
 	delete(r.store, typ)
 	return nil

--- a/kong/custom_entity_service.go
+++ b/kong/custom_entity_service.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 
 	"github.com/kong/go-kong/kong/custom"
 )
@@ -35,7 +35,7 @@ func (s *CustomEntityService) Get(ctx context.Context,
 	entity custom.Entity) (custom.Entity, error) {
 	def := s.client.Lookup(entity.Type())
 	if def == nil {
-		return nil, errors.New("entity '" + string(entity.Type()) +
+		return nil, fmt.Errorf("entity '" + string(entity.Type()) +
 			"' not registered")
 	}
 
@@ -65,7 +65,7 @@ func (s *CustomEntityService) Create(ctx context.Context,
 	entity custom.Entity) (custom.Entity, error) {
 	def := s.client.Lookup(entity.Type())
 	if def == nil {
-		return nil, errors.New("entity '" + string(entity.Type()) +
+		return nil, fmt.Errorf("entity '" + string(entity.Type()) +
 			"' not registered")
 	}
 
@@ -110,7 +110,7 @@ func (s *CustomEntityService) Update(ctx context.Context,
 	entity custom.Entity) (custom.Entity, error) {
 	def := s.client.Lookup(entity.Type())
 	if def == nil {
-		return nil, errors.New("entity '" + string(entity.Type()) +
+		return nil, fmt.Errorf("entity '" + string(entity.Type()) +
 			"' not registered")
 	}
 
@@ -145,7 +145,7 @@ func (s *CustomEntityService) Delete(ctx context.Context,
 	entity custom.Entity) error {
 	def := s.client.Lookup(entity.Type())
 	if def == nil {
-		return errors.New("entity '" + string(entity.Type()) +
+		return fmt.Errorf("entity '" + string(entity.Type()) +
 			"' not registered")
 	}
 
@@ -168,7 +168,7 @@ func (s *CustomEntityService) List(ctx context.Context, opt *ListOpt,
 	entity custom.Entity) ([]custom.Entity, *ListOpt, error) {
 	def := s.client.Lookup(entity.Type())
 	if def == nil {
-		return nil, nil, errors.New("entity '" + string(entity.Type()) +
+		return nil, nil, fmt.Errorf("entity '" + string(entity.Type()) +
 			"' not registered")
 	}
 

--- a/kong/developer_role_service.go
+++ b/kong/developer_role_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -31,7 +30,7 @@ func (s *DeveloperRoleService) Create(ctx context.Context,
 	role *DeveloperRole) (*DeveloperRole, error) {
 
 	if role == nil {
-		return nil, errors.New("cannot create a nil role")
+		return nil, fmt.Errorf("cannot create a nil role")
 	}
 
 	endpoint := "/developers/roles"
@@ -55,7 +54,7 @@ func (s *DeveloperRoleService) Get(ctx context.Context,
 	nameOrID *string) (*DeveloperRole, error) {
 
 	if isEmptyString(nameOrID) {
-		return nil, errors.New("nameOrID cannot be nil for Get operation")
+		return nil, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
 
 	endpoint := fmt.Sprintf("/developers/roles/%v", *nameOrID)
@@ -77,11 +76,11 @@ func (s *DeveloperRoleService) Update(ctx context.Context,
 	role *DeveloperRole) (*DeveloperRole, error) {
 
 	if role == nil {
-		return nil, errors.New("cannot update a nil Role")
+		return nil, fmt.Errorf("cannot update a nil Role")
 	}
 
 	if isEmptyString(role.ID) {
-		return nil, errors.New("ID cannot be nil for Update operation")
+		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
 
 	endpoint := fmt.Sprintf("/developers/roles/%v", *role.ID)
@@ -103,7 +102,7 @@ func (s *DeveloperRoleService) Delete(ctx context.Context,
 	RoleOrID *string) error {
 
 	if isEmptyString(RoleOrID) {
-		return errors.New("RoleOrID cannot be nil for Delete operation")
+		return fmt.Errorf("RoleOrID cannot be nil for Delete operation")
 	}
 
 	endpoint := fmt.Sprintf("/developers/roles/%v", *RoleOrID)

--- a/kong/developer_service.go
+++ b/kong/developer_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 )
@@ -61,7 +60,7 @@ func (s *DeveloperService) Get(ctx context.Context,
 	emailOrID *string) (*Developer, error) {
 
 	if isEmptyString(emailOrID) {
-		return nil, errors.New("emailOrID cannot be nil for Get operation")
+		return nil, fmt.Errorf("emailOrID cannot be nil for Get operation")
 	}
 
 	endpoint := fmt.Sprintf("/developers/%v", *emailOrID)
@@ -83,7 +82,7 @@ func (s *DeveloperService) GetByCustomID(ctx context.Context,
 	customID *string) (*Developer, error) {
 
 	if isEmptyString(customID) {
-		return nil, errors.New("customID cannot be nil for Get operation")
+		return nil, fmt.Errorf("customID cannot be nil for Get operation")
 	}
 
 	type QS struct {
@@ -117,7 +116,7 @@ func (s *DeveloperService) Update(ctx context.Context,
 	developer *Developer) (*Developer, error) {
 
 	if isEmptyString(developer.ID) {
-		return nil, errors.New("ID cannot be nil for Update operation")
+		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
 
 	endpoint := fmt.Sprintf("/developers/%v", *developer.ID)
@@ -141,7 +140,7 @@ func (s *DeveloperService) Delete(ctx context.Context,
 	emailOrID *string) error {
 
 	if isEmptyString(emailOrID) {
-		return errors.New("emailOrID cannot be nil for Delete operation")
+		return fmt.Errorf("emailOrID cannot be nil for Delete operation")
 	}
 
 	endpoint := fmt.Sprintf("/developers/%v", *emailOrID)

--- a/kong/endpoint_permission_service.go
+++ b/kong/endpoint_permission_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -30,10 +29,10 @@ func (s *RBACEndpointPermissionService) Create(ctx context.Context,
 	ep *RBACEndpointPermission) (*RBACEndpointPermission, error) {
 
 	if ep == nil {
-		return nil, errors.New("cannot create a nil endpointpermission")
+		return nil, fmt.Errorf("cannot create a nil endpointpermission")
 	}
 	if ep.Role == nil || ep.Role.ID == nil {
-		return nil, errors.New("cannot create endpoint permission with role or role id undefined")
+		return nil, fmt.Errorf("cannot create endpoint permission with role or role id undefined")
 	}
 
 	method := "POST"
@@ -58,7 +57,7 @@ func (s *RBACEndpointPermissionService) Get(ctx context.Context,
 	roleNameOrID *string, workspaceNameOrID *string, endpointName *string) (*RBACEndpointPermission, error) {
 
 	if isEmptyString(endpointName) {
-		return nil, errors.New("endpointName cannot be nil for Get operation")
+		return nil, fmt.Errorf("endpointName cannot be nil for Get operation")
 	}
 	if *endpointName == "*" {
 		endpointName = String("/" + *endpointName)
@@ -82,17 +81,17 @@ func (s *RBACEndpointPermissionService) Update(ctx context.Context,
 	ep *RBACEndpointPermission) (*RBACEndpointPermission, error) {
 
 	if ep == nil {
-		return nil, errors.New("cannot update a nil EndpointPermission")
+		return nil, fmt.Errorf("cannot update a nil EndpointPermission")
 	}
 	if ep.Workspace == nil {
-		return nil, errors.New("cannot update an EndpointPermission with workspace as nil")
+		return nil, fmt.Errorf("cannot update an EndpointPermission with workspace as nil")
 	}
 	if ep.Role == nil || ep.Role.ID == nil {
-		return nil, errors.New("cannot create endpoint permission with role or role id undefined")
+		return nil, fmt.Errorf("cannot create endpoint permission with role or role id undefined")
 	}
 
 	if isEmptyString(ep.Endpoint) {
-		return nil, errors.New("ID cannot be nil for Update operation")
+		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
 
 	endpoint := fmt.Sprintf("/rbac/roles/%v/endpoints/%v/%v",
@@ -115,13 +114,13 @@ func (s *RBACEndpointPermissionService) Delete(ctx context.Context,
 	roleNameOrID *string, workspaceNameOrID *string, endpoint *string) error {
 
 	if endpoint == nil {
-		return errors.New("cannot update a nil EndpointPermission")
+		return fmt.Errorf("cannot update a nil EndpointPermission")
 	}
 	if workspaceNameOrID == nil {
-		return errors.New("cannot update an EndpointPermission with workspace as nil")
+		return fmt.Errorf("cannot update an EndpointPermission with workspace as nil")
 	}
 	if roleNameOrID == nil {
-		return errors.New("cannot update an EndpointPermission with role as nil")
+		return fmt.Errorf("cannot update an EndpointPermission with role as nil")
 	}
 
 	reqEndpoint := fmt.Sprintf("/rbac/roles/%v/endpoints/%v/%v",

--- a/kong/entity_permission_service.go
+++ b/kong/entity_permission_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -29,10 +28,10 @@ func (s *RBACEntityPermissionService) Create(ctx context.Context,
 	ep *RBACEntityPermission) (*RBACEntityPermission, error) {
 
 	if ep == nil {
-		return nil, errors.New("cannot create a nil entitypermission")
+		return nil, fmt.Errorf("cannot create a nil entitypermission")
 	}
 	if ep.Role == nil || ep.Role.ID == nil {
-		return nil, errors.New("cannot create entity permission with role or role id undefined")
+		return nil, fmt.Errorf("cannot create entity permission with role or role id undefined")
 	}
 
 	method := "POST"
@@ -57,7 +56,7 @@ func (s *RBACEntityPermissionService) Get(ctx context.Context,
 	roleNameOrID *string, entityName *string) (*RBACEntityPermission, error) {
 
 	if isEmptyString(entityName) {
-		return nil, errors.New("entityName cannot be nil for Get operation")
+		return nil, fmt.Errorf("entityName cannot be nil for Get operation")
 	}
 
 	entity := fmt.Sprintf("/rbac/roles/%v/entities/%v", *roleNameOrID, *entityName)
@@ -79,15 +78,15 @@ func (s *RBACEntityPermissionService) Update(ctx context.Context,
 	ep *RBACEntityPermission) (*RBACEntityPermission, error) {
 
 	if ep == nil {
-		return nil, errors.New("cannot update a nil EntityPermission")
+		return nil, fmt.Errorf("cannot update a nil EntityPermission")
 	}
 
 	if ep.Role == nil || ep.Role.ID == nil {
-		return nil, errors.New("cannot create entity permission with role or role id undefined")
+		return nil, fmt.Errorf("cannot create entity permission with role or role id undefined")
 	}
 
 	if isEmptyString(ep.EntityID) {
-		return nil, errors.New("ID cannot be nil for Update operation")
+		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
 
 	entity := fmt.Sprintf("/rbac/roles/%v/entities/%v",
@@ -110,10 +109,10 @@ func (s *RBACEntityPermissionService) Delete(ctx context.Context,
 	roleNameOrID *string, entityID *string) error {
 
 	if roleNameOrID == nil {
-		return errors.New("cannot update an EntityPermission with role as nil")
+		return fmt.Errorf("cannot update an EntityPermission with role as nil")
 	}
 	if entityID == nil {
-		return errors.New("cannot update an EntityPermission with entity ID as nil")
+		return fmt.Errorf("cannot update an EntityPermission with entity ID as nil")
 	}
 
 	endpoint := fmt.Sprintf("/rbac/roles/%v/entities/%v",

--- a/kong/error_test.go
+++ b/kong/error_test.go
@@ -1,7 +1,7 @@
 package kong
 
 import (
-	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,7 +14,7 @@ func TestIsNotFoundErr(T *testing.T) {
 	assert.True(IsNotFoundErr(e))
 	assert.False(IsNotFoundErr(nil))
 
-	err := errors.New("not a 404")
+	err := fmt.Errorf("not a 404")
 	assert.False(IsNotFoundErr(err))
 }
 

--- a/kong/plugin_service.go
+++ b/kong/plugin_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 )
@@ -41,7 +40,7 @@ type PluginService service
 func (s *PluginService) GetSchema(ctx context.Context,
 	pluginName *string) (map[string]interface{}, error) {
 	if isEmptyString(pluginName) {
-		return nil, errors.New("pluginName cannot be empty")
+		return nil, fmt.Errorf("pluginName cannot be empty")
 	}
 	endpoint := fmt.Sprintf("/plugins/schema/%v", *pluginName)
 	req, err := s.client.NewRequest("GET", endpoint, nil, nil)
@@ -88,7 +87,7 @@ func (s *PluginService) Get(ctx context.Context,
 	usernameOrID *string) (*Plugin, error) {
 
 	if isEmptyString(usernameOrID) {
-		return nil, errors.New("usernameOrID cannot be nil for Get operation")
+		return nil, fmt.Errorf("usernameOrID cannot be nil for Get operation")
 	}
 
 	endpoint := fmt.Sprintf("/plugins/%v", *usernameOrID)
@@ -110,7 +109,7 @@ func (s *PluginService) Update(ctx context.Context,
 	plugin *Plugin) (*Plugin, error) {
 
 	if isEmptyString(plugin.ID) {
-		return nil, errors.New("ID cannot be nil for Update operation")
+		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
 
 	endpoint := fmt.Sprintf("/plugins/%v", *plugin.ID)
@@ -132,7 +131,7 @@ func (s *PluginService) Delete(ctx context.Context,
 	usernameOrID *string) error {
 
 	if isEmptyString(usernameOrID) {
-		return errors.New("usernameOrID cannot be nil for Delete operation")
+		return fmt.Errorf("usernameOrID cannot be nil for Delete operation")
 	}
 
 	endpoint := fmt.Sprintf("/plugins/%v", *usernameOrID)
@@ -224,7 +223,7 @@ func (s *PluginService) ListAll(ctx context.Context) ([]*Plugin, error) {
 func (s *PluginService) ListAllForConsumer(ctx context.Context,
 	consumerIDorName *string) ([]*Plugin, error) {
 	if isEmptyString(consumerIDorName) {
-		return nil, errors.New("consumerIDorName cannot be nil")
+		return nil, fmt.Errorf("consumerIDorName cannot be nil")
 	}
 	return s.listAllByPath(ctx, "/consumers/"+*consumerIDorName+"/plugins")
 }
@@ -233,7 +232,7 @@ func (s *PluginService) ListAllForConsumer(ctx context.Context,
 func (s *PluginService) ListAllForService(ctx context.Context,
 	serviceIDorName *string) ([]*Plugin, error) {
 	if isEmptyString(serviceIDorName) {
-		return nil, errors.New("serviceIDorName cannot be nil")
+		return nil, fmt.Errorf("serviceIDorName cannot be nil")
 	}
 	return s.listAllByPath(ctx, "/services/"+*serviceIDorName+"/plugins")
 }
@@ -242,7 +241,7 @@ func (s *PluginService) ListAllForService(ctx context.Context,
 func (s *PluginService) ListAllForRoute(ctx context.Context,
 	routeID *string) ([]*Plugin, error) {
 	if isEmptyString(routeID) {
-		return nil, errors.New("routeID cannot be nil")
+		return nil, fmt.Errorf("routeID cannot be nil")
 	}
 	return s.listAllByPath(ctx, "/routes/"+*routeID+"/plugins")
 }

--- a/kong/rbac_role_service.go
+++ b/kong/rbac_role_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -31,7 +30,7 @@ func (s *RBACRoleService) Create(ctx context.Context,
 	role *RBACRole) (*RBACRole, error) {
 
 	if role == nil {
-		return nil, errors.New("cannot create a nil role")
+		return nil, fmt.Errorf("cannot create a nil role")
 	}
 
 	endpoint := "/rbac/roles"
@@ -59,7 +58,7 @@ func (s *RBACRoleService) Get(ctx context.Context,
 	nameOrID *string) (*RBACRole, error) {
 
 	if isEmptyString(nameOrID) {
-		return nil, errors.New("nameOrID cannot be nil for Get operation")
+		return nil, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
 
 	endpoint := fmt.Sprintf("/rbac/roles/%v", *nameOrID)
@@ -81,11 +80,11 @@ func (s *RBACRoleService) Update(ctx context.Context,
 	role *RBACRole) (*RBACRole, error) {
 
 	if role == nil {
-		return nil, errors.New("cannot update a nil Role")
+		return nil, fmt.Errorf("cannot update a nil Role")
 	}
 
 	if isEmptyString(role.ID) {
-		return nil, errors.New("ID cannot be nil for Update operation")
+		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
 
 	endpoint := fmt.Sprintf("/rbac/roles/%v", *role.ID)
@@ -107,7 +106,7 @@ func (s *RBACRoleService) Delete(ctx context.Context,
 	RoleOrID *string) error {
 
 	if isEmptyString(RoleOrID) {
-		return errors.New("RoleOrID cannot be nil for Delete operation")
+		return fmt.Errorf("RoleOrID cannot be nil for Delete operation")
 	}
 
 	endpoint := fmt.Sprintf("/rbac/roles/%v", *RoleOrID)

--- a/kong/rbac_user_service.go
+++ b/kong/rbac_user_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 )
@@ -41,7 +40,7 @@ func (s *RBACUserService) Create(ctx context.Context,
 	user *RBACUser) (*RBACUser, error) {
 
 	if user == nil {
-		return nil, errors.New("cannot create a nil user")
+		return nil, fmt.Errorf("cannot create a nil user")
 	}
 
 	endpoint := "/rbac/users"
@@ -69,7 +68,7 @@ func (s *RBACUserService) Get(ctx context.Context,
 	nameOrID *string) (*RBACUser, error) {
 
 	if isEmptyString(nameOrID) {
-		return nil, errors.New("nameOrID cannot be nil for Get operation")
+		return nil, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
 
 	endpoint := fmt.Sprintf("/rbac/users/%v", *nameOrID)
@@ -91,11 +90,11 @@ func (s *RBACUserService) Update(ctx context.Context,
 	user *RBACUser) (*RBACUser, error) {
 
 	if user == nil {
-		return nil, errors.New("cannot update a nil User")
+		return nil, fmt.Errorf("cannot update a nil User")
 	}
 
 	if isEmptyString(user.ID) && isEmptyString(user.Name) {
-		return nil, errors.New("ID and Name cannot both be nil for Update operation")
+		return nil, fmt.Errorf("ID and Name cannot both be nil for Update operation")
 	}
 
 	endpoint := fmt.Sprintf("/rbac/users/%v", *user.ID)
@@ -117,7 +116,7 @@ func (s *RBACUserService) Delete(ctx context.Context,
 	userOrID *string) error {
 
 	if isEmptyString(userOrID) {
-		return errors.New("UserOrID cannot be nil for Delete operation")
+		return fmt.Errorf("UserOrID cannot be nil for Delete operation")
 	}
 
 	endpoint := fmt.Sprintf("/rbac/users/%v", *userOrID)

--- a/kong/request.go
+++ b/kong/request.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/google/go-querystring/query"
@@ -17,7 +17,7 @@ func (c *Client) NewRequest(method, endpoint string, qs interface{},
 	body interface{}) (*http.Request, error) {
 
 	if endpoint == "" {
-		return nil, errors.New("endpoint can't be nil")
+		return nil, fmt.Errorf("endpoint can't be nil")
 	}
 	//body to be sent in JSON
 	var buf []byte

--- a/kong/route_service.go
+++ b/kong/route_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -38,7 +37,7 @@ func (s *RouteService) Create(ctx context.Context,
 	route *Route) (*Route, error) {
 
 	if route == nil {
-		return nil, errors.New("cannot create a nil route")
+		return nil, fmt.Errorf("cannot create a nil route")
 	}
 
 	endpoint := "/routes"
@@ -64,10 +63,10 @@ func (s *RouteService) Create(ctx context.Context,
 func (s *RouteService) CreateInService(ctx context.Context,
 	serviceID *string, route *Route) (*Route, error) {
 	if isEmptyString(serviceID) {
-		return nil, errors.New("serviceID cannot be nil for creating a route")
+		return nil, fmt.Errorf("serviceID cannot be nil for creating a route")
 	}
 	if route == nil {
-		return nil, errors.New("cannot create a nil route")
+		return nil, fmt.Errorf("cannot create a nil route")
 	}
 	r := *route
 	r.Service = &Service{ID: serviceID}
@@ -79,7 +78,7 @@ func (s *RouteService) Get(ctx context.Context,
 	nameOrID *string) (*Route, error) {
 
 	if isEmptyString(nameOrID) {
-		return nil, errors.New("nameOrID cannot be nil for Get operation")
+		return nil, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
 
 	endpoint := fmt.Sprintf("/routes/%v", *nameOrID)
@@ -101,11 +100,11 @@ func (s *RouteService) Update(ctx context.Context,
 	route *Route) (*Route, error) {
 
 	if route == nil {
-		return nil, errors.New("cannot update a nil route")
+		return nil, fmt.Errorf("cannot update a nil route")
 	}
 
 	if isEmptyString(route.ID) {
-		return nil, errors.New("ID cannot be nil for Update operation")
+		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
 
 	endpoint := fmt.Sprintf("/routes/%v", *route.ID)
@@ -126,7 +125,7 @@ func (s *RouteService) Update(ctx context.Context,
 func (s *RouteService) Delete(ctx context.Context, nameOrID *string) error {
 
 	if isEmptyString(nameOrID) {
-		return errors.New("nameOrID cannot be nil for Delete operation")
+		return fmt.Errorf("nameOrID cannot be nil for Delete operation")
 	}
 
 	endpoint := fmt.Sprintf("/routes/%v", *nameOrID)

--- a/kong/service_service.go
+++ b/kong/service_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -36,7 +35,7 @@ func (s *Svcservice) Create(ctx context.Context,
 	service *Service) (*Service, error) {
 
 	if service == nil {
-		return nil, errors.New("cannot create a nil service")
+		return nil, fmt.Errorf("cannot create a nil service")
 	}
 
 	endpoint := "/services"
@@ -63,7 +62,7 @@ func (s *Svcservice) Get(ctx context.Context,
 	nameOrID *string) (*Service, error) {
 
 	if isEmptyString(nameOrID) {
-		return nil, errors.New("nameOrID cannot be nil for Get operation")
+		return nil, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
 
 	endpoint := fmt.Sprintf("/services/%v", *nameOrID)
@@ -85,7 +84,7 @@ func (s *Svcservice) GetForRoute(ctx context.Context,
 	routeID *string) (*Service, error) {
 
 	if isEmptyString(routeID) {
-		return nil, errors.New("routeID cannot be nil for Get operation")
+		return nil, fmt.Errorf("routeID cannot be nil for Get operation")
 	}
 
 	endpoint := fmt.Sprintf("/routes/%v/service", *routeID)
@@ -107,11 +106,11 @@ func (s *Svcservice) Update(ctx context.Context,
 	service *Service) (*Service, error) {
 
 	if service == nil {
-		return nil, errors.New("cannot update a nil service")
+		return nil, fmt.Errorf("cannot update a nil service")
 	}
 
 	if isEmptyString(service.ID) {
-		return nil, errors.New("ID cannot be nil for Update operation")
+		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
 
 	endpoint := fmt.Sprintf("/services/%v", *service.ID)
@@ -132,7 +131,7 @@ func (s *Svcservice) Update(ctx context.Context,
 func (s *Svcservice) Delete(ctx context.Context, nameOrID *string) error {
 
 	if isEmptyString(nameOrID) {
-		return errors.New("nameOrID cannot be nil for Delete operation")
+		return fmt.Errorf("nameOrID cannot be nil for Delete operation")
 	}
 
 	endpoint := fmt.Sprintf("/services/%v", *nameOrID)

--- a/kong/sni_service.go
+++ b/kong/sni_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -59,7 +58,7 @@ func (s *SNIService) Get(ctx context.Context,
 	usernameOrID *string) (*SNI, error) {
 
 	if isEmptyString(usernameOrID) {
-		return nil, errors.New(
+		return nil, fmt.Errorf(
 			"usernameOrID cannot be nil for Get operation")
 	}
 
@@ -81,7 +80,7 @@ func (s *SNIService) Get(ctx context.Context,
 func (s *SNIService) Update(ctx context.Context, sni *SNI) (*SNI, error) {
 
 	if isEmptyString(sni.ID) {
-		return nil, errors.New("ID cannot be nil for Update operation")
+		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
 
 	endpoint := fmt.Sprintf("/snis/%v", *sni.ID)
@@ -102,7 +101,7 @@ func (s *SNIService) Update(ctx context.Context, sni *SNI) (*SNI, error) {
 func (s *SNIService) Delete(ctx context.Context, usernameOrID *string) error {
 
 	if isEmptyString(usernameOrID) {
-		return errors.New("usernameOrID cannot be nil for Delete operation")
+		return fmt.Errorf("usernameOrID cannot be nil for Delete operation")
 	}
 
 	endpoint := fmt.Sprintf("/snis/%v", *usernameOrID)

--- a/kong/target_service.go
+++ b/kong/target_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -38,7 +37,7 @@ type TargetService service
 func (s *TargetService) Create(ctx context.Context,
 	upstreamNameOrID *string, target *Target) (*Target, error) {
 	if isEmptyString(upstreamNameOrID) {
-		return nil, errors.New("upstreamNameOrID can not be nil")
+		return nil, fmt.Errorf("upstreamNameOrID can not be nil")
 	}
 	queryPath := "/upstreams/" + *upstreamNameOrID + "/targets"
 	method := "POST"
@@ -64,10 +63,10 @@ func (s *TargetService) Create(ctx context.Context,
 func (s *TargetService) Delete(ctx context.Context,
 	upstreamNameOrID *string, targetOrID *string) error {
 	if isEmptyString(upstreamNameOrID) {
-		return errors.New("upstreamNameOrID cannot be nil for Get operation")
+		return fmt.Errorf("upstreamNameOrID cannot be nil for Get operation")
 	}
 	if isEmptyString(targetOrID) {
-		return errors.New("targetOrID cannot be nil for Delete operation")
+		return fmt.Errorf("targetOrID cannot be nil for Delete operation")
 	}
 
 	endpoint := fmt.Sprintf("/upstreams/%v/targets/%v",
@@ -86,7 +85,7 @@ func (s *TargetService) Delete(ctx context.Context,
 func (s *TargetService) List(ctx context.Context,
 	upstreamNameOrID *string, opt *ListOpt) ([]*Target, *ListOpt, error) {
 	if isEmptyString(upstreamNameOrID) {
-		return nil, nil, errors.New(
+		return nil, nil, fmt.Errorf(
 			"upstreamNameOrID cannot be nil for Get operation")
 	}
 	data, next, err := s.client.list(ctx,
@@ -133,14 +132,14 @@ func (s *TargetService) ListAll(ctx context.Context,
 func (s *TargetService) MarkHealthy(ctx context.Context,
 	upstreamNameOrID *string, target *Target) error {
 	if target == nil {
-		return errors.New("cannot set health status for a nil target")
+		return fmt.Errorf("cannot set health status for a nil target")
 	}
 	if isEmptyString(target.ID) && isEmptyString(target.Target) {
-		return errors.New("need at least one of target or ID to" +
+		return fmt.Errorf("need at least one of target or ID to" +
 			" set health status")
 	}
 	if isEmptyString(upstreamNameOrID) {
-		return errors.New("upstreamNameOrID cannot be nil " +
+		return fmt.Errorf("upstreamNameOrID cannot be nil " +
 			"for updating health check")
 	}
 
@@ -165,14 +164,14 @@ func (s *TargetService) MarkHealthy(ctx context.Context,
 func (s *TargetService) MarkUnhealthy(ctx context.Context,
 	upstreamNameOrID *string, target *Target) error {
 	if target == nil {
-		return errors.New("cannot set health status for a nil target")
+		return fmt.Errorf("cannot set health status for a nil target")
 	}
 	if isEmptyString(target.ID) && isEmptyString(target.Target) {
-		return errors.New("need at least one of target or ID to" +
+		return fmt.Errorf("need at least one of target or ID to" +
 			" set health status")
 	}
 	if isEmptyString(upstreamNameOrID) {
-		return errors.New("upstreamNameOrID cannot be nil " +
+		return fmt.Errorf("upstreamNameOrID cannot be nil " +
 			"for updating health check")
 	}
 

--- a/kong/upstream_service.go
+++ b/kong/upstream_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -58,7 +57,7 @@ func (s *UpstreamService) Get(ctx context.Context,
 	upstreamNameOrID *string) (*Upstream, error) {
 
 	if isEmptyString(upstreamNameOrID) {
-		return nil, errors.New("upstreamNameOrID cannot" +
+		return nil, fmt.Errorf("upstreamNameOrID cannot" +
 			" be nil for Get operation")
 	}
 
@@ -81,7 +80,7 @@ func (s *UpstreamService) Update(ctx context.Context,
 	upstream *Upstream) (*Upstream, error) {
 
 	if isEmptyString(upstream.ID) {
-		return nil, errors.New("ID cannot be nil for Update operation")
+		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
 
 	endpoint := fmt.Sprintf("/upstreams/%v", *upstream.ID)
@@ -103,7 +102,7 @@ func (s *UpstreamService) Delete(ctx context.Context,
 	upstreamNameOrID *string) error {
 
 	if isEmptyString(upstreamNameOrID) {
-		return errors.New("upstreamNameOrID cannot be nil for Delete operation")
+		return fmt.Errorf("upstreamNameOrID cannot be nil for Delete operation")
 	}
 
 	endpoint := fmt.Sprintf("/upstreams/%v", *upstreamNameOrID)

--- a/kong/workspace_service.go
+++ b/kong/workspace_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -47,7 +46,7 @@ type WorkspaceService service
 func (s *WorkspaceService) Exists(ctx context.Context,
 	nameOrID *string) (bool, error) {
 	if isEmptyString(nameOrID) {
-		return false, errors.New("nameOrID cannot be nil for Get operation")
+		return false, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
 
 	endpoint := fmt.Sprintf("/workspaces/%v", *nameOrID)
@@ -59,7 +58,7 @@ func (s *WorkspaceService) Create(ctx context.Context,
 	workspace *Workspace) (*Workspace, error) {
 
 	if workspace == nil {
-		return nil, errors.New("cannot create a nil workspace")
+		return nil, fmt.Errorf("cannot create a nil workspace")
 	}
 
 	endpoint := "/workspaces"
@@ -87,7 +86,7 @@ func (s *WorkspaceService) Get(ctx context.Context,
 	nameOrID *string) (*Workspace, error) {
 
 	if isEmptyString(nameOrID) {
-		return nil, errors.New("nameOrID cannot be nil for Get operation")
+		return nil, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
 
 	endpoint := fmt.Sprintf("/workspaces/%v", *nameOrID)
@@ -110,11 +109,11 @@ func (s *WorkspaceService) Update(ctx context.Context,
 	workspace *Workspace) (*Workspace, error) {
 
 	if workspace == nil {
-		return nil, errors.New("cannot update a nil Workspace")
+		return nil, fmt.Errorf("cannot update a nil Workspace")
 	}
 
 	if isEmptyString(workspace.ID) {
-		return nil, errors.New("ID cannot be nil for Update operation")
+		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
 
 	endpoint := fmt.Sprintf("/workspaces/%v", *workspace.ID)
@@ -136,7 +135,7 @@ func (s *WorkspaceService) Delete(ctx context.Context,
 	WorkspaceOrID *string) error {
 
 	if isEmptyString(WorkspaceOrID) {
-		return errors.New("WorkspaceOrID cannot be nil for Delete operation")
+		return fmt.Errorf("WorkspaceOrID cannot be nil for Delete operation")
 	}
 
 	endpoint := fmt.Sprintf("/workspaces/%v", *WorkspaceOrID)
@@ -201,7 +200,7 @@ func (s *WorkspaceService) AddEntities(ctx context.Context,
 	workspaceNameOrID *string, entityIds *string) (*[]map[string]interface{}, error) {
 
 	if entityIds == nil {
-		return nil, errors.New("entityIds cannot be nil")
+		return nil, fmt.Errorf("entityIds cannot be nil")
 	}
 
 	endpoint := fmt.Sprintf("/workspaces/%v/entities", *workspaceNameOrID)
@@ -233,7 +232,7 @@ func (s *WorkspaceService) DeleteEntities(ctx context.Context,
 	workspaceNameOrID *string, entityIds *string) error {
 
 	if entityIds == nil {
-		return errors.New("entityIds cannot be nil")
+		return fmt.Errorf("entityIds cannot be nil")
 	}
 
 	endpoint := fmt.Sprintf("/workspaces/%v/entities", *workspaceNameOrID)

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -2,4 +2,6 @@
 
 package tools
 
-import _ "k8s.io/code-generator"
+import (
+	_ "k8s.io/code-generator"
+)


### PR DESCRIPTION
Since this package predates Go 1.13 which introduced error wrapping using `%w`
qualifier. This patch does the following:
- replaces `errors.Wrap` with `fmt.Errorf`
- remove `github.com/pkg/errors` as a dependency
- removes use of `errors.New` stdlib package with `fmt.Errorf`