### PR TITLE
feat(plugin) separate validation errors and fails

### DIFF
--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -7,6 +7,37 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestPluginsServiceValidation(T *testing.T) {
+	assert := assert.New(T)
+
+	client, err := NewTestClient(nil, nil)
+	assert.Nil(err)
+	assert.NotNil(client)
+
+	goodPlugin := &Plugin{
+		Name: String("key-auth"),
+		Config: Configuration{
+			"anonymous": "true",
+		},
+	}
+
+	badPlugin := &Plugin{
+		Name: String("key-auth"),
+		Config: Configuration{
+			"garbage": true,
+		},
+	}
+
+	valid, _, err := client.Plugins.Validate(defaultCtx, goodPlugin)
+	assert.True(valid)
+	assert.Nil(err)
+
+	valid, msg, err := client.Plugins.Validate(defaultCtx, badPlugin)
+	assert.False(valid)
+	assert.Nil(err)
+	assert.Equal("schema violation (config.garbage: unknown field)", msg)
+}
+
 func TestPluginsService(T *testing.T) {
 	assert := assert.New(T)
 


### PR DESCRIPTION
Add a new string return value to PluginService.Validate(). When the
response is a validation failure, this string is the response body
message and the error is nil. Actual errors (e.g. connection timeouts,
response parse failures, etc.) still set the error.

Previously, failures also set the error. Downstream applications were
unable to determine whether the validation attempt was unsuccessful or
if the validation attempt was successful and confirmed the payload was
invalid.

This is a breaking API change for anything that uses Validate(). Not sure if that's anything other than the controller yet.