### PR TITLE
change workspace.Exists() endpoints to /{ws}/workspaces/{ws}

### DIFF
--- a/kong/exists.go
+++ b/kong/exists.go
@@ -8,7 +8,11 @@ import (
 // exists check the existence  with a HEAD HTTP verb
 func (c *Client) exists(ctx context.Context,
 	endpoint string) (bool, error) {
-	req, err := c.NewRequest("HEAD", endpoint, nil, nil)
+	// Originally, this used HEAD. We promptly discovered that HEAD doesn't actually work for this
+	// in Kong <=2.6: https://github.com/Kong/kong/issues/7554
+	// Although future versions will support HEAD for existence checks, using GET for backwards
+	// compatibility at the cost of efficiency
+	req, err := c.NewRequest("GET", endpoint, nil, nil)
 	if err != nil {
 		return false, err
 	}

--- a/kong/workspace_service.go
+++ b/kong/workspace_service.go
@@ -49,7 +49,7 @@ func (s *WorkspaceService) Exists(ctx context.Context,
 		return false, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
 
-	endpoint := fmt.Sprintf("/workspaces/%v", *nameOrID)
+	endpoint := fmt.Sprintf("/%v/workspaces/%v", *nameOrID, *nameOrID)
 	return s.client.exists(ctx, endpoint)
 }
 


### PR DESCRIPTION
change workspace.Exists() endpoints from /workspaces endpoints to /{ws}/workspaces/{ws} require less permission