### PR TITLE
fix: correctly marshal RBAC 'actions'

### DIFF
--- a/kong/types.go
+++ b/kong/types.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 )
 
 // Service represents a Service in Kong.
@@ -364,20 +363,17 @@ func (e *RBACEndpointPermission) MarshalJSON() ([]byte, error) {
 		CreatedAt *int      `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 		Workspace *string   `json:"workspace,omitempty" yaml:"workspace,omitempty"`
 		Endpoint  *string   `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
-		Actions   *string   `json:"actions,omitempty" yaml:"actions,omitempty"`
+		Actions   []*string `json:"actions,omitempty" yaml:"actions,omitempty"`
 		Negative  *bool     `json:"negative,omitempty" yaml:"negative,omitempty"`
 		Role      *RBACRole `json:"role,omitempty" yaml:"role,omitempty"`
 		Comment   *string   `json:"comment,omitempty" yaml:"comment,omitempty"`
 	}
-	var actions []string
-	for _, action := range e.Actions {
-		actions = append(actions, *action)
-	}
+
 	return json.Marshal(&ep{
 		CreatedAt: e.CreatedAt,
 		Workspace: e.Workspace,
 		Endpoint:  e.Endpoint,
-		Actions:   String(strings.Join(actions, ",")),
+		Actions:   e.Actions,
 		Negative:  e.Negative,
 		Comment:   e.Comment,
 	})
@@ -403,20 +399,16 @@ func (e *RBACEntityPermission) MarshalJSON() ([]byte, error) {
 		CreatedAt  *int      `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 		EntityID   *string   `json:"entity_id,omitempty" yaml:"entity_id,omitempty"`
 		EntityType *string   `json:"entity_type,omitempty" yaml:"entity_type,omitempty"`
-		Actions    *string   `json:"actions,omitempty" yaml:"actions,omitempty"`
+		Actions    []*string `json:"actions,omitempty" yaml:"actions,omitempty"`
 		Negative   *bool     `json:"negative,omitempty" yaml:"negative,omitempty"`
 		Role       *RBACRole `json:"role,omitempty" yaml:"role,omitempty"`
 		Comment    *string   `json:"comment,omitempty" yaml:"comment,omitempty"`
-	}
-	var actions []string
-	for _, action := range e.Actions {
-		actions = append(actions, *action)
 	}
 	return json.Marshal(&ep{
 		CreatedAt:  e.CreatedAt,
 		EntityID:   e.EntityID,
 		EntityType: e.EntityType,
-		Actions:    String(strings.Join(actions, ",")),
+		Actions:    e.Actions,
 		Negative:   e.Negative,
 		Comment:    e.Comment,
 	})


### PR DESCRIPTION
As highlighted in https://github.com/Kong/deck/issues/586, `go-kong` renders RBAC permissions as a comma-separated string..

```
rbac_roles:
- comment: Full access to all endpoints, across all workspaces
  endpoint_permissions:
  - actions: delete,create,read,update
```

...instead of an actual array:

```
rbac_roles:
- comment: Full access to all endpoints, across all workspaces
  endpoint_permissions:
  - actions:
    - update
    - create
    - delete
    - read
```

With this, `deck` is happy:

```
$ deck dump --rbac-resources-only -o permissions.yaml

$ deck sync --rbac-resources-only -s permissions.yaml
Summary:
  Created: 0
  Updated: 0
  Deleted: 0
```