### PR TITLE
feat(utils) make Enterprise info build info

### DIFF
--- a/kong/utils.go
+++ b/kong/utils.go
@@ -134,7 +134,11 @@ func ParseSemanticVersion(v string) (semver.Version, error) {
 		m[2] = "0"
 	}
 	if m[3] != "" {
-		m[3] = "-" + strings.Replace(m[3], "enterprise-edition", "enterprise", 1)
+		if strings.Contains(m[3], "enterprise") {
+			m[3] = "+" + strings.Replace(m[3], "enterprise-edition", "enterprise", 1)
+		} else {
+			m[3] = "-" + m[3]
+		}
 		m[3] = strings.Replace(m[3], ".", "", -1)
 	}
 	v = fmt.Sprintf("%s.%s%s", m[1], m[2], m[3])

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -64,10 +64,10 @@ func TestFixVersion(t *testing.T) {
 		"0.14.2rc1":                       "0.14.2-rc1",
 		"0.14.2preview":                   "0.14.2-preview",
 		"0.14.2preview1":                  "0.14.2-preview1",
-		"0.33-enterprise-edition":         "0.33.0-enterprise",
-		"0.33-1-enterprise-edition":       "0.33.1-enterprise",
-		"1.3.0.0-enterprise-edition-lite": "1.3.0-0-enterprise-lite",
-		"1.3.0.0-enterprise-lite":         "1.3.0-0-enterprise-lite",
+		"0.33-enterprise-edition":         "0.33.0+enterprise",
+		"0.33-1-enterprise-edition":       "0.33.1+enterprise",
+		"1.3.0.0-enterprise-edition-lite": "1.3.0+0-enterprise-lite",
+		"1.3.0.0-enterprise-lite":         "1.3.0+0-enterprise-lite",
 	}
 	for inputVersion, expectedVersion := range validVersions {
 		v, err := ParseSemanticVersion(inputVersion)


### PR DESCRIPTION
Change the Enterprise suffixes from semver pre-releases to semver build info, so that Enterprise tests against the initial minor release do run as expected.