### PR TITLE
fix: handle auto fields in plugins schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,6 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/stretchr/testify v1.7.1
 	github.com/tidwall/gjson v1.14.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/code-generator v0.23.5
 )


### PR DESCRIPTION
This was highlighted in an [issue](https://github.com/Kong/deck/issues/605) raised in decK.

Sample config:

```
$ cat kong.yaml
plugins:
- name: rate-limiting-advanced
  config:
    limit:
    - 3
    sync_rate: 10
    window_size:
    - 60
```

`rate-limiting-advanced` has a `namespace` config field which is set as `auto`:

```
$ http :8001/schemas/plugins/rate-limiting-advanced
...
...
                        "namespace": {
                            "auto": true,
                            "required": true,
                            "type": "string"
                        }
                    },
...
...
```

Since no `default` entry is found in the schema, the field is left empty, which causes a problem since the field is also marked as `required`.

```
$ deck sync
creating plugin rate-limiting-advanced (global)
Summary:
  Created: 0
  Updated: 0
  Deleted: 0
Error: 1 errors occurred:
	while processing event: {Create} plugin rate-limiting-advanced (global) failed: HTTP status 400 (message: "schema violation (config.namespace: required field missing)")
```

This PR makes sure that we auto-generates a value for such fields as well if not provided by the user

```
$ ./deck sync
creating plugin rate-limiting-advanced (global)
Summary:
  Created: 1
  Updated: 0
  Deleted: 0
```

Question: do all `auto` fields expects a 32 chars string? The answer was not obvious to me while navigating Kong codebase