### PR TITLE
feat: root listeners methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.3.0
+	github.com/mitchellh/mapstructure v1.4.2
 	github.com/stretchr/testify v1.7.0
 	k8s.io/code-generator v0.22.3
 )

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.4.2 h1:6h7AQ0yhTcIsmFmnAwQls75jp2Gzs4iB8W7pjMO+rqo=
+github.com/mitchellh/mapstructure v1.4.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/kong/client.go
+++ b/kong/client.go
@@ -111,6 +111,8 @@ func NewClient(baseURL *string, client *http.Client) (*Client, error) {
 	var rootURL string
 	if baseURL != nil {
 		rootURL = *baseURL
+	} else if urlFromEnv := os.Getenv("KONG_ADMIN_URL"); urlFromEnv != "" {
+		rootURL = urlFromEnv
 	} else {
 		rootURL = defaultBaseURL
 	}

--- a/kong/client.go
+++ b/kong/client.go
@@ -328,3 +328,31 @@ func (c *Client) Root(ctx context.Context) (map[string]interface{}, error) {
 	}
 	return info, nil
 }
+
+// RootJSON returns the response of GET request on the root of the Admin API
+// (GET / or /kong with a workspace) returning the raw JSON response data.
+func (c *Client) RootJSON(ctx context.Context) ([]byte, error) {
+	endpoint := "/"
+	ws := c.Workspace()
+	if len(ws) > 0 {
+		endpoint = "/kong"
+	}
+
+	req, err := c.NewRequestRaw("GET", c.workspacedBaseURL(ws), endpoint, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.DoRAW(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}

--- a/kong/client_test.go
+++ b/kong/client_test.go
@@ -46,6 +46,19 @@ func TestRoot(T *testing.T) {
 	assert.NotNil(root["version"])
 }
 
+func TestRootJSON(T *testing.T) {
+	assert := assert.New(T)
+
+	client, err := NewTestClient(nil, nil)
+	assert.NoError(err)
+	assert.NotNil(client)
+
+	root, err := client.RootJSON(defaultCtx)
+	assert.Nil(err)
+	assert.NotEmpty(root)
+	assert.Contains(string(root), `"version"`)
+}
+
 func TestDo(T *testing.T) {
 	assert := assert.New(T)
 

--- a/kong/listeners.go
+++ b/kong/listeners.go
@@ -1,0 +1,115 @@
+package kong
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// -----------------------------------------------------------------------------
+// Kong Listeners - Public Types
+// -----------------------------------------------------------------------------
+
+// ProxyListener is a configured listener on the Kong Gateway for L7 routing.
+type ProxyListener struct {
+	SSL           bool   `json:"ssl"             mapstructure:"ssl"`
+	Listener      string `json:"listener"        mapstructure:"listener"`
+	Port          int    `json:"port"            mapstructure:"port"`
+	Bind          bool   `json:"bind"            mapstructure:"bind"`
+	IP            string `json:"ip"              mapstructure:"ip"`
+	HTTP2         bool   `json:"http2"           mapstructure:"http2"`
+	ProxyProtocol bool   `json:"proxy_protocol"  mapstructure:"proxy_protocol"`
+	Deferred      bool   `json:"deferred"        mapstructure:"deferred"`
+	ReusePort     bool   `json:"reuseport"       mapstructure:"reuseport"`
+	Backlog       bool   `json:"backlog=%d+"     mapstructure:"backlog=%d+"`
+}
+
+// StreamListener is a configured listener on the Kong Gateway for L4 routing.
+type StreamListener struct {
+	UDP           bool   `json:"udp"             mapstructure:"udp"`
+	SSL           bool   `json:"ssl"             mapstructure:"ssl"`
+	ProxyProtocol bool   `json:"proxy_protocol"  mapstructure:"proxy_protocol"`
+	IP            string `json:"ip"              mapstructure:"ip"`
+	Listener      string `json:"listener"        mapstructure:"listener"`
+	Port          int    `json:"port"            mapstructure:"port"`
+	Bind          bool   `json:"bind"            mapstructure:"bind"`
+	ReusePort     bool   `json:"reuseport"       mapstructure:"reuseport"`
+	Backlog       bool   `json:"backlog=%d+"     mapstructure:"backlog=%d+"`
+}
+
+// -----------------------------------------------------------------------------
+// Kong Listeners - Client Methods
+// -----------------------------------------------------------------------------
+
+// Listeners returns the proxy_listeners and stream_listeners that are currently configured in the
+// Kong root as convenient native types rather than JSON or unstructured.
+func (c *Client) Listeners(ctx context.Context) ([]ProxyListener, []StreamListener, error) {
+	rootJSON, err := c.RootJSON(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("couldn't get root JSON when trying to determine listeners: %w", err)
+	}
+
+	root := dataPlaneConfigWrapper{}
+	if err := json.Unmarshal(rootJSON, &root); err != nil {
+		return nil, nil, fmt.Errorf("couldn't decode root JSON when trying to determine listeners: %w", err)
+	}
+
+	return root.Config.ProxyListeners, root.Config.StreamListeners, nil
+}
+
+// -----------------------------------------------------------------------------
+// Kong Listeners - Private Wrapper Types
+// -----------------------------------------------------------------------------
+
+type dataPlaneConfigWrapper struct {
+	Config dataPlaneConfig `json:"configuration"`
+}
+
+type dataPlaneConfig struct {
+	ProxyListeners  []ProxyListener  `json:"proxy_listeners"`
+	StreamListeners []StreamListener `json:"stream_listeners"`
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling for this type which must
+// be done because the Kong Admin API will return empty objects when a list
+// is empty which will confuse the default unmarshaler.
+func (d *dataPlaneConfig) UnmarshalJSON(data []byte) error {
+	wrapper := make(map[string]interface{})
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return err
+	}
+
+	proxyListenersRaw, ok := wrapper["proxy_listeners"]
+	if ok {
+		listeners, ok := proxyListenersRaw.([]interface{})
+		if ok {
+			d.ProxyListeners = make([]ProxyListener, 0, len(listeners))
+			for _, listener := range listeners {
+				proxyListener := ProxyListener{}
+				if err := mapstructure.Decode(listener, &proxyListener); err != nil {
+					return err
+				}
+				d.ProxyListeners = append(d.ProxyListeners, proxyListener)
+			}
+		}
+	}
+
+	streamListenersRaw, ok := wrapper["stream_listeners"]
+	if ok {
+		listeners, ok := streamListenersRaw.([]interface{})
+		if ok {
+			d.StreamListeners = make([]StreamListener, 0, len(listeners))
+			for _, listener := range listeners {
+				streamListener := StreamListener{}
+				if err := mapstructure.Decode(listener, &streamListener); err != nil {
+					return err
+				}
+				d.StreamListeners = append(d.StreamListeners, streamListener)
+			}
+		}
+	}
+
+	return nil
+}

--- a/kong/listeners_test.go
+++ b/kong/listeners_test.go
@@ -1,0 +1,26 @@
+package kong
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListeners(t *testing.T) {
+	client, err := NewTestClient(nil, nil)
+	assert.NoError(t, err)
+
+	t.Log("pulling the listener configurations from the kong root")
+	proxyListeners, _, err := client.Listeners(defaultCtx)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, proxyListeners)
+
+	t.Log("verifying that the standard http listener was found")
+	foundHTTPListener := false
+	for _, listener := range proxyListeners {
+		if listener.SSL == false {
+			foundHTTPListener = true
+		}
+	}
+	assert.True(t, foundHTTPListener)
+}


### PR DESCRIPTION
This patch adds the ability to retrieve the `proxy_listeners` and `stream_listeners` from the data-plane as convenient Go types.

The original use case for this is to make it easy to retrieve L7 information about Kong listeners for the upcoming Gateway APIs support in KIC.

This focuses on a minimal, but forward thinking implementation: we could take this further from where this leaves off and make the kong root a full object (and this leaves us in a fine place to do that next) but that wasn't the immediate need.