### PR TITLE
feat: add GetFullSchema and FillDefaults methods to plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.16
 
 require (
 	github.com/blang/semver/v4 v4.0.0
+	github.com/google/go-cmp v0.5.6
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.3.0
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/stretchr/testify v1.7.0
+	github.com/tidwall/gjson v1.13.0
 	k8s.io/code-generator v0.22.4
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/blang/semver/v4 v4.0.0
-	github.com/google/go-cmp v0.5.6
+	github.com/google/go-cmp v0.5.7
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.3.0
 	github.com/mitchellh/mapstructure v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -116,6 +118,12 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tidwall/gjson v1.13.0 h1:3TFY9yxOQShrvmjdM76K+jc66zJeT6D3/VFFYCGQf7M=
+github.com/tidwall/gjson v1.13.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/go.sum
+++ b/go.sum
@@ -54,7 +54,6 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/kong/plugin_service.go
+++ b/kong/plugin_service.go
@@ -29,18 +29,19 @@ type AbstractPluginService interface {
 	ListAllForRoute(ctx context.Context, routeID *string) ([]*Plugin, error)
 	// Validate validates a Plugin against its schema
 	Validate(ctx context.Context, plugin *Plugin) (bool, string, error)
-	// GetSchema retrieves the config schema of a plugin
+	// GetSchema retrieves the config schema of a plugin.
 	//
-	// Deprecated: Use GetFullSchema instead
+	// Deprecated: Use GetFullSchema instead.
 	GetSchema(ctx context.Context, pluginName *string) (map[string]interface{}, error)
-	// GetFullSchema retrieves the full schema of a plugin
+	// GetFullSchema retrieves the full schema of a plugin.
+	// This makes the use of `/schemas` endpoint in Kong.
 	GetFullSchema(ctx context.Context, pluginName *string) (map[string]interface{}, error)
 }
 
 // PluginService handles Plugins in Kong.
 type PluginService service
 
-// GetFullSchema retrieves the full schema of a plugin
+// GetFullSchema retrieves the full schema of a plugin.
 func (s *PluginService) GetFullSchema(ctx context.Context,
 	pluginName *string) (map[string]interface{}, error) {
 	if isEmptyString(pluginName) {

--- a/kong/plugin_service.go
+++ b/kong/plugin_service.go
@@ -32,6 +32,8 @@ type AbstractPluginService interface {
 	// Validate validates a Plugin against its schema
 	Validate(ctx context.Context, plugin *Plugin) (bool, string, error)
 	// GetSchema retrieves the config schema of a plugin
+	//
+	// Deprecated: Use GetFullSchema instead
 	GetSchema(ctx context.Context, pluginName *string) (map[string]interface{}, error)
 	// GetFullSchema retrieves the full schema of a plugin
 	GetFullSchema(ctx context.Context, pluginName *string) (map[string]interface{}, error)
@@ -83,6 +85,8 @@ func (s *PluginService) FillDefaults(ctx context.Context,
 }
 
 // GetSchema retrieves the config schema of a plugin
+//
+// Deprecated: Use GetPluginSchema instead
 func (s *PluginService) GetSchema(ctx context.Context,
 	pluginName *string) (map[string]interface{}, error) {
 	if isEmptyString(pluginName) {

--- a/kong/plugin_service.go
+++ b/kong/plugin_service.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-
-	"github.com/tidwall/gjson"
 )
 
 // AbstractPluginService handles Plugins in Kong.
@@ -37,8 +35,6 @@ type AbstractPluginService interface {
 	GetSchema(ctx context.Context, pluginName *string) (map[string]interface{}, error)
 	// GetFullSchema retrieves the full schema of a plugin
 	GetFullSchema(ctx context.Context, pluginName *string) (map[string]interface{}, error)
-	// FillDefaults ingests plugin's defaults from its schema
-	FillDefaults(ctx context.Context, plugin *Plugin, schema map[string]interface{}) (*Plugin, error)
 }
 
 // PluginService handles Plugins in Kong.
@@ -61,27 +57,6 @@ func (s *PluginService) GetFullSchema(ctx context.Context,
 		return nil, err
 	}
 	return schema, nil
-}
-
-// FillDefaults ingests plugin's defaults from its schema
-func (s *PluginService) FillDefaults(ctx context.Context,
-	plugin *Plugin, schema map[string]interface{}) (*Plugin, error) {
-	jsonb, err := json.Marshal(&schema)
-	if err != nil {
-		return nil, err
-	}
-	gjsonSchema := gjson.ParseBytes((jsonb))
-	if plugin.Config == nil {
-		plugin.Config = make(Configuration)
-	}
-	plugin.Config = fillConfigRecord(gjsonSchema, plugin.Config)
-	if plugin.Protocols == nil {
-		plugin.Protocols = getDefaultProtocols(gjsonSchema)
-	}
-	if plugin.Enabled == nil {
-		plugin.Enabled = Bool(true)
-	}
-	return plugin, nil
 }
 
 // GetSchema retrieves the config schema of a plugin

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -336,40 +336,16 @@ func TestGetFullSchema(T *testing.T) {
 	}{
 		{
 			name:   "ok",
-			plugin: String("basic-auth"),
+			plugin: String("prometheus"),
 			expected: map[string]interface{}{
 				"fields": []interface{}{
-					map[string]interface{}{
-						"consumer": map[string]interface{}{
-							"eq":        nil,
-							"reference": "consumers",
-							"type":      "foreign",
-						},
-					},
-					map[string]interface{}{
-						"protocols": map[string]interface{}{
-							"default": []interface{}{"grpc", "grpcs", "http", "https"},
-							"elements": map[string]interface{}{
-								"one_of": []interface{}{"grpc", "grpcs", "http", "https"},
-								"type":   "string",
-							},
-							"required": true,
-							"type":     "set",
-						},
-					},
 					map[string]interface{}{
 						"config": map[string]interface{}{
 							"fields": []interface{}{
 								map[string]interface{}{
-									"anonymous": map[string]interface{}{
-										"type": "string",
-									},
-								},
-								map[string]interface{}{
-									"hide_credentials": map[string]interface{}{
-										"default":  false,
-										"required": true,
-										"type":     "boolean",
+									"per_consumer": map[string]interface{}{
+										"default": false,
+										"type":    "boolean",
 									},
 								},
 							},

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -422,7 +422,7 @@ func TestFillPluginDefaults(T *testing.T) {
 			fullSchema, err := client.Plugins.GetFullSchema(defaultCtx, tc.plugin.Name)
 			assert.Nil(err)
 			assert.NotNil(fullSchema)
-			got, err := client.Plugins.FillDefaults(defaultCtx, tc.plugin, fullSchema)
+			got, err := FillPluginsDefaults(tc.plugin, fullSchema)
 			if err != nil {
 				t.Errorf(err.Error())
 			}

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -3,6 +3,7 @@ package kong
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
@@ -318,6 +319,118 @@ func TestPluginListAllForEntityEndpoint(T *testing.T) {
 	assert.Nil(client.Consumers.Delete(defaultCtx, createdConsumer.ID))
 	assert.Nil(client.Routes.Delete(defaultCtx, createdRoute.ID))
 	assert.Nil(client.Services.Delete(defaultCtx, createdService.ID))
+}
+
+func TestFillPluginDefaults(T *testing.T) {
+	assert := assert.New(T)
+
+	client, err := NewTestClient(nil, nil)
+	assert.Nil(err)
+	assert.NotNil(client)
+
+	tests := []struct {
+		name     string
+		plugin   *Plugin
+		expected *Plugin
+	}{
+		{
+			name: "no_config_no_protocols",
+			plugin: &Plugin{
+				Name: String("basic-auth"),
+			},
+			expected: &Plugin{
+				Name: String("basic-auth"),
+				Config: Configuration{
+					"anonymous":        nil,
+					"hide_credentials": false,
+				},
+				Protocols: []*string{String("grpc"), String("grpcs"), String("http"), String("https")},
+				Enabled:   Bool(true),
+			},
+		},
+		{
+			name: "partial_config_no_protocols",
+			plugin: &Plugin{
+				Name: String("basic-auth"),
+				Config: Configuration{
+					"hide_credentials": true,
+				},
+			},
+			expected: &Plugin{
+				Name: String("basic-auth"),
+				Config: Configuration{
+					"anonymous":        nil,
+					"hide_credentials": true,
+				},
+				Protocols: []*string{String("grpc"), String("grpcs"), String("http"), String("https")},
+				Enabled:   Bool(true),
+			},
+		},
+		{
+			name: "nested_config_partial_protocols",
+			plugin: &Plugin{
+				Name: String("request-transformer"),
+				Config: Configuration{
+					"add": map[string]interface{}{
+						"body":        []interface{}{},
+						"headers":     "x-new-header:value",
+						"querystring": []interface{}{},
+					},
+				},
+				Enabled:   Bool(false),
+				Protocols: []*string{String("grpc"), String("grpcs")},
+			},
+			expected: &Plugin{
+				Name: String("request-transformer"),
+				Config: Configuration{
+					"http_method": nil,
+					"add": map[string]interface{}{
+						"body":        []interface{}{},
+						"headers":     "x-new-header:value",
+						"querystring": []interface{}{},
+					},
+					"append": map[string]interface{}{
+						"body":        []interface{}{},
+						"headers":     []interface{}{},
+						"querystring": []interface{}{},
+					},
+					"remove": map[string]interface{}{
+						"body":        []interface{}{},
+						"headers":     []interface{}{},
+						"querystring": []interface{}{},
+					},
+					"rename": map[string]interface{}{
+						"body":        []interface{}{},
+						"headers":     []interface{}{},
+						"querystring": []interface{}{},
+					},
+					"replace": map[string]interface{}{
+						"body":        []interface{}{},
+						"headers":     []interface{}{},
+						"querystring": []interface{}{},
+						"uri":         nil,
+					},
+				},
+				Protocols: []*string{String("grpc"), String("grpcs")},
+				Enabled:   Bool(false),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		T.Run(tc.name, func(t *testing.T) {
+			fullSchema, err := client.Plugins.GetFullSchema(defaultCtx, tc.plugin.Name)
+			assert.Nil(err)
+			assert.NotNil(fullSchema)
+			got, err := client.Plugins.FillDefaults(defaultCtx, tc.plugin, fullSchema)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			if diff := cmp.Diff(got, tc.expected); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
 }
 
 func comparePlugins(expected, actual []*Plugin) bool {

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -336,16 +336,78 @@ func TestGetFullSchema(T *testing.T) {
 	}{
 		{
 			name:   "ok",
-			plugin: String("prometheus"),
+			plugin: String("key-auth"),
 			expected: map[string]interface{}{
 				"fields": []interface{}{
+					map[string]interface{}{
+						"consumer": map[string]interface{}{
+							"eq":        nil,
+							"reference": "consumers",
+							"type":      "foreign",
+						},
+					},
+					map[string]interface{}{
+						"protocols": map[string]interface{}{
+							"default": []interface{}{"grpc", "grpcs", "http", "https"},
+							"elements": map[string]interface{}{
+								"one_of": []interface{}{"grpc", "grpcs", "http", "https"},
+								"type":   "string",
+							},
+							"required": true,
+							"type":     "set",
+						},
+					},
 					map[string]interface{}{
 						"config": map[string]interface{}{
 							"fields": []interface{}{
 								map[string]interface{}{
-									"per_consumer": map[string]interface{}{
-										"default": false,
-										"type":    "boolean",
+									"key_names": map[string]interface{}{
+										"default": []interface{}{"apikey"},
+										"elements": map[string]interface{}{
+											"type": "string",
+										},
+										"required": true,
+										"type":     "array",
+									},
+								},
+								map[string]interface{}{
+									"hide_credentials": map[string]interface{}{
+										"default":  false,
+										"required": true,
+										"type":     "boolean",
+									},
+								},
+								map[string]interface{}{
+									"anonymous": map[string]interface{}{
+										"type": "string",
+									},
+								},
+								map[string]interface{}{
+									"key_in_header": map[string]interface{}{
+										"default":  true,
+										"required": true,
+										"type":     "boolean",
+									},
+								},
+								map[string]interface{}{
+									"key_in_query": map[string]interface{}{
+										"default":  true,
+										"required": true,
+										"type":     "boolean",
+									},
+								},
+								map[string]interface{}{
+									"key_in_body": map[string]interface{}{
+										"default":  false,
+										"required": true,
+										"type":     "boolean",
+									},
+								},
+								map[string]interface{}{
+									"run_on_preflight": map[string]interface{}{
+										"default":  true,
+										"required": true,
+										"type":     "boolean",
 									},
 								},
 							},

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -334,7 +334,7 @@ func TestFillPluginDefaults(T *testing.T) {
 		expected *Plugin
 	}{
 		{
-			name: "no_config_no_protocols",
+			name: "no config no protocols",
 			plugin: &Plugin{
 				Name: String("basic-auth"),
 			},
@@ -349,7 +349,7 @@ func TestFillPluginDefaults(T *testing.T) {
 			},
 		},
 		{
-			name: "partial_config_no_protocols",
+			name: "partial config no protocols",
 			plugin: &Plugin{
 				Name: String("basic-auth"),
 				Config: Configuration{
@@ -367,7 +367,7 @@ func TestFillPluginDefaults(T *testing.T) {
 			},
 		},
 		{
-			name: "nested_config_partial_protocols",
+			name: "nested config partial protocols",
 			plugin: &Plugin{
 				Name: String("request-transformer"),
 				Config: Configuration{

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -328,115 +328,15 @@ func TestGetFullSchema(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(client)
 
-	tests := []struct {
-		name        string
-		plugin      *string
-		expected    map[string]interface{}
-		expectedErr error
-	}{
-		{
-			name:   "ok",
-			plugin: String("key-auth"),
-			expected: map[string]interface{}{
-				"fields": []interface{}{
-					map[string]interface{}{
-						"consumer": map[string]interface{}{
-							"eq":        nil,
-							"reference": "consumers",
-							"type":      "foreign",
-						},
-					},
-					map[string]interface{}{
-						"protocols": map[string]interface{}{
-							"default": []interface{}{"grpc", "grpcs", "http", "https"},
-							"elements": map[string]interface{}{
-								"one_of": []interface{}{"grpc", "grpcs", "http", "https"},
-								"type":   "string",
-							},
-							"required": true,
-							"type":     "set",
-						},
-					},
-					map[string]interface{}{
-						"config": map[string]interface{}{
-							"fields": []interface{}{
-								map[string]interface{}{
-									"key_names": map[string]interface{}{
-										"default": []interface{}{"apikey"},
-										"elements": map[string]interface{}{
-											"type": "string",
-										},
-										"required": true,
-										"type":     "array",
-									},
-								},
-								map[string]interface{}{
-									"hide_credentials": map[string]interface{}{
-										"default":  false,
-										"required": true,
-										"type":     "boolean",
-									},
-								},
-								map[string]interface{}{
-									"anonymous": map[string]interface{}{
-										"type": "string",
-									},
-								},
-								map[string]interface{}{
-									"key_in_header": map[string]interface{}{
-										"default":  true,
-										"required": true,
-										"type":     "boolean",
-									},
-								},
-								map[string]interface{}{
-									"key_in_query": map[string]interface{}{
-										"default":  true,
-										"required": true,
-										"type":     "boolean",
-									},
-								},
-								map[string]interface{}{
-									"key_in_body": map[string]interface{}{
-										"default":  false,
-										"required": true,
-										"type":     "boolean",
-									},
-								},
-								map[string]interface{}{
-									"run_on_preflight": map[string]interface{}{
-										"default":  true,
-										"required": true,
-										"type":     "boolean",
-									},
-								},
-							},
-							"required": true,
-							"type":     "record",
-						},
-					},
-				},
-			},
-		},
-		{
-			name:        "bad",
-			plugin:      String("noexist"),
-			expected:    nil,
-			expectedErr: NewAPIError(404, "No plugin named 'noexist'"),
-		},
-	}
+	schema, err := client.Plugins.GetFullSchema(defaultCtx, String("key-auth"))
+	_, ok := schema["fields"]
+	assert.True(ok)
+	assert.Nil(err)
 
-	for _, tc := range tests {
-		T.Run(tc.name, func(t *testing.T) {
-			got, err := client.Plugins.GetFullSchema(defaultCtx, tc.plugin)
-			if diff := cmp.Diff(err, tc.expectedErr, cmp.AllowUnexported(APIError{})); diff != "" {
-				t.Errorf(diff)
-			}
-			if diff := cmp.Diff(got, tc.expected); diff != "" {
-				t.Errorf(diff)
-			}
-		})
-	}
+	schema, err = client.Plugins.GetFullSchema(defaultCtx, String("noexist"))
+	assert.Nil(schema)
+	assert.NotNil(err)
+	assert.True(IsNotFoundErr(err))
 }
 
 func TestFillPluginDefaults(T *testing.T) {

--- a/kong/utils.go
+++ b/kong/utils.go
@@ -2,6 +2,7 @@ package kong
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -209,4 +210,24 @@ func fillConfigRecord(schema gjson.Result, config Configuration) Configuration {
 	})
 
 	return res
+}
+
+// FillPluginsDefaults ingests plugin's defaults from its schema
+func FillPluginsDefaults(plugin *Plugin, schema map[string]interface{}) (*Plugin, error) {
+	jsonb, err := json.Marshal(&schema)
+	if err != nil {
+		return nil, err
+	}
+	gjsonSchema := gjson.ParseBytes((jsonb))
+	if plugin.Config == nil {
+		plugin.Config = make(Configuration)
+	}
+	plugin.Config = fillConfigRecord(gjsonSchema, plugin.Config)
+	if plugin.Protocols == nil {
+		plugin.Protocols = getDefaultProtocols(gjsonSchema)
+	}
+	if plugin.Enabled == nil {
+		plugin.Enabled = Bool(true)
+	}
+	return plugin, nil
 }

--- a/kong/utils.go
+++ b/kong/utils.go
@@ -149,17 +149,13 @@ func getDefaultProtocols(schema gjson.Result) []*string {
 	fields := schema.Get("fields")
 
 	for _, field := range fields.Array() {
-		for key, value := range field.Map() {
-			if key != "protocols" {
-				continue
+		protocols := field.Map()["protocols"]
+		d := protocols.Get("default")
+		if d.Exists() {
+			for _, v := range d.Array() {
+				res = append(res, String(v.String()))
 			}
-			d := value.Get("default")
-			if d.Exists() {
-				for _, v := range d.Array() {
-					res = append(res, String(v.String()))
-				}
-				return res
-			}
+			return res
 		}
 	}
 	return res


### PR DESCRIPTION
`GetFullSchema`: returns full schema for plugins (`/schemas/plugins/<ID>`)
`FillDefaults`: given a schema and a config object, fills all defaults

Based on the discussion happening in [here](https://github.com/Kong/deck/pull/562), this PR is introducing 2 new methods for `Plugin` (along few other helper functions, mostly taken from [KIC](https://github.com/Kong/kubernetes-ingress-controller/blob/main/internal/deckgen/deckgen.go#L121-L122) plus few changes).
These can be leveraged by `deck` and `KIC` to fill defaults values into plugins from their schemas.