### PR TITLE
chore: update go to 1.18

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,12 +10,12 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.16'
+          go-version: '^1.18'
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v3.1.0
         with:
-          version: v1.43.0
+          version: v1.45.2
       - name: Verify Codegen
         run: make verify-codegen

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/go-kong
 
-go 1.16
+go 1.18
 
 replace github.com/imdario/mergo v0.3.12 => github.com/Kong/mergo v0.3.13
 
@@ -13,5 +13,37 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/stretchr/testify v1.7.1
 	github.com/tidwall/gjson v1.14.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/code-generator v0.23.5
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
+	github.com/go-logr/logr v1.2.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.14 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
+	golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/tools v0.1.6-0.20210820212750-d4cc65f0b2ff // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c // indirect
+	k8s.io/klog/v2 v2.30.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/kong/acl_service.go
+++ b/kong/acl_service.go
@@ -32,8 +32,8 @@ type ACLService service
 // create the group association in Kong, otherwise an ID
 // is auto-generated.
 func (s *ACLService) Create(ctx context.Context,
-	consumerUsernameOrID *string, aclGroup *ACLGroup) (*ACLGroup, error) {
-
+	consumerUsernameOrID *string, aclGroup *ACLGroup,
+) (*ACLGroup, error) {
 	cred, err := s.client.credentials.Create(ctx, "acl",
 		consumerUsernameOrID, aclGroup)
 	if err != nil {
@@ -51,8 +51,8 @@ func (s *ACLService) Create(ctx context.Context,
 
 // Get fetches an ACL group for a consumer in Kong.
 func (s *ACLService) Get(ctx context.Context,
-	consumerUsernameOrID, groupOrID *string) (*ACLGroup, error) {
-
+	consumerUsernameOrID, groupOrID *string,
+) (*ACLGroup, error) {
 	cred, err := s.client.credentials.Get(ctx, "acl",
 		consumerUsernameOrID, groupOrID)
 	if err != nil {
@@ -70,8 +70,8 @@ func (s *ACLService) Get(ctx context.Context,
 
 // Update updates an ACL group for a consumer in Kong
 func (s *ACLService) Update(ctx context.Context,
-	consumerUsernameOrID *string, aclGroup *ACLGroup) (*ACLGroup, error) {
-
+	consumerUsernameOrID *string, aclGroup *ACLGroup,
+) (*ACLGroup, error) {
 	cred, err := s.client.credentials.Update(ctx, "acl",
 		consumerUsernameOrID, aclGroup)
 	if err != nil {
@@ -89,7 +89,8 @@ func (s *ACLService) Update(ctx context.Context,
 
 // Delete deletes an ACL group association for a consumer in Kong
 func (s *ACLService) Delete(ctx context.Context,
-	consumerUsernameOrID, groupOrID *string) error {
+	consumerUsernameOrID, groupOrID *string,
+) error {
 	return s.client.credentials.Delete(ctx, "acl",
 		consumerUsernameOrID, groupOrID)
 }
@@ -97,7 +98,8 @@ func (s *ACLService) Delete(ctx context.Context,
 // List fetches a list of all ACL group and consumer associations in Kong.
 // opt can be used to control pagination.
 func (s *ACLService) List(ctx context.Context,
-	opt *ListOpt) ([]*ACLGroup, *ListOpt, error) {
+	opt *ListOpt,
+) ([]*ACLGroup, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/acls", opt)
 	if err != nil {
 		return nil, nil, err
@@ -141,7 +143,8 @@ func (s *ACLService) ListAll(ctx context.Context) ([]*ACLGroup, error) {
 // in Kong associated with a specific consumer.
 // opt can be used to control pagination.
 func (s *ACLService) ListForConsumer(ctx context.Context,
-	consumerUsernameOrID *string, opt *ListOpt) ([]*ACLGroup, *ListOpt, error) {
+	consumerUsernameOrID *string, opt *ListOpt,
+) ([]*ACLGroup, *ListOpt, error) {
 	data, next, err := s.client.list(ctx,
 		"/consumers/"+*consumerUsernameOrID+"/acls", opt)
 	if err != nil {

--- a/kong/admin_service.go
+++ b/kong/admin_service.go
@@ -45,8 +45,8 @@ type AdminService service
 
 // Invite creates an Admin in Kong.
 func (s *AdminService) Invite(ctx context.Context,
-	admin *Admin) (*Admin, error) {
-
+	admin *Admin,
+) (*Admin, error) {
 	if admin == nil {
 		return nil, fmt.Errorf("cannot create a nil admin")
 	}
@@ -71,14 +71,15 @@ func (s *AdminService) Invite(ctx context.Context,
 // Create aliases the Invite function as it performs
 // essentially the same operation.
 func (s *AdminService) Create(ctx context.Context,
-	admin *Admin) (*Admin, error) {
+	admin *Admin,
+) (*Admin, error) {
 	return s.Invite(ctx, admin)
 }
 
 // Get fetches a Admin in Kong.
 func (s *AdminService) Get(ctx context.Context,
-	nameOrID *string) (*Admin, error) {
-
+	nameOrID *string,
+) (*Admin, error) {
 	if isEmptyString(nameOrID) {
 		return nil, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
@@ -101,8 +102,8 @@ func (s *AdminService) Get(ctx context.Context,
 // GenerateRegisterURL fetches an Admin in Kong
 // and returns a unique registration URL for the Admin
 func (s *AdminService) GenerateRegisterURL(ctx context.Context,
-	nameOrID *string) (*Admin, error) {
-
+	nameOrID *string,
+) (*Admin, error) {
 	if isEmptyString(nameOrID) {
 		return nil, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
@@ -124,8 +125,8 @@ func (s *AdminService) GenerateRegisterURL(ctx context.Context,
 
 // Update updates an Admin in Kong.
 func (s *AdminService) Update(ctx context.Context,
-	admin *Admin) (*Admin, error) {
-
+	admin *Admin,
+) (*Admin, error) {
 	if admin == nil {
 		return nil, fmt.Errorf("cannot update a nil Admin")
 	}
@@ -150,8 +151,8 @@ func (s *AdminService) Update(ctx context.Context,
 
 // Delete deletes an Admin in Kong
 func (s *AdminService) Delete(ctx context.Context,
-	AdminOrID *string) error {
-
+	AdminOrID *string,
+) error {
 	if isEmptyString(AdminOrID) {
 		return fmt.Errorf("AdminOrID cannot be nil for Delete operation")
 	}
@@ -168,8 +169,8 @@ func (s *AdminService) Delete(ctx context.Context,
 
 // List fetches a list of all Admins in Kong.
 func (s *AdminService) List(ctx context.Context,
-	opt *ListOpt) ([]*Admin, *ListOpt, error) {
-
+	opt *ListOpt,
+) ([]*Admin, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/admins/", opt)
 	if err != nil {
 		return nil, nil, err
@@ -193,8 +194,8 @@ func (s *AdminService) List(ctx context.Context,
 
 // RegisterCredentials registers credentials for existing Kong Admins
 func (s *AdminService) RegisterCredentials(ctx context.Context,
-	admin *Admin) error {
-
+	admin *Admin,
+) error {
 	if admin == nil {
 		return fmt.Errorf("cannot register credentials for a nil Admin")
 	}
@@ -223,7 +224,8 @@ func (s *AdminService) RegisterCredentials(ctx context.Context,
 
 // ListWorkspaces lists the workspaces associated with an admin
 func (s *AdminService) ListWorkspaces(ctx context.Context,
-	emailOrID *string) ([]*Workspace, error) {
+	emailOrID *string,
+) ([]*Workspace, error) {
 	endpoint := fmt.Sprintf("/admins/%v/workspaces", *emailOrID)
 	req, err := s.client.NewRequest("GET", endpoint, nil, nil)
 	if err != nil {
@@ -239,8 +241,8 @@ func (s *AdminService) ListWorkspaces(ctx context.Context,
 
 // ListRoles returns a slice of Kong RBAC roles associated with an Admin.
 func (s *AdminService) ListRoles(ctx context.Context,
-	emailOrID *string, opt *ListOpt) ([]*RBACRole, error) {
-
+	emailOrID *string, opt *ListOpt,
+) ([]*RBACRole, error) {
 	endpoint := fmt.Sprintf("/admins/%v/roles", *emailOrID)
 	req, err := s.client.NewRequest("GET", endpoint, nil, nil)
 	if err != nil {
@@ -260,8 +262,8 @@ func (s *AdminService) ListRoles(ctx context.Context,
 
 // UpdateRoles creates or updates roles associated with an Admin
 func (s *AdminService) UpdateRoles(ctx context.Context,
-	emailOrID *string, roles []*RBACRole) ([]*RBACRole, error) {
-
+	emailOrID *string, roles []*RBACRole,
+) ([]*RBACRole, error) {
 	var updateRoles struct {
 		NameOrID *string `json:"name_or_id,omitempty" yaml:"name_or_id,omitempty"`
 		Roles    *string `json:"roles,omitempty" yaml:"roles,omitempty"`
@@ -292,8 +294,8 @@ func (s *AdminService) UpdateRoles(ctx context.Context,
 
 // DeleteRoles deletes roles associated with an Admin
 func (s *AdminService) DeleteRoles(ctx context.Context,
-	emailOrID *string, roles []*RBACRole) error {
-
+	emailOrID *string, roles []*RBACRole,
+) error {
 	var updateRoles struct {
 		NameOrID *string `json:"name_or_id,omitempty" yaml:"name_or_id,omitempty"`
 		Roles    *string `json:"roles,omitempty" yaml:"roles,omitempty"`
@@ -324,8 +326,8 @@ func (s *AdminService) DeleteRoles(ctx context.Context,
 // GetConsumer fetches the Consumer that gets generated for an Admin when
 // the Admin is created.
 func (s *AdminService) GetConsumer(ctx context.Context,
-	emailOrID *string) (*Consumer, error) {
-
+	emailOrID *string,
+) (*Consumer, error) {
 	if isEmptyString(emailOrID) {
 		return nil, fmt.Errorf("emailOrID cannot be nil for GetConsumer operation")
 	}

--- a/kong/admin_service_test.go
+++ b/kong/admin_service_test.go
@@ -137,7 +137,6 @@ func TestAdminServiceList(T *testing.T) {
 	assert.Nil(err)
 	err = client.Admins.Delete(defaultCtx, createdAdmin2.ID)
 	assert.Nil(err)
-
 }
 
 // XXX:
@@ -177,5 +176,4 @@ func TestAdminServiceRegisterCredentials(T *testing.T) {
 
 	err = client.Admins.Delete(defaultCtx, admin.ID)
 	assert.Nil(err)
-
 }

--- a/kong/basic_auth_service.go
+++ b/kong/basic_auth_service.go
@@ -33,8 +33,8 @@ type BasicAuthService service
 // create a basic-auth in Kong, otherwise an ID
 // is auto-generated.
 func (s *BasicAuthService) Create(ctx context.Context,
-	consumerUsernameOrID *string, basicAuth *BasicAuth) (*BasicAuth, error) {
-
+	consumerUsernameOrID *string, basicAuth *BasicAuth,
+) (*BasicAuth, error) {
 	cred, err := s.client.credentials.Create(ctx, "basic-auth",
 		consumerUsernameOrID, basicAuth)
 	if err != nil {
@@ -52,8 +52,8 @@ func (s *BasicAuthService) Create(ctx context.Context,
 
 // Get fetches a basic-auth credential from Kong.
 func (s *BasicAuthService) Get(ctx context.Context,
-	consumerUsernameOrID, usernameOrID *string) (*BasicAuth, error) {
-
+	consumerUsernameOrID, usernameOrID *string,
+) (*BasicAuth, error) {
 	cred, err := s.client.credentials.Get(ctx, "basic-auth",
 		consumerUsernameOrID, usernameOrID)
 	if err != nil {
@@ -71,8 +71,8 @@ func (s *BasicAuthService) Get(ctx context.Context,
 
 // Update updates a basic-auth credential in Kong
 func (s *BasicAuthService) Update(ctx context.Context,
-	consumerUsernameOrID *string, basicAuth *BasicAuth) (*BasicAuth, error) {
-
+	consumerUsernameOrID *string, basicAuth *BasicAuth,
+) (*BasicAuth, error) {
 	cred, err := s.client.credentials.Update(ctx, "basic-auth",
 		consumerUsernameOrID, basicAuth)
 	if err != nil {
@@ -90,7 +90,8 @@ func (s *BasicAuthService) Update(ctx context.Context,
 
 // Delete deletes a basic-auth credential in Kong
 func (s *BasicAuthService) Delete(ctx context.Context,
-	consumerUsernameOrID, usernameOrID *string) error {
+	consumerUsernameOrID, usernameOrID *string,
+) error {
 	return s.client.credentials.Delete(ctx, "basic-auth",
 		consumerUsernameOrID, usernameOrID)
 }
@@ -98,7 +99,8 @@ func (s *BasicAuthService) Delete(ctx context.Context,
 // List fetches a list of basic-auth credentials in Kong.
 // opt can be used to control pagination.
 func (s *BasicAuthService) List(ctx context.Context,
-	opt *ListOpt) ([]*BasicAuth, *ListOpt, error) {
+	opt *ListOpt,
+) ([]*BasicAuth, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/basic-auths", opt)
 	if err != nil {
 		return nil, nil, err
@@ -142,7 +144,8 @@ func (s *BasicAuthService) ListAll(ctx context.Context) ([]*BasicAuth, error) {
 // in Kong associated with a specific consumer.
 // opt can be used to control pagination.
 func (s *BasicAuthService) ListForConsumer(ctx context.Context,
-	consumerUsernameOrID *string, opt *ListOpt) ([]*BasicAuth, *ListOpt, error) {
+	consumerUsernameOrID *string, opt *ListOpt,
+) ([]*BasicAuth, *ListOpt, error) {
 	data, next, err := s.client.list(ctx,
 		"/consumers/"+*consumerUsernameOrID+"/basic-auth", opt)
 	if err != nil {

--- a/kong/basic_auth_service_test.go
+++ b/kong/basic_auth_service_test.go
@@ -313,8 +313,7 @@ func TestBasicAuthListMethods(T *testing.T) {
 	assert.NotNil(page2)
 	assert.Equal(3, len(page2))
 
-	basicAuthsForConsumer, next, err :=
-		client.BasicAuths.ListForConsumer(defaultCtx, consumer1.ID, nil)
+	basicAuthsForConsumer, next, err := client.BasicAuths.ListForConsumer(defaultCtx, consumer1.ID, nil)
 	assert.Nil(err)
 	assert.Nil(next)
 	assert.NotNil(basicAuthsForConsumer)

--- a/kong/ca_certificate_service.go
+++ b/kong/ca_certificate_service.go
@@ -30,8 +30,8 @@ type CACertificateService service
 // create a certificate in Kong, otherwise an ID
 // is auto-generated.
 func (s *CACertificateService) Create(ctx context.Context,
-	certificate *CACertificate) (*CACertificate, error) {
-
+	certificate *CACertificate,
+) (*CACertificate, error) {
 	queryPath := "/ca_certificates"
 	method := "POST"
 	if certificate.ID != nil {
@@ -53,8 +53,8 @@ func (s *CACertificateService) Create(ctx context.Context,
 
 // Get fetches a CACertificate in Kong.
 func (s *CACertificateService) Get(ctx context.Context,
-	ID *string) (*CACertificate, error) {
-
+	ID *string,
+) (*CACertificate, error) {
 	if isEmptyString(ID) {
 		return nil, fmt.Errorf("ID cannot be nil for Get operation")
 	}
@@ -75,8 +75,8 @@ func (s *CACertificateService) Get(ctx context.Context,
 
 // Update updates a CACertificate in Kong
 func (s *CACertificateService) Update(ctx context.Context,
-	certificate *CACertificate) (*CACertificate, error) {
-
+	certificate *CACertificate,
+) (*CACertificate, error) {
 	if isEmptyString(certificate.ID) {
 		return nil, fmt.Errorf("ID cannot be nil for Update op           eration")
 	}
@@ -97,8 +97,8 @@ func (s *CACertificateService) Update(ctx context.Context,
 
 // Delete deletes a CACertificate in Kong
 func (s *CACertificateService) Delete(ctx context.Context,
-	ID *string) error {
-
+	ID *string,
+) error {
 	if isEmptyString(ID) {
 		return fmt.Errorf("ID cannot be nil for Delete operation")
 	}
@@ -116,7 +116,8 @@ func (s *CACertificateService) Delete(ctx context.Context,
 // List fetches a list of certificate in Kong.
 // opt can be used to control pagination.
 func (s *CACertificateService) List(ctx context.Context,
-	opt *ListOpt) ([]*CACertificate, *ListOpt, error) {
+	opt *ListOpt,
+) ([]*CACertificate, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/ca_certificates", opt)
 	if err != nil {
 		return nil, nil, err
@@ -142,7 +143,8 @@ func (s *CACertificateService) List(ctx context.Context,
 // This method can take a while if there
 // a lot of Certificates present.
 func (s *CACertificateService) ListAll(ctx context.Context) ([]*CACertificate,
-	error) {
+	error,
+) {
 	var certificates, data []*CACertificate
 	var err error
 	opt := &ListOpt{Size: pageSize}

--- a/kong/ca_certificate_service_test.go
+++ b/kong/ca_certificate_service_test.go
@@ -201,8 +201,7 @@ func TestCACertificateListEndpoint(T *testing.T) {
 		certificates[i] = certificate
 	}
 
-	certificatesFromKong, next, err :=
-		client.CACertificates.List(defaultCtx, nil)
+	certificatesFromKong, next, err := client.CACertificates.List(defaultCtx, nil)
 
 	assert.Nil(err)
 	assert.Nil(next)

--- a/kong/certificate_service.go
+++ b/kong/certificate_service.go
@@ -30,8 +30,8 @@ type CertificateService service
 // create a certificate in Kong, otherwise an ID
 // is auto-generated.
 func (s *CertificateService) Create(ctx context.Context,
-	certificate *Certificate) (*Certificate, error) {
-
+	certificate *Certificate,
+) (*Certificate, error) {
 	queryPath := "/certificates"
 	method := "POST"
 	if certificate.ID != nil {
@@ -53,8 +53,8 @@ func (s *CertificateService) Create(ctx context.Context,
 
 // Get fetches a Certificate in Kong.
 func (s *CertificateService) Get(ctx context.Context,
-	usernameOrID *string) (*Certificate, error) {
-
+	usernameOrID *string,
+) (*Certificate, error) {
 	if isEmptyString(usernameOrID) {
 		return nil, fmt.Errorf("usernameOrID cannot be nil for Get operation")
 	}
@@ -75,8 +75,8 @@ func (s *CertificateService) Get(ctx context.Context,
 
 // Update updates a Certificate in Kong
 func (s *CertificateService) Update(ctx context.Context,
-	certificate *Certificate) (*Certificate, error) {
-
+	certificate *Certificate,
+) (*Certificate, error) {
 	if isEmptyString(certificate.ID) {
 		return nil, fmt.Errorf("ID cannot be nil for Update op           eration")
 	}
@@ -97,8 +97,8 @@ func (s *CertificateService) Update(ctx context.Context,
 
 // Delete deletes a Certificate in Kong
 func (s *CertificateService) Delete(ctx context.Context,
-	usernameOrID *string) error {
-
+	usernameOrID *string,
+) error {
 	if isEmptyString(usernameOrID) {
 		return fmt.Errorf("usernameOrID cannot be nil for Delete operation")
 	}
@@ -116,7 +116,8 @@ func (s *CertificateService) Delete(ctx context.Context,
 // List fetches a list of certificate in Kong.
 // opt can be used to control pagination.
 func (s *CertificateService) List(ctx context.Context,
-	opt *ListOpt) ([]*Certificate, *ListOpt, error) {
+	opt *ListOpt,
+) ([]*Certificate, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/certificates", opt)
 	if err != nil {
 		return nil, nil, err
@@ -142,7 +143,8 @@ func (s *CertificateService) List(ctx context.Context,
 // This method can take a while if there
 // a lot of Certificates present.
 func (s *CertificateService) ListAll(ctx context.Context) ([]*Certificate,
-	error) {
+	error,
+) {
 	var certificates, data []*Certificate
 	var err error
 	opt := &ListOpt{Size: pageSize}

--- a/kong/client.go
+++ b/kong/client.go
@@ -224,7 +224,8 @@ func (c *Client) DoRAW(ctx context.Context, req *http.Request) (*http.Response, 
 
 // Do executes an HTTP request and returns a kong.Response
 func (c *Client) Do(ctx context.Context, req *http.Request,
-	v interface{}) (*Response, error) {
+	v interface{},
+) (*Response, error) {
 	resp, err := c.DoRAW(ctx, req)
 	if err != nil {
 		return nil, err

--- a/kong/consumer_service.go
+++ b/kong/consumer_service.go
@@ -33,8 +33,8 @@ type ConsumerService service
 // create a consumer in Kong, otherwise an ID
 // is auto-generated.
 func (s *ConsumerService) Create(ctx context.Context,
-	consumer *Consumer) (*Consumer, error) {
-
+	consumer *Consumer,
+) (*Consumer, error) {
 	queryPath := "/consumers"
 	method := "POST"
 	if consumer.ID != nil {
@@ -56,8 +56,8 @@ func (s *ConsumerService) Create(ctx context.Context,
 
 // Get fetches a Consumer in Kong.
 func (s *ConsumerService) Get(ctx context.Context,
-	usernameOrID *string) (*Consumer, error) {
-
+	usernameOrID *string,
+) (*Consumer, error) {
 	if isEmptyString(usernameOrID) {
 		return nil, fmt.Errorf("usernameOrID cannot be nil for Get operation")
 	}
@@ -78,8 +78,8 @@ func (s *ConsumerService) Get(ctx context.Context,
 
 // GetByCustomID fetches a Consumer in Kong.
 func (s *ConsumerService) GetByCustomID(ctx context.Context,
-	customID *string) (*Consumer, error) {
-
+	customID *string,
+) (*Consumer, error) {
 	if isEmptyString(customID) {
 		return nil, fmt.Errorf("customID cannot be nil for Get operation")
 	}
@@ -112,8 +112,8 @@ func (s *ConsumerService) GetByCustomID(ctx context.Context,
 
 // Update updates a Consumer in Kong
 func (s *ConsumerService) Update(ctx context.Context,
-	consumer *Consumer) (*Consumer, error) {
-
+	consumer *Consumer,
+) (*Consumer, error) {
 	if isEmptyString(consumer.ID) {
 		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
@@ -134,8 +134,8 @@ func (s *ConsumerService) Update(ctx context.Context,
 
 // Delete deletes a Consumer in Kong
 func (s *ConsumerService) Delete(ctx context.Context,
-	usernameOrID *string) error {
-
+	usernameOrID *string,
+) error {
 	if isEmptyString(usernameOrID) {
 		return fmt.Errorf("usernameOrID cannot be nil for Delete operation")
 	}
@@ -153,7 +153,8 @@ func (s *ConsumerService) Delete(ctx context.Context,
 // List fetches a list of Consumers in Kong.
 // opt can be used to control pagination.
 func (s *ConsumerService) List(ctx context.Context,
-	opt *ListOpt) ([]*Consumer, *ListOpt, error) {
+	opt *ListOpt,
+) ([]*Consumer, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/consumers", opt)
 	if err != nil {
 		return nil, nil, err

--- a/kong/credentials_service.go
+++ b/kong/credentials_service.go
@@ -41,8 +41,8 @@ var credPath = map[string]string{
 // is auto-generated.
 func (s *credentialService) Create(ctx context.Context, credType string,
 	consumerUsernameOrID *string,
-	credential interface{}) (json.RawMessage, error) {
-
+	credential interface{},
+) (json.RawMessage, error) {
 	if isEmptyString(consumerUsernameOrID) {
 		return nil, fmt.Errorf("consumerUsernameOrID cannot be nil")
 	}
@@ -81,8 +81,8 @@ func (s *credentialService) Create(ctx context.Context, credType string,
 // Get fetches a credential of credType with credIdentifier from Kong.
 func (s *credentialService) Get(ctx context.Context, credType string,
 	consumerUsernameOrID *string,
-	credIdentifier *string) (json.RawMessage, error) {
-
+	credIdentifier *string,
+) (json.RawMessage, error) {
 	if isEmptyString(credIdentifier) {
 		return nil, fmt.Errorf("credIdentifier cannot be nil for Get operation")
 	}
@@ -112,8 +112,8 @@ func (s *credentialService) Get(ctx context.Context, credType string,
 // Update updates credential in Kong
 func (s *credentialService) Update(ctx context.Context, credType string,
 	consumerUsernameOrID *string,
-	credential interface{}) (json.RawMessage, error) {
-
+	credential interface{},
+) (json.RawMessage, error) {
 	if isEmptyString(consumerUsernameOrID) {
 		return nil, fmt.Errorf("consumerUsernameOrID cannot be nil")
 	}
@@ -157,8 +157,8 @@ func (s *credentialService) Update(ctx context.Context, credType string,
 
 // Delete deletes a credential in Kong
 func (s *credentialService) Delete(ctx context.Context, credType string,
-	consumerUsernameOrID, credIdentifier *string) error {
-
+	consumerUsernameOrID, credIdentifier *string,
+) error {
 	if isEmptyString(credIdentifier) {
 		return fmt.Errorf("credIdentifier cannot be nil for Delete operation")
 	}

--- a/kong/custom_entity_service.go
+++ b/kong/custom_entity_service.go
@@ -32,7 +32,8 @@ type CustomEntityService service
 // Get fetches a custom entity. The primary key and all relations of the
 // entity must be populated in entity.
 func (s *CustomEntityService) Get(ctx context.Context,
-	entity custom.Entity) (custom.Entity, error) {
+	entity custom.Entity,
+) (custom.Entity, error) {
 	def := s.client.Lookup(entity.Type())
 	if def == nil {
 		return nil, fmt.Errorf("entity '" + string(entity.Type()) +
@@ -61,7 +62,8 @@ func (s *CustomEntityService) Get(ctx context.Context,
 // Create creates a custom entity based on entity.
 // All required fields must be present in entity.
 func (s *CustomEntityService) Create(ctx context.Context,
-	entity custom.Entity) (custom.Entity, error) {
+	entity custom.Entity,
+) (custom.Entity, error) {
 	def := s.client.Lookup(entity.Type())
 	if def == nil {
 		return nil, fmt.Errorf("entity '" + string(entity.Type()) +
@@ -105,7 +107,8 @@ func (s *CustomEntityService) Create(ctx context.Context,
 
 // Update updates a custom entity in Kong.
 func (s *CustomEntityService) Update(ctx context.Context,
-	entity custom.Entity) (custom.Entity, error) {
+	entity custom.Entity,
+) (custom.Entity, error) {
 	def := s.client.Lookup(entity.Type())
 	if def == nil {
 		return nil, fmt.Errorf("entity '" + string(entity.Type()) +
@@ -139,7 +142,8 @@ func (s *CustomEntityService) Update(ctx context.Context,
 
 // Delete deletes a custom entity in Kong.
 func (s *CustomEntityService) Delete(ctx context.Context,
-	entity custom.Entity) error {
+	entity custom.Entity,
+) error {
 	def := s.client.Lookup(entity.Type())
 	if def == nil {
 		return fmt.Errorf("entity '" + string(entity.Type()) +
@@ -162,7 +166,8 @@ func (s *CustomEntityService) Delete(ctx context.Context,
 
 // List fetches all custom entities based on relations
 func (s *CustomEntityService) List(ctx context.Context, opt *ListOpt,
-	entity custom.Entity) ([]custom.Entity, *ListOpt, error) {
+	entity custom.Entity,
+) ([]custom.Entity, *ListOpt, error) {
 	def := s.client.Lookup(entity.Type())
 	if def == nil {
 		return nil, nil, fmt.Errorf("entity '" + string(entity.Type()) +
@@ -203,7 +208,8 @@ func (s *CustomEntityService) List(ctx context.Context, opt *ListOpt,
 
 // ListAll fetches all custom entities based on relations
 func (s *CustomEntityService) ListAll(ctx context.Context,
-	entity custom.Entity) ([]custom.Entity, error) {
+	entity custom.Entity,
+) ([]custom.Entity, error) {
 	var entities, data []custom.Entity
 	var err error
 	opt := &ListOpt{Size: pageSize}

--- a/kong/developer_role_service.go
+++ b/kong/developer_role_service.go
@@ -27,8 +27,8 @@ type DeveloperRoleService service
 
 // Create creates a Developer Role in Kong.
 func (s *DeveloperRoleService) Create(ctx context.Context,
-	role *DeveloperRole) (*DeveloperRole, error) {
-
+	role *DeveloperRole,
+) (*DeveloperRole, error) {
 	if role == nil {
 		return nil, fmt.Errorf("cannot create a nil role")
 	}
@@ -50,8 +50,8 @@ func (s *DeveloperRoleService) Create(ctx context.Context,
 
 // Get fetches a Developer Role in Kong.
 func (s *DeveloperRoleService) Get(ctx context.Context,
-	nameOrID *string) (*DeveloperRole, error) {
-
+	nameOrID *string,
+) (*DeveloperRole, error) {
 	if isEmptyString(nameOrID) {
 		return nil, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
@@ -72,8 +72,8 @@ func (s *DeveloperRoleService) Get(ctx context.Context,
 
 // Update updates a Developer Role in Kong.
 func (s *DeveloperRoleService) Update(ctx context.Context,
-	role *DeveloperRole) (*DeveloperRole, error) {
-
+	role *DeveloperRole,
+) (*DeveloperRole, error) {
 	if role == nil {
 		return nil, fmt.Errorf("cannot update a nil Role")
 	}
@@ -98,8 +98,8 @@ func (s *DeveloperRoleService) Update(ctx context.Context,
 
 // Delete deletes a Developer Role in Kong
 func (s *DeveloperRoleService) Delete(ctx context.Context,
-	RoleOrID *string) error {
-
+	RoleOrID *string,
+) error {
 	if isEmptyString(RoleOrID) {
 		return fmt.Errorf("RoleOrID cannot be nil for Delete operation")
 	}
@@ -117,7 +117,8 @@ func (s *DeveloperRoleService) Delete(ctx context.Context,
 // List fetches a list of all Developer Roles in Kong.
 // opt can be used to control pagination.
 func (s *DeveloperRoleService) List(ctx context.Context,
-	opt *ListOpt) ([]*DeveloperRole, *ListOpt, error) {
+	opt *ListOpt,
+) ([]*DeveloperRole, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/developers/roles/", opt)
 	if err != nil {
 		return nil, nil, err

--- a/kong/developer_service.go
+++ b/kong/developer_service.go
@@ -37,8 +37,8 @@ type DeveloperService service
 // the hidden consumer that backs the developer. Subsequent attempts to use such developers
 // result in fatal errors.
 func (s *DeveloperService) Create(ctx context.Context,
-	developer *Developer) (*Developer, error) {
-
+	developer *Developer,
+) (*Developer, error) {
 	queryPath := "/developers"
 	method := "POST"
 	req, err := s.client.NewRequest(method, queryPath, nil, developer)
@@ -56,8 +56,8 @@ func (s *DeveloperService) Create(ctx context.Context,
 
 // Get fetches a Developer in Kong.
 func (s *DeveloperService) Get(ctx context.Context,
-	emailOrID *string) (*Developer, error) {
-
+	emailOrID *string,
+) (*Developer, error) {
 	if isEmptyString(emailOrID) {
 		return nil, fmt.Errorf("emailOrID cannot be nil for Get operation")
 	}
@@ -78,8 +78,8 @@ func (s *DeveloperService) Get(ctx context.Context,
 
 // GetByCustomID fetches a Developer in Kong.
 func (s *DeveloperService) GetByCustomID(ctx context.Context,
-	customID *string) (*Developer, error) {
-
+	customID *string,
+) (*Developer, error) {
 	if isEmptyString(customID) {
 		return nil, fmt.Errorf("customID cannot be nil for Get operation")
 	}
@@ -112,8 +112,8 @@ func (s *DeveloperService) GetByCustomID(ctx context.Context,
 
 // Update updates a Developer in Kong
 func (s *DeveloperService) Update(ctx context.Context,
-	developer *Developer) (*Developer, error) {
-
+	developer *Developer,
+) (*Developer, error) {
 	if isEmptyString(developer.ID) {
 		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
@@ -136,8 +136,8 @@ func (s *DeveloperService) Update(ctx context.Context,
 
 // Delete deletes a Developer in Kong
 func (s *DeveloperService) Delete(ctx context.Context,
-	emailOrID *string) error {
-
+	emailOrID *string,
+) error {
 	if isEmptyString(emailOrID) {
 		return fmt.Errorf("emailOrID cannot be nil for Delete operation")
 	}
@@ -155,7 +155,8 @@ func (s *DeveloperService) Delete(ctx context.Context,
 // List fetches a list of Developers in Kong.
 // opt can be used to control pagination.
 func (s *DeveloperService) List(ctx context.Context,
-	opt *ListOpt) ([]*Developer, *ListOpt, error) {
+	opt *ListOpt,
+) ([]*Developer, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/developers", opt)
 	if err != nil {
 		return nil, nil, err

--- a/kong/endpoint_permission_service.go
+++ b/kong/endpoint_permission_service.go
@@ -26,8 +26,8 @@ type RBACEndpointPermissionService service
 
 // Create creates a RBACEndpointPermission in Kong.
 func (s *RBACEndpointPermissionService) Create(ctx context.Context,
-	ep *RBACEndpointPermission) (*RBACEndpointPermission, error) {
-
+	ep *RBACEndpointPermission,
+) (*RBACEndpointPermission, error) {
 	if ep == nil {
 		return nil, fmt.Errorf("cannot create a nil endpointpermission")
 	}
@@ -53,8 +53,8 @@ func (s *RBACEndpointPermissionService) Create(ctx context.Context,
 
 // Get fetches a RBACEndpointPermission in Kong.
 func (s *RBACEndpointPermissionService) Get(ctx context.Context,
-	roleNameOrID *string, workspaceNameOrID *string, endpointName *string) (*RBACEndpointPermission, error) {
-
+	roleNameOrID *string, workspaceNameOrID *string, endpointName *string,
+) (*RBACEndpointPermission, error) {
 	if isEmptyString(endpointName) {
 		return nil, fmt.Errorf("endpointName cannot be nil for Get operation")
 	}
@@ -77,8 +77,8 @@ func (s *RBACEndpointPermissionService) Get(ctx context.Context,
 
 // Update updates a RBACEndpointPermission in Kong.
 func (s *RBACEndpointPermissionService) Update(ctx context.Context,
-	ep *RBACEndpointPermission) (*RBACEndpointPermission, error) {
-
+	ep *RBACEndpointPermission,
+) (*RBACEndpointPermission, error) {
 	if ep == nil {
 		return nil, fmt.Errorf("cannot update a nil EndpointPermission")
 	}
@@ -114,8 +114,8 @@ func (s *RBACEndpointPermissionService) Update(ctx context.Context,
 
 // Delete deletes a EndpointPermission in Kong
 func (s *RBACEndpointPermissionService) Delete(ctx context.Context,
-	roleNameOrID *string, workspaceNameOrID *string, endpointName *string) error {
-
+	roleNameOrID *string, workspaceNameOrID *string, endpointName *string,
+) error {
 	if endpointName == nil {
 		return fmt.Errorf("cannot update a nil EndpointPermission")
 	}
@@ -142,8 +142,8 @@ func (s *RBACEndpointPermissionService) Delete(ctx context.Context,
 
 // ListAllForRole fetches a list of all RBACEndpointPermissions in Kong for a given role.
 func (s *RBACEndpointPermissionService) ListAllForRole(ctx context.Context,
-	roleNameOrID *string) ([]*RBACEndpointPermission, error) {
-
+	roleNameOrID *string,
+) ([]*RBACEndpointPermission, error) {
 	data, _, err := s.client.list(ctx, fmt.Sprintf("/rbac/roles/%v/endpoints", *roleNameOrID), nil)
 	if err != nil {
 		return nil, err

--- a/kong/entity_permission_service.go
+++ b/kong/entity_permission_service.go
@@ -25,8 +25,8 @@ type RBACEntityPermissionService service
 
 // Create creates an RBACEntityPermission in Kong.
 func (s *RBACEntityPermissionService) Create(ctx context.Context,
-	ep *RBACEntityPermission) (*RBACEntityPermission, error) {
-
+	ep *RBACEntityPermission,
+) (*RBACEntityPermission, error) {
 	if ep == nil {
 		return nil, fmt.Errorf("cannot create a nil entitypermission")
 	}
@@ -52,8 +52,8 @@ func (s *RBACEntityPermissionService) Create(ctx context.Context,
 
 // Get fetches an EntityPermission in Kong.
 func (s *RBACEntityPermissionService) Get(ctx context.Context,
-	roleNameOrID *string, entityName *string) (*RBACEntityPermission, error) {
-
+	roleNameOrID *string, entityName *string,
+) (*RBACEntityPermission, error) {
 	if isEmptyString(entityName) {
 		return nil, fmt.Errorf("entityName cannot be nil for Get operation")
 	}
@@ -74,8 +74,8 @@ func (s *RBACEntityPermissionService) Get(ctx context.Context,
 
 // Update updates an EntityPermission in Kong.
 func (s *RBACEntityPermissionService) Update(ctx context.Context,
-	ep *RBACEntityPermission) (*RBACEntityPermission, error) {
-
+	ep *RBACEntityPermission,
+) (*RBACEntityPermission, error) {
 	if ep == nil {
 		return nil, fmt.Errorf("cannot update a nil EntityPermission")
 	}
@@ -105,8 +105,8 @@ func (s *RBACEntityPermissionService) Update(ctx context.Context,
 
 // Delete deletes an EntityPermission in Kong
 func (s *RBACEntityPermissionService) Delete(ctx context.Context,
-	roleNameOrID *string, entityID *string) error {
-
+	roleNameOrID *string, entityID *string,
+) error {
 	if roleNameOrID == nil {
 		return fmt.Errorf("cannot update an EntityPermission with role as nil")
 	}
@@ -127,8 +127,8 @@ func (s *RBACEntityPermissionService) Delete(ctx context.Context,
 
 // ListAllForRole fetches a list of all RBACEntityPermissions in Kong for a given role.
 func (s *RBACEntityPermissionService) ListAllForRole(ctx context.Context,
-	roleNameOrID *string) ([]*RBACEntityPermission, error) {
-
+	roleNameOrID *string,
+) ([]*RBACEntityPermission, error) {
 	endpoint := fmt.Sprintf("/rbac/roles/%v/entities", *roleNameOrID)
 	data, _, err := s.client.list(ctx, endpoint, nil)
 	if err != nil {

--- a/kong/exists.go
+++ b/kong/exists.go
@@ -7,7 +7,8 @@ import (
 
 // exists check the existence  with a HEAD HTTP verb
 func (c *Client) exists(ctx context.Context,
-	endpoint string) (bool, error) {
+	endpoint string,
+) (bool, error) {
 	// Originally, this used HEAD. We promptly discovered that HEAD doesn't actually work for this
 	// in Kong <=2.6: https://github.com/Kong/kong/issues/7554
 	// Although future versions will support HEAD for existence checks, using GET for backwards

--- a/kong/hmac_auth_service.go
+++ b/kong/hmac_auth_service.go
@@ -32,8 +32,8 @@ type HMACAuthService service
 // create a hmac-auth in Kong, otherwise an ID
 // is auto-generated.
 func (s *HMACAuthService) Create(ctx context.Context,
-	consumerUsernameOrID *string, hmacAuth *HMACAuth) (*HMACAuth, error) {
-
+	consumerUsernameOrID *string, hmacAuth *HMACAuth,
+) (*HMACAuth, error) {
 	cred, err := s.client.credentials.Create(ctx, "hmac-auth",
 		consumerUsernameOrID, hmacAuth)
 	if err != nil {
@@ -51,8 +51,8 @@ func (s *HMACAuthService) Create(ctx context.Context,
 
 // Get fetches a hmac-auth credential from Kong.
 func (s *HMACAuthService) Get(ctx context.Context,
-	consumerUsernameOrID, usernameOrID *string) (*HMACAuth, error) {
-
+	consumerUsernameOrID, usernameOrID *string,
+) (*HMACAuth, error) {
 	cred, err := s.client.credentials.Get(ctx, "hmac-auth",
 		consumerUsernameOrID, usernameOrID)
 	if err != nil {
@@ -70,8 +70,8 @@ func (s *HMACAuthService) Get(ctx context.Context,
 
 // Update updates a hmac-auth credential in Kong
 func (s *HMACAuthService) Update(ctx context.Context,
-	consumerUsernameOrID *string, hmacAuth *HMACAuth) (*HMACAuth, error) {
-
+	consumerUsernameOrID *string, hmacAuth *HMACAuth,
+) (*HMACAuth, error) {
 	cred, err := s.client.credentials.Update(ctx, "hmac-auth",
 		consumerUsernameOrID, hmacAuth)
 	if err != nil {
@@ -89,7 +89,8 @@ func (s *HMACAuthService) Update(ctx context.Context,
 
 // Delete deletes a hmac-auth credential in Kong
 func (s *HMACAuthService) Delete(ctx context.Context,
-	consumerUsernameOrID, usernameOrID *string) error {
+	consumerUsernameOrID, usernameOrID *string,
+) error {
 	return s.client.credentials.Delete(ctx, "hmac-auth",
 		consumerUsernameOrID, usernameOrID)
 }
@@ -97,7 +98,8 @@ func (s *HMACAuthService) Delete(ctx context.Context,
 // List fetches a list of hmac-auth credentials in Kong.
 // opt can be used to control pagination.
 func (s *HMACAuthService) List(ctx context.Context,
-	opt *ListOpt) ([]*HMACAuth, *ListOpt, error) {
+	opt *ListOpt,
+) ([]*HMACAuth, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/hmac-auths", opt)
 	if err != nil {
 		return nil, nil, err
@@ -141,7 +143,8 @@ func (s *HMACAuthService) ListAll(ctx context.Context) ([]*HMACAuth, error) {
 // in Kong associated with a specific consumer.
 // opt can be used to control pagination.
 func (s *HMACAuthService) ListForConsumer(ctx context.Context,
-	consumerUsernameOrID *string, opt *ListOpt) ([]*HMACAuth, *ListOpt, error) {
+	consumerUsernameOrID *string, opt *ListOpt,
+) ([]*HMACAuth, *ListOpt, error) {
 	data, next, err := s.client.list(ctx,
 		"/consumers/"+*consumerUsernameOrID+"/hmac-auth", opt)
 	if err != nil {

--- a/kong/hmac_auth_service_test.go
+++ b/kong/hmac_auth_service_test.go
@@ -290,8 +290,7 @@ func TestHMACAuthListMethods(T *testing.T) {
 	assert.NotNil(page2)
 	assert.Equal(3, len(page2))
 
-	hmacAuthsForConsumer, next, err :=
-		client.HMACAuths.ListForConsumer(defaultCtx, consumer1.ID, nil)
+	hmacAuthsForConsumer, next, err := client.HMACAuths.ListForConsumer(defaultCtx, consumer1.ID, nil)
 	assert.Nil(err)
 	assert.Nil(next)
 	assert.NotNil(hmacAuthsForConsumer)

--- a/kong/jwt_auth_service.go
+++ b/kong/jwt_auth_service.go
@@ -32,8 +32,8 @@ type JWTAuthService service
 // create a JWT in Kong, otherwise an ID
 // is auto-generated.
 func (s *JWTAuthService) Create(ctx context.Context,
-	consumerUsernameOrID *string, jwtAuth *JWTAuth) (*JWTAuth, error) {
-
+	consumerUsernameOrID *string, jwtAuth *JWTAuth,
+) (*JWTAuth, error) {
 	cred, err := s.client.credentials.Create(ctx, "jwt-auth",
 		consumerUsernameOrID, jwtAuth)
 	if err != nil {
@@ -51,8 +51,8 @@ func (s *JWTAuthService) Create(ctx context.Context,
 
 // Get fetches a JWT credential from Kong.
 func (s *JWTAuthService) Get(ctx context.Context,
-	consumerUsernameOrID, keyOrID *string) (*JWTAuth, error) {
-
+	consumerUsernameOrID, keyOrID *string,
+) (*JWTAuth, error) {
 	cred, err := s.client.credentials.Get(ctx, "jwt-auth",
 		consumerUsernameOrID, keyOrID)
 	if err != nil {
@@ -70,8 +70,8 @@ func (s *JWTAuthService) Get(ctx context.Context,
 
 // Update updates a JWT credential in Kong
 func (s *JWTAuthService) Update(ctx context.Context,
-	consumerUsernameOrID *string, jwtAuth *JWTAuth) (*JWTAuth, error) {
-
+	consumerUsernameOrID *string, jwtAuth *JWTAuth,
+) (*JWTAuth, error) {
 	cred, err := s.client.credentials.Update(ctx, "jwt-auth",
 		consumerUsernameOrID, jwtAuth)
 	if err != nil {
@@ -89,7 +89,8 @@ func (s *JWTAuthService) Update(ctx context.Context,
 
 // Delete deletes a JWT credential in Kong
 func (s *JWTAuthService) Delete(ctx context.Context,
-	consumerUsernameOrID, keyOrID *string) error {
+	consumerUsernameOrID, keyOrID *string,
+) error {
 	return s.client.credentials.Delete(ctx, "jwt-auth",
 		consumerUsernameOrID, keyOrID)
 }
@@ -97,7 +98,8 @@ func (s *JWTAuthService) Delete(ctx context.Context,
 // List fetches a list of JWT credentials in Kong.
 // opt can be used to control pagination.
 func (s *JWTAuthService) List(ctx context.Context,
-	opt *ListOpt) ([]*JWTAuth, *ListOpt, error) {
+	opt *ListOpt,
+) ([]*JWTAuth, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/jwts", opt)
 	if err != nil {
 		return nil, nil, err
@@ -141,7 +143,8 @@ func (s *JWTAuthService) ListAll(ctx context.Context) ([]*JWTAuth, error) {
 // in Kong associated with a specific consumer.
 // opt can be used to control pagination.
 func (s *JWTAuthService) ListForConsumer(ctx context.Context,
-	consumerUsernameOrID *string, opt *ListOpt) ([]*JWTAuth, *ListOpt, error) {
+	consumerUsernameOrID *string, opt *ListOpt,
+) ([]*JWTAuth, *ListOpt, error) {
 	data, next, err := s.client.list(ctx,
 		"/consumers/"+*consumerUsernameOrID+"/jwt", opt)
 	if err != nil {

--- a/kong/key_auth_service.go
+++ b/kong/key_auth_service.go
@@ -31,8 +31,8 @@ type KeyAuthService service
 // create a key-auth in Kong, otherwise an ID
 // is auto-generated.
 func (s *KeyAuthService) Create(ctx context.Context,
-	consumerUsernameOrID *string, keyAuth *KeyAuth) (*KeyAuth, error) {
-
+	consumerUsernameOrID *string, keyAuth *KeyAuth,
+) (*KeyAuth, error) {
 	cred, err := s.client.credentials.Create(ctx, "key-auth",
 		consumerUsernameOrID, keyAuth)
 	if err != nil {
@@ -50,8 +50,8 @@ func (s *KeyAuthService) Create(ctx context.Context,
 
 // Get fetches a key-auth credential from Kong.
 func (s *KeyAuthService) Get(ctx context.Context,
-	consumerUsernameOrID, keyOrID *string) (*KeyAuth, error) {
-
+	consumerUsernameOrID, keyOrID *string,
+) (*KeyAuth, error) {
 	cred, err := s.client.credentials.Get(ctx, "key-auth",
 		consumerUsernameOrID, keyOrID)
 	if err != nil {
@@ -69,8 +69,8 @@ func (s *KeyAuthService) Get(ctx context.Context,
 
 // Update updates a key-auth credential in Kong
 func (s *KeyAuthService) Update(ctx context.Context,
-	consumerUsernameOrID *string, keyAuth *KeyAuth) (*KeyAuth, error) {
-
+	consumerUsernameOrID *string, keyAuth *KeyAuth,
+) (*KeyAuth, error) {
 	cred, err := s.client.credentials.Update(ctx, "key-auth",
 		consumerUsernameOrID, keyAuth)
 	if err != nil {
@@ -88,7 +88,8 @@ func (s *KeyAuthService) Update(ctx context.Context,
 
 // Delete deletes a key-auth credential in Kong
 func (s *KeyAuthService) Delete(ctx context.Context,
-	consumerUsernameOrID, keyOrID *string) error {
+	consumerUsernameOrID, keyOrID *string,
+) error {
 	return s.client.credentials.Delete(ctx, "key-auth",
 		consumerUsernameOrID, keyOrID)
 }
@@ -96,7 +97,8 @@ func (s *KeyAuthService) Delete(ctx context.Context,
 // List fetches a list of key-auth credentials in Kong.
 // opt can be used to control pagination.
 func (s *KeyAuthService) List(ctx context.Context,
-	opt *ListOpt) ([]*KeyAuth, *ListOpt, error) {
+	opt *ListOpt,
+) ([]*KeyAuth, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/key-auths", opt)
 	if err != nil {
 		return nil, nil, err
@@ -140,7 +142,8 @@ func (s *KeyAuthService) ListAll(ctx context.Context) ([]*KeyAuth, error) {
 // in Kong associated with a specific consumer.
 // opt can be used to control pagination.
 func (s *KeyAuthService) ListForConsumer(ctx context.Context,
-	consumerUsernameOrID *string, opt *ListOpt) ([]*KeyAuth, *ListOpt, error) {
+	consumerUsernameOrID *string, opt *ListOpt,
+) ([]*KeyAuth, *ListOpt, error) {
 	data, next, err := s.client.list(ctx,
 		"/consumers/"+*consumerUsernameOrID+"/key-auth", opt)
 	if err != nil {

--- a/kong/key_auth_service_test.go
+++ b/kong/key_auth_service_test.go
@@ -285,8 +285,7 @@ func TestKeyAuthListMethods(T *testing.T) {
 	assert.NotNil(page2)
 	assert.Equal(3, len(page2))
 
-	keyAuthsForConsumer, next, err :=
-		client.KeyAuths.ListForConsumer(defaultCtx, consumer1.ID, nil)
+	keyAuthsForConsumer, next, err := client.KeyAuths.ListForConsumer(defaultCtx, consumer1.ID, nil)
 	assert.Nil(err)
 	assert.Nil(next)
 	assert.NotNil(keyAuthsForConsumer)

--- a/kong/list.go
+++ b/kong/list.go
@@ -32,8 +32,8 @@ type qs struct {
 // list fetches a list of an entity in Kong.
 // opt can be used to control pagination.
 func (c *Client) list(ctx context.Context,
-	endpoint string, opt *ListOpt) ([]json.RawMessage, *ListOpt, error) {
-
+	endpoint string, opt *ListOpt,
+) ([]json.RawMessage, *ListOpt, error) {
 	q := constructQueryString(opt)
 	req, err := c.NewRequest("GET", endpoint, &q, nil)
 	if err != nil {

--- a/kong/mtls_auth_service.go
+++ b/kong/mtls_auth_service.go
@@ -32,8 +32,8 @@ type MTLSAuthService service
 // create a MTLS in Kong, otherwise an ID
 // is auto-generated.
 func (s *MTLSAuthService) Create(ctx context.Context,
-	consumerUsernameOrID *string, mtlsAuth *MTLSAuth) (*MTLSAuth, error) {
-
+	consumerUsernameOrID *string, mtlsAuth *MTLSAuth,
+) (*MTLSAuth, error) {
 	cred, err := s.client.credentials.Create(ctx, "mtls-auth",
 		consumerUsernameOrID, mtlsAuth)
 	if err != nil {
@@ -51,8 +51,8 @@ func (s *MTLSAuthService) Create(ctx context.Context,
 
 // Get fetches an MTLS credential from Kong.
 func (s *MTLSAuthService) Get(ctx context.Context,
-	consumerUsernameOrID, keyOrID *string) (*MTLSAuth, error) {
-
+	consumerUsernameOrID, keyOrID *string,
+) (*MTLSAuth, error) {
 	cred, err := s.client.credentials.Get(ctx, "mtls-auth",
 		consumerUsernameOrID, keyOrID)
 	if err != nil {
@@ -70,8 +70,8 @@ func (s *MTLSAuthService) Get(ctx context.Context,
 
 // Update updates an MTLS credential in Kong
 func (s *MTLSAuthService) Update(ctx context.Context,
-	consumerUsernameOrID *string, mtlsAuth *MTLSAuth) (*MTLSAuth, error) {
-
+	consumerUsernameOrID *string, mtlsAuth *MTLSAuth,
+) (*MTLSAuth, error) {
 	cred, err := s.client.credentials.Update(ctx, "mtls-auth",
 		consumerUsernameOrID, mtlsAuth)
 	if err != nil {
@@ -89,7 +89,8 @@ func (s *MTLSAuthService) Update(ctx context.Context,
 
 // Delete deletes an MTLS credential in Kong
 func (s *MTLSAuthService) Delete(ctx context.Context,
-	consumerUsernameOrID, keyOrID *string) error {
+	consumerUsernameOrID, keyOrID *string,
+) error {
 	return s.client.credentials.Delete(ctx, "mtls-auth",
 		consumerUsernameOrID, keyOrID)
 }
@@ -97,7 +98,8 @@ func (s *MTLSAuthService) Delete(ctx context.Context,
 // List fetches a list of MTLS credentials in Kong.
 // opt can be used to control pagination.
 func (s *MTLSAuthService) List(ctx context.Context,
-	opt *ListOpt) ([]*MTLSAuth, *ListOpt, error) {
+	opt *ListOpt,
+) ([]*MTLSAuth, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/mtls-auths", opt)
 	if err != nil {
 		return nil, nil, err
@@ -141,7 +143,8 @@ func (s *MTLSAuthService) ListAll(ctx context.Context) ([]*MTLSAuth, error) {
 // in Kong associated with a specific consumer.
 // opt can be used to control pagination.
 func (s *MTLSAuthService) ListForConsumer(ctx context.Context,
-	consumerUsernameOrID *string, opt *ListOpt) ([]*MTLSAuth, *ListOpt, error) {
+	consumerUsernameOrID *string, opt *ListOpt,
+) ([]*MTLSAuth, *ListOpt, error) {
 	data, next, err := s.client.list(ctx,
 		"/consumers/"+*consumerUsernameOrID+"/mtls-auth", opt)
 	if err != nil {

--- a/kong/mtls_auth_service_test.go
+++ b/kong/mtls_auth_service_test.go
@@ -1,3 +1,4 @@
+//go:build enterprise
 // +build enterprise
 
 package kong

--- a/kong/oauth2_auth_service.go
+++ b/kong/oauth2_auth_service.go
@@ -33,8 +33,8 @@ type Oauth2Service service
 // is auto-generated.
 func (s *Oauth2Service) Create(ctx context.Context,
 	consumerUsernameOrID *string,
-	oauth2Cred *Oauth2Credential) (*Oauth2Credential, error) {
-
+	oauth2Cred *Oauth2Credential,
+) (*Oauth2Credential, error) {
 	cred, err := s.client.credentials.Create(ctx, "oauth2",
 		consumerUsernameOrID, oauth2Cred)
 	if err != nil {
@@ -52,8 +52,8 @@ func (s *Oauth2Service) Create(ctx context.Context,
 
 // Get fetches an oauth2 credential from Kong.
 func (s *Oauth2Service) Get(ctx context.Context,
-	consumerUsernameOrID, clientIDorID *string) (*Oauth2Credential, error) {
-
+	consumerUsernameOrID, clientIDorID *string,
+) (*Oauth2Credential, error) {
 	cred, err := s.client.credentials.Get(ctx, "oauth2",
 		consumerUsernameOrID, clientIDorID)
 	if err != nil {
@@ -72,8 +72,8 @@ func (s *Oauth2Service) Get(ctx context.Context,
 // Update updates an oauth2 credential in Kong.
 func (s *Oauth2Service) Update(ctx context.Context,
 	consumerUsernameOrID *string,
-	oauth2Cred *Oauth2Credential) (*Oauth2Credential, error) {
-
+	oauth2Cred *Oauth2Credential,
+) (*Oauth2Credential, error) {
 	cred, err := s.client.credentials.Update(ctx, "oauth2",
 		consumerUsernameOrID, oauth2Cred)
 	if err != nil {
@@ -91,7 +91,8 @@ func (s *Oauth2Service) Update(ctx context.Context,
 
 // Delete deletes an oauth2 credential in Kong.
 func (s *Oauth2Service) Delete(ctx context.Context,
-	consumerUsernameOrID, clientIDorID *string) error {
+	consumerUsernameOrID, clientIDorID *string,
+) error {
 	return s.client.credentials.Delete(ctx, "oauth2",
 		consumerUsernameOrID, clientIDorID)
 }
@@ -99,7 +100,8 @@ func (s *Oauth2Service) Delete(ctx context.Context,
 // List fetches a list of oauth2 credentials in Kong.
 // opt can be used to control pagination.
 func (s *Oauth2Service) List(ctx context.Context,
-	opt *ListOpt) ([]*Oauth2Credential, *ListOpt, error) {
+	opt *ListOpt,
+) ([]*Oauth2Credential, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/oauth2", opt)
 	if err != nil {
 		return nil, nil, err
@@ -125,7 +127,8 @@ func (s *Oauth2Service) List(ctx context.Context,
 // This method can take a while if there
 // a lot of oauth2 credentials present.
 func (s *Oauth2Service) ListAll(
-	ctx context.Context) ([]*Oauth2Credential, error) {
+	ctx context.Context,
+) ([]*Oauth2Credential, error) {
 	var oauth2Creds, data []*Oauth2Credential
 	var err error
 	opt := &ListOpt{Size: pageSize}
@@ -145,7 +148,8 @@ func (s *Oauth2Service) ListAll(
 // opt can be used to control pagination.
 func (s *Oauth2Service) ListForConsumer(ctx context.Context,
 	consumerUsernameOrID *string, opt *ListOpt) ([]*Oauth2Credential,
-	*ListOpt, error) {
+	*ListOpt, error,
+) {
 	data, next, err := s.client.list(ctx,
 		"/consumers/"+*consumerUsernameOrID+"/oauth2", opt)
 	if err != nil {

--- a/kong/oauth2_auth_service_test.go
+++ b/kong/oauth2_auth_service_test.go
@@ -174,8 +174,7 @@ func TestOauth2CredentialUpdate(T *testing.T) {
 
 	oauth2Cred.Name = String("new-foo-name")
 	oauth2Cred.ClientSecret = String("my-new-secret")
-	updatedOauth2Credential, err :=
-		client.Oauth2Credentials.Update(defaultCtx, consumer.ID, oauth2Cred)
+	updatedOauth2Credential, err := client.Oauth2Credentials.Update(defaultCtx, consumer.ID, oauth2Cred)
 	assert.Nil(err)
 	assert.NotNil(updatedOauth2Credential)
 	assert.Equal("new-foo-name", *updatedOauth2Credential.Name)
@@ -208,8 +207,7 @@ func TestOauth2CredentialDelete(T *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(consumer)
 
-	createdOauth2Credential, err :=
-		client.Oauth2Credentials.Create(defaultCtx, consumer.ID, oauth2Cred)
+	createdOauth2Credential, err := client.Oauth2Credentials.Create(defaultCtx, consumer.ID, oauth2Cred)
 	assert.Nil(err)
 	assert.NotNil(createdOauth2Credential)
 
@@ -286,16 +284,14 @@ func TestOauth2CredentialListMethods(T *testing.T) {
 		oauth2Creds[i] = oauth2Cred
 	}
 
-	oauth2CredsFromKong, next, err :=
-		client.Oauth2Credentials.List(defaultCtx, nil)
+	oauth2CredsFromKong, next, err := client.Oauth2Credentials.List(defaultCtx, nil)
 	assert.Nil(err)
 	assert.Nil(next)
 	assert.NotNil(oauth2CredsFromKong)
 	assert.Equal(4, len(oauth2CredsFromKong))
 
 	// first page
-	page1, next, err :=
-		client.Oauth2Credentials.List(defaultCtx, &ListOpt{Size: 1})
+	page1, next, err := client.Oauth2Credentials.List(defaultCtx, &ListOpt{Size: 1})
 	assert.Nil(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
@@ -309,8 +305,7 @@ func TestOauth2CredentialListMethods(T *testing.T) {
 	assert.NotNil(page2)
 	assert.Equal(3, len(page2))
 
-	oauth2CredsForConsumer, next, err :=
-		client.Oauth2Credentials.ListForConsumer(defaultCtx, consumer1.ID, nil)
+	oauth2CredsForConsumer, next, err := client.Oauth2Credentials.ListForConsumer(defaultCtx, consumer1.ID, nil)
 	assert.Nil(err)
 	assert.Nil(next)
 	assert.NotNil(oauth2CredsForConsumer)

--- a/kong/plugin_service.go
+++ b/kong/plugin_service.go
@@ -44,7 +44,8 @@ type PluginService service
 
 // GetFullSchema retrieves the full schema of a plugin.
 func (s *PluginService) GetFullSchema(ctx context.Context,
-	pluginName *string) (Schema, error) {
+	pluginName *string,
+) (Schema, error) {
 	if isEmptyString(pluginName) {
 		return nil, fmt.Errorf("pluginName cannot be empty")
 	}
@@ -65,7 +66,8 @@ func (s *PluginService) GetFullSchema(ctx context.Context,
 //
 // Deprecated: Use GetPluginSchema instead
 func (s *PluginService) GetSchema(ctx context.Context,
-	pluginName *string) (Schema, error) {
+	pluginName *string,
+) (Schema, error) {
 	if isEmptyString(pluginName) {
 		return nil, fmt.Errorf("pluginName cannot be empty")
 	}
@@ -87,8 +89,8 @@ func (s *PluginService) GetSchema(ctx context.Context,
 // create a plugin in Kong, otherwise an ID
 // is auto-generated.
 func (s *PluginService) Create(ctx context.Context,
-	plugin *Plugin) (*Plugin, error) {
-
+	plugin *Plugin,
+) (*Plugin, error) {
 	queryPath := "/plugins"
 	method := "POST"
 	if plugin.ID != nil {
@@ -110,8 +112,8 @@ func (s *PluginService) Create(ctx context.Context,
 
 // Get fetches a Plugin in Kong.
 func (s *PluginService) Get(ctx context.Context,
-	usernameOrID *string) (*Plugin, error) {
-
+	usernameOrID *string,
+) (*Plugin, error) {
 	if isEmptyString(usernameOrID) {
 		return nil, fmt.Errorf("usernameOrID cannot be nil for Get operation")
 	}
@@ -132,8 +134,8 @@ func (s *PluginService) Get(ctx context.Context,
 
 // Update updates a Plugin in Kong
 func (s *PluginService) Update(ctx context.Context,
-	plugin *Plugin) (*Plugin, error) {
-
+	plugin *Plugin,
+) (*Plugin, error) {
 	if isEmptyString(plugin.ID) {
 		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
@@ -154,8 +156,8 @@ func (s *PluginService) Update(ctx context.Context,
 
 // Delete deletes a Plugin in Kong
 func (s *PluginService) Delete(ctx context.Context,
-	usernameOrID *string) error {
-
+	usernameOrID *string,
+) error {
 	if isEmptyString(usernameOrID) {
 		return fmt.Errorf("usernameOrID cannot be nil for Delete operation")
 	}
@@ -204,7 +206,8 @@ func (s *PluginService) Validate(ctx context.Context, plugin *Plugin) (bool, str
 // This is a helper method for listing all plugins
 // or plugins for specific entities.
 func (s *PluginService) listByPath(ctx context.Context,
-	path string, opt *ListOpt) ([]*Plugin, *ListOpt, error) {
+	path string, opt *ListOpt,
+) ([]*Plugin, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, path, opt)
 	if err != nil {
 		return nil, nil, err
@@ -231,7 +234,8 @@ func (s *PluginService) listByPath(ctx context.Context,
 // This method can take a while if there
 // a lot of Plugins present.
 func (s *PluginService) listAllByPath(ctx context.Context,
-	path string) ([]*Plugin, error) {
+	path string,
+) ([]*Plugin, error) {
 	var plugins, data []*Plugin
 	var err error
 	opt := &ListOpt{Size: pageSize}
@@ -249,7 +253,8 @@ func (s *PluginService) listAllByPath(ctx context.Context,
 // List fetches a list of Plugins in Kong.
 // opt can be used to control pagination.
 func (s *PluginService) List(ctx context.Context,
-	opt *ListOpt) ([]*Plugin, *ListOpt, error) {
+	opt *ListOpt,
+) ([]*Plugin, *ListOpt, error) {
 	return s.listByPath(ctx, "/plugins", opt)
 }
 
@@ -262,7 +267,8 @@ func (s *PluginService) ListAll(ctx context.Context) ([]*Plugin, error) {
 
 // ListAllForConsumer fetches all Plugins in Kong enabled for a consumer.
 func (s *PluginService) ListAllForConsumer(ctx context.Context,
-	consumerIDorName *string) ([]*Plugin, error) {
+	consumerIDorName *string,
+) ([]*Plugin, error) {
 	if isEmptyString(consumerIDorName) {
 		return nil, fmt.Errorf("consumerIDorName cannot be nil")
 	}
@@ -271,7 +277,8 @@ func (s *PluginService) ListAllForConsumer(ctx context.Context,
 
 // ListAllForService fetches all Plugins in Kong enabled for a service.
 func (s *PluginService) ListAllForService(ctx context.Context,
-	serviceIDorName *string) ([]*Plugin, error) {
+	serviceIDorName *string,
+) ([]*Plugin, error) {
 	if isEmptyString(serviceIDorName) {
 		return nil, fmt.Errorf("serviceIDorName cannot be nil")
 	}
@@ -280,7 +287,8 @@ func (s *PluginService) ListAllForService(ctx context.Context,
 
 // ListAllForRoute fetches all Plugins in Kong enabled for a service.
 func (s *PluginService) ListAllForRoute(ctx context.Context,
-	routeID *string) ([]*Plugin, error) {
+	routeID *string,
+) ([]*Plugin, error) {
 	if isEmptyString(routeID) {
 		return nil, fmt.Errorf("routeID cannot be nil")
 	}

--- a/kong/rbac_role_service.go
+++ b/kong/rbac_role_service.go
@@ -27,8 +27,8 @@ type RBACRoleService service
 
 // Create creates a Role in Kong.
 func (s *RBACRoleService) Create(ctx context.Context,
-	role *RBACRole) (*RBACRole, error) {
-
+	role *RBACRole,
+) (*RBACRole, error) {
 	if role == nil {
 		return nil, fmt.Errorf("cannot create a nil role")
 	}
@@ -54,8 +54,8 @@ func (s *RBACRoleService) Create(ctx context.Context,
 
 // Get fetches a Role in Kong.
 func (s *RBACRoleService) Get(ctx context.Context,
-	nameOrID *string) (*RBACRole, error) {
-
+	nameOrID *string,
+) (*RBACRole, error) {
 	if isEmptyString(nameOrID) {
 		return nil, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
@@ -76,8 +76,8 @@ func (s *RBACRoleService) Get(ctx context.Context,
 
 // Update updates a Role in Kong.
 func (s *RBACRoleService) Update(ctx context.Context,
-	role *RBACRole) (*RBACRole, error) {
-
+	role *RBACRole,
+) (*RBACRole, error) {
 	if role == nil {
 		return nil, fmt.Errorf("cannot update a nil Role")
 	}
@@ -102,8 +102,8 @@ func (s *RBACRoleService) Update(ctx context.Context,
 
 // Delete deletes a Role in Kong
 func (s *RBACRoleService) Delete(ctx context.Context,
-	RoleOrID *string) error {
-
+	RoleOrID *string,
+) error {
 	if isEmptyString(RoleOrID) {
 		return fmt.Errorf("RoleOrID cannot be nil for Delete operation")
 	}
@@ -120,8 +120,8 @@ func (s *RBACRoleService) Delete(ctx context.Context,
 
 // List fetches a list of all Roles in Kong.
 func (s *RBACRoleService) List(ctx context.Context,
-	opt *ListOpt) ([]*RBACRole, *ListOpt, error) {
-
+	opt *ListOpt,
+) ([]*RBACRole, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/rbac/roles/", opt)
 	if err != nil {
 		return nil, nil, err

--- a/kong/rbac_user_service.go
+++ b/kong/rbac_user_service.go
@@ -37,8 +37,8 @@ type RBACUserService service
 
 // Create creates an RBAC User in Kong.
 func (s *RBACUserService) Create(ctx context.Context,
-	user *RBACUser) (*RBACUser, error) {
-
+	user *RBACUser,
+) (*RBACUser, error) {
 	if user == nil {
 		return nil, fmt.Errorf("cannot create a nil user")
 	}
@@ -64,8 +64,8 @@ func (s *RBACUserService) Create(ctx context.Context,
 
 // Get fetches a User in Kong.
 func (s *RBACUserService) Get(ctx context.Context,
-	nameOrID *string) (*RBACUser, error) {
-
+	nameOrID *string,
+) (*RBACUser, error) {
 	if isEmptyString(nameOrID) {
 		return nil, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
@@ -86,8 +86,8 @@ func (s *RBACUserService) Get(ctx context.Context,
 
 // Update updates a User in Kong.
 func (s *RBACUserService) Update(ctx context.Context,
-	user *RBACUser) (*RBACUser, error) {
-
+	user *RBACUser,
+) (*RBACUser, error) {
 	if user == nil {
 		return nil, fmt.Errorf("cannot update a nil User")
 	}
@@ -112,8 +112,8 @@ func (s *RBACUserService) Update(ctx context.Context,
 
 // Delete deletes a User in Kong
 func (s *RBACUserService) Delete(ctx context.Context,
-	userOrID *string) error {
-
+	userOrID *string,
+) error {
 	if isEmptyString(userOrID) {
 		return fmt.Errorf("UserOrID cannot be nil for Delete operation")
 	}
@@ -131,8 +131,8 @@ func (s *RBACUserService) Delete(ctx context.Context,
 // List fetches a list of Users in Kong.
 // opt can be used to control pagination.
 func (s *RBACUserService) List(ctx context.Context,
-	opt *ListOpt) ([]*RBACUser, *ListOpt, error) {
-
+	opt *ListOpt,
+) ([]*RBACUser, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/rbac/users/", opt)
 	if err != nil {
 		return nil, nil, err
@@ -173,8 +173,8 @@ func (s *RBACUserService) ListAll(ctx context.Context) ([]*RBACUser, error) {
 
 // AddRoles adds a comma separated list of roles to a User.
 func (s *RBACUserService) AddRoles(ctx context.Context,
-	nameOrID *string, roles []*RBACRole) ([]*RBACRole, error) {
-
+	nameOrID *string, roles []*RBACRole,
+) ([]*RBACRole, error) {
 	var updateRoles struct {
 		NameOrID *string `json:"name_or_id,omitempty" yaml:"name_or_id,omitempty"`
 		Roles    *string `json:"roles,omitempty" yaml:"roles,omitempty"`
@@ -206,8 +206,8 @@ func (s *RBACUserService) AddRoles(ctx context.Context,
 
 // DeleteRoles deletes roles associated with a User
 func (s *RBACUserService) DeleteRoles(ctx context.Context,
-	nameOrID *string, roles []*RBACRole) error {
-
+	nameOrID *string, roles []*RBACRole,
+) error {
 	var updateRoles struct {
 		NameOrID *string `json:"name_or_id,omitempty" yaml:"name_or_id,omitempty"`
 		Roles    *string `json:"roles,omitempty" yaml:"roles,omitempty"`
@@ -237,8 +237,8 @@ func (s *RBACUserService) DeleteRoles(ctx context.Context,
 
 // ListRoles returns a slice of Kong RBAC roles associated with a User.
 func (s *RBACUserService) ListRoles(ctx context.Context,
-	nameOrID *string) ([]*RBACRole, error) {
-
+	nameOrID *string,
+) ([]*RBACRole, error) {
 	endpoint := fmt.Sprintf("/rbac/users/%v/roles", *nameOrID)
 	req, err := s.client.NewRequest("GET", endpoint, nil, nil)
 	if err != nil {
@@ -257,8 +257,8 @@ func (s *RBACUserService) ListRoles(ctx context.Context,
 
 // ListPermissions returns the entity and endpoint permissions associated with a user.
 func (s *RBACUserService) ListPermissions(ctx context.Context,
-	nameOrID *string) (*RBACPermissionsList, error) {
-
+	nameOrID *string,
+) (*RBACPermissionsList, error) {
 	endpoint := fmt.Sprintf("/rbac/users/%v/permissions", *nameOrID)
 	req, err := s.client.NewRequest("GET", endpoint, nil, nil)
 	if err != nil {

--- a/kong/request.go
+++ b/kong/request.go
@@ -11,7 +11,8 @@ import (
 
 // NewRequestRaw creates a request based on the inputs.
 func (c *Client) NewRequestRaw(method, baseURL string, endpoint string, qs interface{},
-	body interface{}) (*http.Request, error) {
+	body interface{},
+) (*http.Request, error) {
 	if endpoint == "" {
 		return nil, fmt.Errorf("endpoint can't be nil")
 	}
@@ -52,6 +53,7 @@ func (c *Client) NewRequestRaw(method, baseURL string, endpoint string, qs inter
 // client creation.
 // body is always marshaled into JSON.
 func (c *Client) NewRequest(method, endpoint string, qs interface{},
-	body interface{}) (*http.Request, error) {
+	body interface{},
+) (*http.Request, error) {
 	return c.NewRequestRaw(method, c.workspacedBaseURL(c.Workspace()), endpoint, qs, body)
 }

--- a/kong/route_service.go
+++ b/kong/route_service.go
@@ -34,8 +34,8 @@ type RouteService service
 // create a route in Kong, otherwise an ID
 // is auto-generated.
 func (s *RouteService) Create(ctx context.Context,
-	route *Route) (*Route, error) {
-
+	route *Route,
+) (*Route, error) {
 	if route == nil {
 		return nil, fmt.Errorf("cannot create a nil route")
 	}
@@ -61,7 +61,8 @@ func (s *RouteService) Create(ctx context.Context,
 
 // CreateInService creates a route associated with serviceID
 func (s *RouteService) CreateInService(ctx context.Context,
-	serviceID *string, route *Route) (*Route, error) {
+	serviceID *string, route *Route,
+) (*Route, error) {
 	if isEmptyString(serviceID) {
 		return nil, fmt.Errorf("serviceID cannot be nil for creating a route")
 	}
@@ -75,8 +76,8 @@ func (s *RouteService) CreateInService(ctx context.Context,
 
 // Get fetches a Route in Kong.
 func (s *RouteService) Get(ctx context.Context,
-	nameOrID *string) (*Route, error) {
-
+	nameOrID *string,
+) (*Route, error) {
 	if isEmptyString(nameOrID) {
 		return nil, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
@@ -97,8 +98,8 @@ func (s *RouteService) Get(ctx context.Context,
 
 // Update updates a Route in Kong
 func (s *RouteService) Update(ctx context.Context,
-	route *Route) (*Route, error) {
-
+	route *Route,
+) (*Route, error) {
 	if route == nil {
 		return nil, fmt.Errorf("cannot update a nil route")
 	}
@@ -140,7 +141,8 @@ func (s *RouteService) Delete(ctx context.Context, nameOrID *string) error {
 // List fetches a list of Routes in Kong.
 // opt can be used to control pagination.
 func (s *RouteService) List(ctx context.Context,
-	opt *ListOpt) ([]*Route, *ListOpt, error) {
+	opt *ListOpt,
+) ([]*Route, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/routes", opt)
 	if err != nil {
 		return nil, nil, err
@@ -183,7 +185,8 @@ func (s *RouteService) ListAll(ctx context.Context) ([]*Route, error) {
 // ListForService fetches a list of Routes in Kong associated with a service.
 // opt can be used to control pagination.
 func (s *RouteService) ListForService(ctx context.Context,
-	serviceNameOrID *string, opt *ListOpt) ([]*Route, *ListOpt, error) {
+	serviceNameOrID *string, opt *ListOpt,
+) ([]*Route, *ListOpt, error) {
 	data, next, err := s.client.list(ctx,
 		"/services/"+*serviceNameOrID+"/routes", opt)
 	if err != nil {

--- a/kong/service_service.go
+++ b/kong/service_service.go
@@ -32,8 +32,8 @@ type Svcservice service
 // create a service in Kong, otherwise an ID
 // is auto-generated.
 func (s *Svcservice) Create(ctx context.Context,
-	service *Service) (*Service, error) {
-
+	service *Service,
+) (*Service, error) {
 	if service == nil {
 		return nil, fmt.Errorf("cannot create a nil service")
 	}
@@ -59,8 +59,8 @@ func (s *Svcservice) Create(ctx context.Context,
 
 // Get fetches an Service in Kong.
 func (s *Svcservice) Get(ctx context.Context,
-	nameOrID *string) (*Service, error) {
-
+	nameOrID *string,
+) (*Service, error) {
 	if isEmptyString(nameOrID) {
 		return nil, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
@@ -81,8 +81,8 @@ func (s *Svcservice) Get(ctx context.Context,
 
 // GetForRoute fetches a Service associated with routeID in Kong.
 func (s *Svcservice) GetForRoute(ctx context.Context,
-	routeID *string) (*Service, error) {
-
+	routeID *string,
+) (*Service, error) {
 	if isEmptyString(routeID) {
 		return nil, fmt.Errorf("routeID cannot be nil for Get operation")
 	}
@@ -103,8 +103,8 @@ func (s *Svcservice) GetForRoute(ctx context.Context,
 
 // Update updates an Service in Kong
 func (s *Svcservice) Update(ctx context.Context,
-	service *Service) (*Service, error) {
-
+	service *Service,
+) (*Service, error) {
 	if service == nil {
 		return nil, fmt.Errorf("cannot update a nil service")
 	}
@@ -146,7 +146,8 @@ func (s *Svcservice) Delete(ctx context.Context, nameOrID *string) error {
 // List fetches a list of Services in Kong.
 // opt can be used to control pagination.
 func (s *Svcservice) List(ctx context.Context,
-	opt *ListOpt) ([]*Service, *ListOpt, error) {
+	opt *ListOpt,
+) ([]*Service, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/services", opt)
 	if err != nil {
 		return nil, nil, err

--- a/kong/sni_service.go
+++ b/kong/sni_service.go
@@ -53,8 +53,8 @@ func (s *SNIService) Create(ctx context.Context, sni *SNI) (*SNI, error) {
 
 // Get fetches a SNI in Kong.
 func (s *SNIService) Get(ctx context.Context,
-	usernameOrID *string) (*SNI, error) {
-
+	usernameOrID *string,
+) (*SNI, error) {
 	if isEmptyString(usernameOrID) {
 		return nil, fmt.Errorf(
 			"usernameOrID cannot be nil for Get operation")
@@ -113,7 +113,8 @@ func (s *SNIService) Delete(ctx context.Context, usernameOrID *string) error {
 // List fetches a list of SNIs in Kong.
 // opt can be used to control pagination.
 func (s *SNIService) List(ctx context.Context,
-	opt *ListOpt) ([]*SNI, *ListOpt, error) {
+	opt *ListOpt,
+) ([]*SNI, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/snis", opt)
 	if err != nil {
 		return nil, nil, err
@@ -139,7 +140,8 @@ func (s *SNIService) List(ctx context.Context,
 // in Kong associated with certificateID.
 // opt can be used to control pagination.
 func (s *SNIService) ListForCertificate(ctx context.Context,
-	certificateID *string, opt *ListOpt) ([]*SNI, *ListOpt, error) {
+	certificateID *string, opt *ListOpt,
+) ([]*SNI, *ListOpt, error) {
 	data, next, err := s.client.list(ctx,
 		"/certificates/"+*certificateID+"/snis", opt)
 	if err != nil {

--- a/kong/target_service.go
+++ b/kong/target_service.go
@@ -35,7 +35,8 @@ type TargetService service
 // create a target in Kong, otherwise an ID
 // is auto-generated.
 func (s *TargetService) Create(ctx context.Context,
-	upstreamNameOrID *string, target *Target) (*Target, error) {
+	upstreamNameOrID *string, target *Target,
+) (*Target, error) {
 	if isEmptyString(upstreamNameOrID) {
 		return nil, fmt.Errorf("upstreamNameOrID can not be nil")
 	}
@@ -60,7 +61,8 @@ func (s *TargetService) Create(ctx context.Context,
 
 // Delete deletes a Target in Kong
 func (s *TargetService) Delete(ctx context.Context,
-	upstreamNameOrID *string, targetOrID *string) error {
+	upstreamNameOrID *string, targetOrID *string,
+) error {
 	if isEmptyString(upstreamNameOrID) {
 		return fmt.Errorf("upstreamNameOrID cannot be nil for Get operation")
 	}
@@ -82,7 +84,8 @@ func (s *TargetService) Delete(ctx context.Context,
 // List fetches a list of Targets in Kong.
 // opt can be used to control pagination.
 func (s *TargetService) List(ctx context.Context,
-	upstreamNameOrID *string, opt *ListOpt) ([]*Target, *ListOpt, error) {
+	upstreamNameOrID *string, opt *ListOpt,
+) ([]*Target, *ListOpt, error) {
 	if isEmptyString(upstreamNameOrID) {
 		return nil, nil, fmt.Errorf(
 			"upstreamNameOrID cannot be nil for Get operation")
@@ -111,7 +114,8 @@ func (s *TargetService) List(ctx context.Context,
 
 // ListAll fetches all Targets in Kong for an upstream.
 func (s *TargetService) ListAll(ctx context.Context,
-	upstreamNameOrID *string) ([]*Target, error) {
+	upstreamNameOrID *string,
+) ([]*Target, error) {
 	var targets, data []*Target
 	var err error
 	opt := &ListOpt{Size: pageSize}
@@ -129,7 +133,8 @@ func (s *TargetService) ListAll(ctx context.Context,
 // MarkHealthy marks target belonging to upstreamNameOrID as healthy in
 // Kong's load balancer.
 func (s *TargetService) MarkHealthy(ctx context.Context,
-	upstreamNameOrID *string, target *Target) error {
+	upstreamNameOrID *string, target *Target,
+) error {
 	if target == nil {
 		return fmt.Errorf("cannot set health status for a nil target")
 	}
@@ -161,7 +166,8 @@ func (s *TargetService) MarkHealthy(ctx context.Context,
 // MarkUnhealthy marks target belonging to upstreamNameOrID as unhealthy in
 // Kong's load balancer.
 func (s *TargetService) MarkUnhealthy(ctx context.Context,
-	upstreamNameOrID *string, target *Target) error {
+	upstreamNameOrID *string, target *Target,
+) error {
 	if target == nil {
 		return fmt.Errorf("cannot set health status for a nil target")
 	}

--- a/kong/upstream_service.go
+++ b/kong/upstream_service.go
@@ -30,8 +30,8 @@ type UpstreamService service
 // create a upstream in Kong, otherwise an ID
 // is auto-generated.
 func (s *UpstreamService) Create(ctx context.Context,
-	upstream *Upstream) (*Upstream, error) {
-
+	upstream *Upstream,
+) (*Upstream, error) {
 	queryPath := "/upstreams"
 	method := "POST"
 	if upstream.ID != nil {
@@ -53,8 +53,8 @@ func (s *UpstreamService) Create(ctx context.Context,
 
 // Get fetches a Upstream in Kong.
 func (s *UpstreamService) Get(ctx context.Context,
-	upstreamNameOrID *string) (*Upstream, error) {
-
+	upstreamNameOrID *string,
+) (*Upstream, error) {
 	if isEmptyString(upstreamNameOrID) {
 		return nil, fmt.Errorf("upstreamNameOrID cannot" +
 			" be nil for Get operation")
@@ -76,8 +76,8 @@ func (s *UpstreamService) Get(ctx context.Context,
 
 // Update updates a Upstream in Kong
 func (s *UpstreamService) Update(ctx context.Context,
-	upstream *Upstream) (*Upstream, error) {
-
+	upstream *Upstream,
+) (*Upstream, error) {
 	if isEmptyString(upstream.ID) {
 		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
@@ -98,8 +98,8 @@ func (s *UpstreamService) Update(ctx context.Context,
 
 // Delete deletes a Upstream in Kong
 func (s *UpstreamService) Delete(ctx context.Context,
-	upstreamNameOrID *string) error {
-
+	upstreamNameOrID *string,
+) error {
 	if isEmptyString(upstreamNameOrID) {
 		return fmt.Errorf("upstreamNameOrID cannot be nil for Delete operation")
 	}
@@ -117,7 +117,8 @@ func (s *UpstreamService) Delete(ctx context.Context,
 // List fetches a list of Upstreams in Kong.
 // opt can be used to control pagination.
 func (s *UpstreamService) List(ctx context.Context,
-	opt *ListOpt) ([]*Upstream, *ListOpt, error) {
+	opt *ListOpt,
+) ([]*Upstream, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/upstreams", opt)
 	if err != nil {
 		return nil, nil, err

--- a/kong/utils.go
+++ b/kong/utils.go
@@ -106,7 +106,8 @@ func requestWithHeaders(req *http.Request, headers http.Header) *http.Request {
 // HTTPClientWithHeaders returns a client which injects headers
 // before sending any request.
 func HTTPClientWithHeaders(client *http.Client,
-	headers http.Header) *http.Client {
+	headers http.Header,
+) *http.Client {
 	var res *http.Client
 	if client == nil {
 		defaultTransport := http.DefaultTransport.(*http.Transport)

--- a/kong/workspace_service.go
+++ b/kong/workspace_service.go
@@ -46,7 +46,8 @@ type WorkspaceService service
 
 // Exists checks the exitence of the Workspace in Kong.
 func (s *WorkspaceService) Exists(ctx context.Context,
-	nameOrID *string) (bool, error) {
+	nameOrID *string,
+) (bool, error) {
 	if isEmptyString(nameOrID) {
 		return false, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
@@ -57,7 +58,8 @@ func (s *WorkspaceService) Exists(ctx context.Context,
 
 // ExistsByName checks the exitence of the Workspace using its name in Kong.
 func (s *WorkspaceService) ExistsByName(ctx context.Context,
-	name *string) (bool, error) {
+	name *string,
+) (bool, error) {
 	if isEmptyString(name) {
 		return false, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
@@ -68,8 +70,8 @@ func (s *WorkspaceService) ExistsByName(ctx context.Context,
 
 // Create creates a Workspace in Kong.
 func (s *WorkspaceService) Create(ctx context.Context,
-	workspace *Workspace) (*Workspace, error) {
-
+	workspace *Workspace,
+) (*Workspace, error) {
 	if workspace == nil {
 		return nil, fmt.Errorf("cannot create a nil workspace")
 	}
@@ -95,8 +97,8 @@ func (s *WorkspaceService) Create(ctx context.Context,
 
 // Get fetches a Workspace in Kong.
 func (s *WorkspaceService) Get(ctx context.Context,
-	nameOrID *string) (*Workspace, error) {
-
+	nameOrID *string,
+) (*Workspace, error) {
 	if isEmptyString(nameOrID) {
 		return nil, fmt.Errorf("nameOrID cannot be nil for Get operation")
 	}
@@ -118,8 +120,8 @@ func (s *WorkspaceService) Get(ctx context.Context,
 // Update updates a Workspace in Kong. Only updates to the
 // `comment` field are supported. To rename a workspace use Create.
 func (s *WorkspaceService) Update(ctx context.Context,
-	workspace *Workspace) (*Workspace, error) {
-
+	workspace *Workspace,
+) (*Workspace, error) {
 	if workspace == nil {
 		return nil, fmt.Errorf("cannot update a nil Workspace")
 	}
@@ -144,8 +146,8 @@ func (s *WorkspaceService) Update(ctx context.Context,
 
 // Delete deletes a Workspace in Kong
 func (s *WorkspaceService) Delete(ctx context.Context,
-	WorkspaceOrID *string) error {
-
+	WorkspaceOrID *string,
+) error {
 	if isEmptyString(WorkspaceOrID) {
 		return fmt.Errorf("WorkspaceOrID cannot be nil for Delete operation")
 	}
@@ -162,8 +164,8 @@ func (s *WorkspaceService) Delete(ctx context.Context,
 
 // List fetches a list of all Workspaces in Kong.
 func (s *WorkspaceService) List(ctx context.Context,
-	opt *ListOpt) ([]*Workspace, *ListOpt, error) {
-
+	opt *ListOpt,
+) ([]*Workspace, *ListOpt, error) {
 	data, next, err := s.client.list(ctx, "/workspaces/", opt)
 	if err != nil {
 		return nil, nil, err
@@ -208,8 +210,8 @@ func (s *WorkspaceService) ListAll(ctx context.Context) ([]*Workspace, error) {
 //
 // Deprecated: Kong 2.x removed this endpoint.
 func (s *WorkspaceService) AddEntities(ctx context.Context,
-	workspaceNameOrID *string, entityIds *string) (*[]map[string]interface{}, error) {
-
+	workspaceNameOrID *string, entityIds *string,
+) (*[]map[string]interface{}, error) {
 	if entityIds == nil {
 		return nil, fmt.Errorf("entityIds cannot be nil")
 	}
@@ -239,8 +241,8 @@ func (s *WorkspaceService) AddEntities(ctx context.Context,
 //
 // Deprecated: Kong 2.x removed this endpoint.
 func (s *WorkspaceService) DeleteEntities(ctx context.Context,
-	workspaceNameOrID *string, entityIds *string) error {
-
+	workspaceNameOrID *string, entityIds *string,
+) error {
 	if entityIds == nil {
 		return fmt.Errorf("entityIds cannot be nil")
 	}
@@ -267,8 +269,8 @@ func (s *WorkspaceService) DeleteEntities(ctx context.Context,
 //
 // Deprecated: Kong 2.x removed this endpoint.
 func (s *WorkspaceService) ListEntities(ctx context.Context,
-	workspaceNameOrID *string) ([]*WorkspaceEntity, error) {
-
+	workspaceNameOrID *string,
+) ([]*WorkspaceEntity, error) {
 	endpoint := fmt.Sprintf("/workspaces/%v/entities", *workspaceNameOrID)
 
 	data, _, err := s.client.list(ctx, endpoint, nil)


### PR DESCRIPTION
Update to Go 1.18 and tidy mod.

If we're lucky, this will fix the golangci-lint errors we hit with the latest version.

Edit: it did, after some further changes to the action version, but also added a bunch of new formatting requirements, so an additional commit to run everything through `gofumpt`.