### PR TITLE
Use github.com/google/uuid instead of github.com/satori/go.uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/google/go-querystring v1.1.0
-	github.com/satori/go.uuid v1.2.0
+	github.com/google/uuid v1.3.0
 	github.com/stretchr/testify v1.7.0
 	k8s.io/code-generator v0.21.2
 )

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -99,8 +101,6 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/kong/acl_service_test.go
+++ b/kong/acl_service_test.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -56,7 +56,7 @@ func TestACLGroupCreateWithID(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	acl := &ACLGroup{
 		ID:    String(uuid),
 		Group: String("my-group"),
@@ -88,7 +88,7 @@ func TestACLGroupGet(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	acl := &ACLGroup{
 		ID:    String(uuid),
 		Group: String("my-group"),
@@ -134,7 +134,7 @@ func TestACLGroupUpdate(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	acl := &ACLGroup{
 		ID:    String(uuid),
 		Group: String("my-group"),
@@ -173,7 +173,7 @@ func TestACLGroupDelete(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	acl := &ACLGroup{
 		ID:    String(uuid),
 		Group: String("my-group"),

--- a/kong/basic_auth_service_test.go
+++ b/kong/basic_auth_service_test.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -66,7 +66,7 @@ func TestBasicAuthCreateWithID(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	basicAuth := &BasicAuth{
 		ID:       String(uuid),
 		Username: String("my-username"),
@@ -102,7 +102,7 @@ func TestBasicAuthGet(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	basicAuth := &BasicAuth{
 		ID:       String(uuid),
 		Username: String("my-username"),
@@ -152,7 +152,7 @@ func TestBasicAuthUpdate(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	basicAuth := &BasicAuth{
 		ID:       String(uuid),
 		Username: String("my-username"),
@@ -197,7 +197,7 @@ func TestBasicAuthDelete(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	basicAuth := &BasicAuth{
 		ID:       String(uuid),
 		Username: String("my-username"),

--- a/kong/ca_certificate_service_test.go
+++ b/kong/ca_certificate_service_test.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -132,7 +132,7 @@ func TestCACertificatesService(T *testing.T) {
 	assert.Nil(err)
 
 	// ID can be specified
-	id := uuid.NewV4().String()
+	id := uuid.NewString()
 	certificate = &CACertificate{
 		Cert: String(caCert3),
 		ID:   String(id),

--- a/kong/certificate_service_test.go
+++ b/kong/certificate_service_test.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -291,7 +291,7 @@ func TestCertificatesService(T *testing.T) {
 	assert.Nil(err)
 
 	// ID can be specified
-	id := uuid.NewV4().String()
+	id := uuid.NewString()
 	certificate = &Certificate{
 		Key:  String(key3),
 		Cert: String(cert3),

--- a/kong/consumer_service_test.go
+++ b/kong/consumer_service_test.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,7 +49,7 @@ func TestConsumersService(T *testing.T) {
 	assert.Nil(err)
 
 	// ID can be specified
-	id := uuid.NewV4().String()
+	id := uuid.NewString()
 	consumer = &Consumer{
 		Username: String("foo"),
 		ID:       String(id),

--- a/kong/developer_role_service_test.go
+++ b/kong/developer_role_service_test.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,7 +41,7 @@ func TestDeveloperRoleService(T *testing.T) {
 	assert.Nil(err)
 
 	// ID can be specified
-	id := uuid.NewV4().String()
+	id := uuid.NewString()
 	role = &DeveloperRole{
 		Name: String("teamB"),
 		ID:   String(id),

--- a/kong/developer_service_test.go
+++ b/kong/developer_service_test.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -58,7 +58,7 @@ func TestDevelopersService(T *testing.T) {
 	assert.Nil(err)
 
 	// ID can be specified
-	id := uuid.NewV4().String()
+	id := uuid.NewString()
 	developer = &Developer{
 		Meta:     String("{\"full_name\": \"Foo BAR\"}"),
 		Email:    String("foo.bar@example.com"),

--- a/kong/hmac_auth_service_test.go
+++ b/kong/hmac_auth_service_test.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -58,7 +58,7 @@ func TestHMACAuthCreateWithID(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	hmacAuth := &HMACAuth{
 		ID:       String(uuid),
 		Username: String("my-username"),
@@ -93,7 +93,7 @@ func TestHMACAuthGet(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	hmacAuth := &HMACAuth{
 		ID:       String(uuid),
 		Username: String("my-username"),
@@ -141,7 +141,7 @@ func TestHMACAuthUpdate(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	hmacAuth := &HMACAuth{
 		ID:       String(uuid),
 		Username: String("my-username"),
@@ -185,7 +185,7 @@ func TestHMACAuthDelete(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	hmacAuth := &HMACAuth{
 		ID:       String(uuid),
 		Username: String("my-username"),

--- a/kong/jwt_auth_service_test.go
+++ b/kong/jwt_auth_service_test.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -58,7 +58,7 @@ func TestJWTCreateWithID(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	jwt := &JWTAuth{
 		ID:     String(uuid),
 		Key:    String("my-key"),
@@ -93,7 +93,7 @@ func TestJWTGet(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	jwt := &JWTAuth{
 		ID:  String(uuid),
 		Key: String("my-key"),
@@ -140,7 +140,7 @@ func TestJWTUpdate(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	jwt := &JWTAuth{
 		ID:  String(uuid),
 		Key: String("my-key"),
@@ -181,7 +181,7 @@ func TestJWTDelete(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	jwt := &JWTAuth{
 		ID:  String(uuid),
 		Key: String("my-key"),

--- a/kong/key_auth_service_test.go
+++ b/kong/key_auth_service_test.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -55,7 +55,7 @@ func TestKeyAuthCreateWithID(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	keyAuth := &KeyAuth{
 		ID:  String(uuid),
 		Key: String("my-apikey"),
@@ -88,7 +88,7 @@ func TestKeyAuthGet(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	keyAuth := &KeyAuth{
 		ID:  String(uuid),
 		Key: String("my-apikey"),
@@ -138,7 +138,7 @@ func TestKeyAuthUpdate(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	keyAuth := &KeyAuth{
 		ID:  String(uuid),
 		Key: String("my-apikey"),
@@ -180,7 +180,7 @@ func TestKeyAuthDelete(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	keyAuth := &KeyAuth{
 		ID:  String(uuid),
 		Key: String("my-apikey"),

--- a/kong/mtls_auth_service_test.go
+++ b/kong/mtls_auth_service_test.go
@@ -5,7 +5,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -82,7 +82,7 @@ func TestMTLSCreateWithID(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	mtls := &MTLSAuth{
 		ID:          String(uuid),
 		SubjectName: String("test@example.com"),
@@ -115,7 +115,7 @@ func TestMTLSGet(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	mtls := &MTLSAuth{
 		ID:          String(uuid),
 		SubjectName: String("test@example.com"),
@@ -157,7 +157,7 @@ func TestMTLSUpdate(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	mtls := &MTLSAuth{
 		ID:          String(uuid),
 		SubjectName: String("test@example.com"),
@@ -196,7 +196,7 @@ func TestMTLSDelete(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	mtls := &MTLSAuth{
 		ID:          String(uuid),
 		SubjectName: String("test@example.com"),

--- a/kong/oauth2_auth_service_test.go
+++ b/kong/oauth2_auth_service_test.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -55,7 +55,7 @@ func TestOauth2CredentialCreateWithID(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	oauth2Cred := &Oauth2Credential{
 		ID:           String(uuid),
 		Name:         String("name"),
@@ -92,7 +92,7 @@ func TestOauth2CredentialGet(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	oauth2Cred := &Oauth2Credential{
 		ID:           String(uuid),
 		Name:         String("name-foo"),
@@ -145,7 +145,7 @@ func TestOauth2CredentialUpdate(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	oauth2Cred := &Oauth2Credential{
 		ID:           String(uuid),
 		ClientID:     String("client-id"),
@@ -191,7 +191,7 @@ func TestOauth2CredentialDelete(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	uuid := uuid.NewV4().String()
+	uuid := uuid.NewString()
 	oauth2Cred := &Oauth2Credential{
 		ID:           String(uuid),
 		ClientID:     String("my-client-id"),

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,7 +36,7 @@ func TestPluginsService(T *testing.T) {
 	assert.Nil(err)
 
 	// ID can be specified
-	id := uuid.NewV4().String()
+	id := uuid.NewString()
 	plugin = &Plugin{
 		Name: String("prometheus"),
 		ID:   String(id),

--- a/kong/rbac_role_service_test.go
+++ b/kong/rbac_role_service_test.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,7 +37,7 @@ func TestRBACRoleService(T *testing.T) {
 	assert.Nil(err)
 
 	// ID can be specified
-	id := uuid.NewV4().String()
+	id := uuid.NewString()
 	role = &RBACRole{
 		Name: String("teamB"),
 		ID:   String(id),

--- a/kong/route_service_test.go
+++ b/kong/route_service_test.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -58,7 +58,7 @@ func TestRoutesRoute(T *testing.T) {
 	assert.Nil(err)
 
 	// ID can be specified
-	id := uuid.NewV4().String()
+	id := uuid.NewString()
 	route = &Route{
 		ID:        String(id),
 		Name:      String("new-route"),

--- a/kong/service_service_test.go
+++ b/kong/service_service_test.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -57,7 +57,7 @@ func TestServicesService(T *testing.T) {
 	assert.Nil(err)
 
 	// ID can be specified
-	id := uuid.NewV4().String()
+	id := uuid.NewString()
 	service = &Service{
 		Name: String("fizz"),
 		ID:   String(id),

--- a/kong/sni_service_test.go
+++ b/kong/sni_service_test.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -54,7 +54,7 @@ func TestSNIsCertificate(T *testing.T) {
 	assert.Nil(err)
 
 	// ID can be specified
-	id := uuid.NewV4().String()
+	id := uuid.NewString()
 	sni = &SNI{
 		Name:        String("host3.com"),
 		ID:          String(id),

--- a/kong/target_service_test.go
+++ b/kong/target_service_test.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -43,7 +43,7 @@ func TestTargetsUpstream(T *testing.T) {
 	assert.Nil(err)
 
 	// ID can be specified
-	id := uuid.NewV4().String()
+	id := uuid.NewString()
 	target = &Target{
 		ID:       String(id),
 		Target:   String("10.0.0.3"),

--- a/kong/upstream_service_test.go
+++ b/kong/upstream_service_test.go
@@ -3,7 +3,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,7 +36,7 @@ func TestUpstreamsService(T *testing.T) {
 	assert.Nil(err)
 
 	// ID can be specified
-	id := uuid.NewV4().String()
+	id := uuid.NewString()
 	upstream = &Upstream{
 		Name: String("key-auth"),
 		ID:   String(id),

--- a/kong/workspace_service_test.go
+++ b/kong/workspace_service_test.go
@@ -5,7 +5,7 @@ package kong
 import (
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,7 +49,7 @@ func TestWorkspaceService(T *testing.T) {
 	assert.Nil(err)
 
 	// ID can be specified
-	id := uuid.NewV4().String()
+	id := uuid.NewString()
 	workspace = &Workspace{
 		Name: String("teamB"),
 		ID:   String(id),
@@ -192,5 +192,4 @@ func TestWorkspaceService_Entities(T *testing.T) {
 	// Delete the workspace
 	err = client.Workspaces.Delete(defaultCtx, createdWorkspace.ID)
 	assert.Nil(err)
-
 }


### PR DESCRIPTION
This PR is for avoiding to have several dependencies responsible for the uuid handling. It will reduce the number of dependencies in deck and kic and ktf