### PR TITLE
feat: add oauth2 hash_secret field

### DIFF
--- a/kong/credentials.go
+++ b/kong/credentials.go
@@ -58,6 +58,7 @@ type Oauth2Credential struct {
 	Name         *string   `json:"name,omitempty" yaml:"name,omitempty"`
 	ClientID     *string   `json:"client_id,omitempty" yaml:"client_id,omitempty"`
 	ClientSecret *string   `json:"client_secret,omitempty" yaml:"client_secret,omitempty"`
+	HashSecret   *bool     `json:"hash_secret,omitempty" yaml:"hash_secret,omitempty"`
 	RedirectURIs []*string `json:"redirect_uris,omitempty" yaml:"redirect_uris,omitempty"`
 	Tags         []*string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }

--- a/kong/zz_generated.deepcopy.go
+++ b/kong/zz_generated.deepcopy.go
@@ -949,6 +949,11 @@ func (in *Oauth2Credential) DeepCopyInto(out *Oauth2Credential) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.HashSecret != nil {
+		in, out := &in.HashSecret, &out.HashSecret
+		*out = new(bool)
+		**out = **in
+	}
 	if in.RedirectURIs != nil {
 		in, out := &in.RedirectURIs, &out.RedirectURIs
 		*out = make([]*string, len(*in))


### PR DESCRIPTION
Adds the [newish oauth2 `hash_secret` field](https://github.com/Kong/kong/blame/6455987f64f99aa40ca3ddf415915b6d48683344/kong/plugins/oauth2/daos.lua#L36) to the matching go-kong schema.

Requested in https://github.com/Kong/kubernetes-ingress-controller/issues/1521 but the change needs to go here.

Been a while since I've added a new field to some existing struct, so to confirm, we don't need related changes downstream, correct? Adding the field here and bumping to a new go-kong version with it is all decK and KIC need to start using the field, correct?