### PR TITLE
fix: marshall and unmarshall actions on endpoint permissions

### DIFF
--- a/kong/types.go
+++ b/kong/types.go
@@ -3,6 +3,7 @@ package kong
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // Service represents a Service in Kong.
@@ -363,17 +364,20 @@ func (e *RBACEndpointPermission) MarshalJSON() ([]byte, error) {
 		CreatedAt *int      `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 		Workspace *string   `json:"workspace,omitempty" yaml:"workspace,omitempty"`
 		Endpoint  *string   `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
-		Actions   []*string `json:"actions,omitempty" yaml:"actions,omitempty"`
+		Actions   *string   `json:"actions,omitempty" yaml:"actions,omitempty"`
 		Negative  *bool     `json:"negative,omitempty" yaml:"negative,omitempty"`
 		Role      *RBACRole `json:"role,omitempty" yaml:"role,omitempty"`
 		Comment   *string   `json:"comment,omitempty" yaml:"comment,omitempty"`
 	}
-
+	var actions []string
+	for _, action := range e.Actions {
+		actions = append(actions, *action)
+	}
 	return json.Marshal(&ep{
 		CreatedAt: e.CreatedAt,
 		Workspace: e.Workspace,
 		Endpoint:  e.Endpoint,
-		Actions:   e.Actions,
+		Actions:   String(strings.Join(actions, ",")),
 		Negative:  e.Negative,
 		Comment:   e.Comment,
 	})
@@ -399,16 +403,20 @@ func (e *RBACEntityPermission) MarshalJSON() ([]byte, error) {
 		CreatedAt  *int      `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 		EntityID   *string   `json:"entity_id,omitempty" yaml:"entity_id,omitempty"`
 		EntityType *string   `json:"entity_type,omitempty" yaml:"entity_type,omitempty"`
-		Actions    []*string `json:"actions,omitempty" yaml:"actions,omitempty"`
+		Actions    *string   `json:"actions,omitempty" yaml:"actions,omitempty"`
 		Negative   *bool     `json:"negative,omitempty" yaml:"negative,omitempty"`
 		Role       *RBACRole `json:"role,omitempty" yaml:"role,omitempty"`
 		Comment    *string   `json:"comment,omitempty" yaml:"comment,omitempty"`
+	}
+	var actions []string
+	for _, action := range e.Actions {
+		actions = append(actions, *action)
 	}
 	return json.Marshal(&ep{
 		CreatedAt:  e.CreatedAt,
 		EntityID:   e.EntityID,
 		EntityType: e.EntityType,
-		Actions:    e.Actions,
+		Actions:    String(strings.Join(actions, ",")),
 		Negative:   e.Negative,
 		Comment:    e.Comment,
 	})


### PR DESCRIPTION
For endpoint permissions's `actions`, Kong returns a list with GET requests, but it expects a
comma-separated string with POST/PUT requests.

This fixes the marshalling for this entity (reverting https://github.com/Kong/go-kong/pull/131)

Sample script attempting to configure `actions` as a list:

```
$ echo '
id: 82bfb84b-d659-4ac1-ab29-94576f838753
name: workspace-super-admin
comment: "Full access to all endpoints in the workspace"
' | y2j |  http PUT ":8001/workspace1/rbac/roles/82bfb84b-d659-4ac1-ab29-94576f838753"

$ echo '
workspace: workspace1
endpoint: /rbac/*/*/*
actions:
    - delete
    - create
    - read
    - update
negative: true
' | y2j | http POST ":8001/workspace1/rbac/roles/82bfb84b-d659-4ac1-ab29-94576f838753/endpoints"

HTTP/1.1 200 OK
{
    "comment": "Full access to all endpoints in the workspace",
    "created_at": 1647520491,
    "id": "82bfb84b-d659-4ac1-ab29-94576f838753",
    "is_default": false,
    "name": "workspace-super-admin"
}


HTTP/1.1 201 Created
{
    "actions": [],
    "created_at": 1647520491,
    "endpoint": "/rbac/*/*/*",
    "negative": true,
    "role": {
        "id": "82bfb84b-d659-4ac1-ab29-94576f838753"
    },
    "workspace": "workspace1"
}
```

The `actions` field is ignored. While it works if the `actions` field is a string:

```
$ echo '
workspace: workspace1
endpoint: /rbac/*/*/*
actions: delete,create,read,update
negative: true
' | y2j | http POST ":8001/workspace1/rbac/roles/82bfb84b-d659-4ac1-ab29-94576f838753/endpoints"
HTTP/1.1 201 Created
{
    "actions": [
        "read",
        "delete",
        "create",
        "update"
    ],
    "created_at": 1647520694,
    "endpoint": "/rbac/*/*/*",
    "negative": true,
    "role": {
        "id": "82bfb84b-d659-4ac1-ab29-94576f838753"
    },
    "workspace": "workspace1"
}
```
