### PR TITLE
feat: improve handling zero-value fields with defaults

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/kong/go-kong
 
 go 1.16
 
+replace github.com/imdario/mergo v0.3.12 => github.com/Kong/mergo v0.3.13
+
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/google/go-cmp v0.5.7

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Kong/mergo v0.3.13 h1:J+RyBootTG0GSmmzPBF4GqhHDLBKuSZeuaIyAHtOF9Y=
+github.com/Kong/mergo v0.3.13/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -70,8 +72,6 @@ github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2c
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
-github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -207,6 +207,25 @@ func TestFillRoutesDefaults(T *testing.T) {
 				HTTPSRedirectStatusCode: Int(426),
 			},
 		},
+		{
+			name: "boolean default values don't overwrite existing fields if set",
+			route: &Route{
+				Name:         String("r1"),
+				Paths:        []*string{String("/r1")},
+				Protocols:    []*string{String("grpc")},
+				StripPath:    Bool(false),
+				PreserveHost: Bool(true),
+			},
+			expected: &Route{
+				Name:                    String("r1"),
+				Paths:                   []*string{String("/r1")},
+				PreserveHost:            Bool(true),
+				Protocols:               []*string{String("grpc")},
+				RegexPriority:           Int(0),
+				StripPath:               Bool(false),
+				HTTPSRedirectStatusCode: Int(426),
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -335,6 +354,15 @@ func TestFillTargetDefaults(T *testing.T) {
 			target: &Target{},
 			expected: &Target{
 				Weight: Int(100),
+			},
+		},
+		{
+			name: "set zero-value",
+			target: &Target{
+				Weight: Int(0),
+			},
+			expected: &Target{
+				Weight: Int(0),
 			},
 		},
 	}


### PR DESCRIPTION
We recently forked and patched `mergo` (https://github.com/Kong/mergo/pull/1)
to improve the way we can handle zero-value fields with defaults values.
Currently, if an entity field is set with a zero-value (e.g. a target
with weight=0, a route with strip_path=false etc.), we will overwrite it
when merging it with its default if this is not a zero-value itself.

This updates the `mergo` dependence and adds a custom transformer to support
such cases as well. Also, add few test cases with zero-value fields.