### PR TITLE
doc(changelog) add 0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v0.25.1](#v0251)
 - [v0.25.0](#v0250)
 - [v0.24.0](#v0240)
 - [v0.23.0](#v0230)
@@ -29,6 +30,13 @@
 - [0.3.0](#030)
 - [0.2.0](#020)
 - [0.1.0](#010)
+
+## [v0.25.1]
+
+> Release date: 2021/12/08
+
+v0.25.1 reverts the k8s.io/code-generator version originally used in v0.25.0 to
+avoid an unwanted upgrade of its github.com/go-logr/logr dependency.
 
 ## [v0.25.0]
 
@@ -481,6 +489,7 @@ authentication credentials in Kong.
   releases of Kong since every release of Kong is introducing breaking changes
   to the Admin API.
 
+[v0.25.1]: https://github.com/Kong/go-kong/compare/v0.24.0...v0.25.1
 [v0.25.0]: https://github.com/Kong/go-kong/compare/v0.24.0...v0.25.0
 [v0.24.0]: https://github.com/Kong/go-kong/compare/v0.23.0...v0.24.0
 [v0.23.0]: https://github.com/Kong/go-kong/compare/v0.22.0...v0.23.0


### PR DESCRIPTION
Well, I stand corrected re https://github.com/Kong/go-kong/pull/107#issuecomment-989166927

While nothing was using the original 0.25.0 release, Github apparently has it... somewhere, as `go get` refuses to pull the revised version, even on a machine that hadn't pulled the original the past.