### PR TITLE
tests: export requiredFeatures

### DIFF
--- a/kong/admin_service_test.go
+++ b/kong/admin_service_test.go
@@ -1,3 +1,4 @@
+//go:build enterprise
 // +build enterprise
 
 package kong
@@ -10,7 +11,7 @@ import (
 )
 
 func TestAdminService(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -43,7 +44,7 @@ func TestAdminService(T *testing.T) {
 }
 
 func TestAdminServiceWorkspace(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -93,7 +94,7 @@ func TestAdminServiceWorkspace(T *testing.T) {
 func TestAdminServiceList(T *testing.T) {
 	assert := assert.New(T)
 	client, err := NewTestClient(nil, nil)
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{})
 
 	assert.Nil(err)
 	assert.NotNil(client)
@@ -142,7 +143,7 @@ func TestAdminServiceList(T *testing.T) {
 // XXX:
 // This test requires RBAC to be enabled.
 func TestAdminServiceRegisterCredentials(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{RBAC: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/client_test.go
+++ b/kong/client_test.go
@@ -89,7 +89,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestRunWhenEnterprise(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -141,7 +141,7 @@ func (t *TestWorkspace) UpdateConfig(config map[string]interface{}) error {
 }
 
 func TestTestWorkspace(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{portal: true})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{Portal: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/developer_role_service_test.go
+++ b/kong/developer_role_service_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDeveloperRoleService(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{portal: true})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{Portal: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -59,7 +59,7 @@ func TestDeveloperRoleService(T *testing.T) {
 }
 
 func TestDeveloperRoleServiceList(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{portal: true})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{Portal: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -97,7 +97,7 @@ func TestDeveloperRoleServiceList(T *testing.T) {
 }
 
 func TestDeveloperRoleListEndpoint(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{portal: true})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{Portal: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/developer_service_test.go
+++ b/kong/developer_service_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDevelopersService(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{portal: true})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{Portal: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -78,7 +78,7 @@ func TestDevelopersService(T *testing.T) {
 }
 
 func TestDeveloperListEndpoint(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{portal: true})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{Portal: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/endpoint_permission_service_test.go
+++ b/kong/endpoint_permission_service_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRBACEndpointPermissionservice(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{RBAC: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/entity_permission_service_test.go
+++ b/kong/entity_permission_service_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRBACEntityPermissionservice(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{RBAC: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -78,7 +78,7 @@ func TestRBACEntityPermissionservice(T *testing.T) {
 }
 
 func TestRBACEntityPermissionserviceList(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{RBAC: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/rbac_role_service_test.go
+++ b/kong/rbac_role_service_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRBACRoleService(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{RBAC: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -53,7 +53,7 @@ func TestRBACRoleService(T *testing.T) {
 }
 
 func TestRBACRoleServiceList(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{RBAC: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -86,7 +86,7 @@ func TestRBACRoleServiceList(T *testing.T) {
 }
 
 func TestRBACRoleListEndpoint(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{RBAC: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/rbac_user_service_test.go
+++ b/kong/rbac_user_service_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRBACUserService(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{RBAC: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -42,7 +42,7 @@ func TestRBACUserService(T *testing.T) {
 }
 
 func TestRBACUserServiceWorkspace(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{RBAC: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -93,7 +93,7 @@ func TestRBACUserServiceWorkspace(T *testing.T) {
 }
 
 func TestUserRoles(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", requiredFeatures{rbac: true})
+	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{RBAC: true})
 	assert := assert.New(T)
 	client, err := NewTestClient(nil, nil)
 

--- a/kong/test_utils.go
+++ b/kong/test_utils.go
@@ -9,9 +9,9 @@ import (
 	"github.com/blang/semver/v4"
 )
 
-type requiredFeatures struct {
-	portal bool
-	rbac   bool
+type RequiredFeatures struct {
+	Portal bool
+	RBAC   bool
 }
 
 // RunWhenKong skips the current test if the version of Kong doesn't
@@ -47,7 +47,7 @@ func RunWhenKong(t *testing.T, semverRange string) {
 // fall within the semver range. If a test requires
 // RBAC and RBAC is not enabled on Kong the test
 // will be skipped
-func RunWhenEnterprise(t *testing.T, semverRange string, required requiredFeatures) {
+func RunWhenEnterprise(t *testing.T, semverRange string, required RequiredFeatures) {
 	client, err := NewTestClient(nil, nil)
 	if err != nil {
 		t.Error(err)
@@ -64,12 +64,12 @@ func RunWhenEnterprise(t *testing.T, semverRange string, required requiredFeatur
 	}
 	configuration := info["configuration"].(map[string]interface{})
 
-	if required.rbac && configuration["rbac"].(string) != "on" {
+	if required.RBAC && configuration["rbac"].(string) != "on" {
 		t.Log("RBAC not enabled on test Kong instance, skipping")
 		t.Skip()
 	}
 
-	if required.portal && !configuration["portal"].(bool) {
+	if required.Portal && !configuration["portal"].(bool) {
 		t.Log("Portal not enabled on test Kong instance, skipping")
 		t.Skip()
 	}

--- a/kong/workspace_service_test.go
+++ b/kong/workspace_service_test.go
@@ -151,7 +151,7 @@ func TestWorkspaceServiceListAll(T *testing.T) {
 // Workspace entities
 
 func TestWorkspaceService_Entities(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0 <=2.0.5", requiredFeatures{})
+	RunWhenEnterprise(T, ">=0.33.0 <=2.0.5", RequiredFeatures{})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)


### PR DESCRIPTION
Recently we exported the RunWhenKong and RunWhenEnterprise utils,
but the latter is not usable if we don't export requiredFeatures too.