### PR TITLE
feat(client) add configuration_hash to Status

### DIFF
--- a/kong/client.go
+++ b/kong/client.go
@@ -92,6 +92,7 @@ type Status struct {
 		ConnectionsWriting  int `json:"connections_writing"`
 		TotalRequests       int `json:"total_requests"`
 	} `json:"server"`
+	ConfigurationHash string `json:"configuration_hash,omitempty" yaml:"configuration_hash,omitempty"`
 }
 
 // NewClient returns a Client which talks to Admin API of Kong


### PR DESCRIPTION
Adds support for the configuration hash added to 2.8's status endpoint.