### PR TITLE
chore: use assert.NoError instead of assert.NotNil for pretty errors in tests output

### DIFF
--- a/kong/acl_service_test.go
+++ b/kong/acl_service_test.go
@@ -11,7 +11,7 @@ func TestACLGroupCreate(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	acl, err := client.ACLs.Create(defaultCtx,
@@ -36,24 +36,24 @@ func TestACLGroupCreate(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	acl = &ACLGroup{
 		Group: String("my-group"),
 	}
 	createdACL, err := client.ACLs.Create(defaultCtx, consumer.ID, acl)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdACL)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestACLGroupCreateWithID(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -68,24 +68,24 @@ func TestACLGroupCreateWithID(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdACL, err := client.ACLs.Create(defaultCtx, consumer.ID, acl)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdACL)
 
 	assert.Equal(uuid, *createdACL.ID)
 	assert.Equal("my-group", *createdACL.Group)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestACLGroupGet(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -100,19 +100,19 @@ func TestACLGroupGet(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdACL, err := client.ACLs.Create(defaultCtx, consumer.ID, acl)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdACL)
 
 	aclGroup, err := client.ACLs.Get(defaultCtx, consumer.ID, acl.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("my-group", *aclGroup.Group)
 
 	aclGroup, err = client.ACLs.Get(defaultCtx, consumer.ID, acl.Group)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("my-group", *aclGroup.Group)
 
 	aclGroup, err = client.ACLs.Get(defaultCtx, consumer.ID,
@@ -124,14 +124,14 @@ func TestACLGroupGet(T *testing.T) {
 	assert.Nil(aclGroup)
 	assert.NotNil(err)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestACLGroupUpdate(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -146,31 +146,31 @@ func TestACLGroupUpdate(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdACL, err := client.ACLs.Create(defaultCtx, consumer.ID, acl)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdACL)
 
 	aclGroup, err := client.ACLs.Get(defaultCtx, consumer.ID, acl.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("my-group", *aclGroup.Group)
 
 	acl.Group = String("my-new-group")
 	updatedACLGroup, err := client.ACLs.Update(defaultCtx, consumer.ID, acl)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(updatedACLGroup)
 	assert.Equal("my-new-group", *updatedACLGroup.Group)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestACLGroupDelete(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -185,28 +185,28 @@ func TestACLGroupDelete(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdACL, err := client.ACLs.Create(defaultCtx, consumer.ID, acl)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdACL)
 
 	err = client.ACLs.Delete(defaultCtx, consumer.ID, acl.Group)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	aclGroup, err := client.ACLs.Get(defaultCtx, consumer.ID, acl.ID)
 	assert.NotNil(err)
 	assert.Nil(aclGroup)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestACLGroupListMethods(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// consumer for the ACLGroup
@@ -215,7 +215,7 @@ func TestACLGroupListMethods(T *testing.T) {
 	}
 
 	consumer1, err = client.Consumers.Create(defaultCtx, consumer1)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer1)
 
 	consumer2 := &Consumer{
@@ -223,7 +223,7 @@ func TestACLGroupListMethods(T *testing.T) {
 	}
 
 	consumer2, err = client.Consumers.Create(defaultCtx, consumer2)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer2)
 
 	// fixtures
@@ -250,20 +250,20 @@ func TestACLGroupListMethods(T *testing.T) {
 	for i := 0; i < len(aclGroups); i++ {
 		acl, err := client.ACLs.Create(defaultCtx,
 			aclGroups[i].Consumer.ID, aclGroups[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(acl)
 		aclGroups[i] = acl
 	}
 
 	aclGroupsFromKong, next, err := client.ACLs.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(aclGroupsFromKong)
 	assert.Equal(4, len(aclGroupsFromKong))
 
 	// first page
 	page1, next, err := client.ACLs.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -271,23 +271,23 @@ func TestACLGroupListMethods(T *testing.T) {
 	// last page
 	next.Size = 3
 	page2, next, err := client.ACLs.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(3, len(page2))
 
 	aclGroupsForConsumer, next, err := client.ACLs.ListForConsumer(defaultCtx,
 		consumer1.ID, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(aclGroupsForConsumer)
 	assert.Equal(2, len(aclGroupsForConsumer))
 
 	aclGroups, err = client.ACLs.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(aclGroups)
 	assert.Equal(4, len(aclGroups))
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer1.ID))
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer2.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer1.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer2.ID))
 }

--- a/kong/admin_service_test.go
+++ b/kong/admin_service_test.go
@@ -15,7 +15,7 @@ func TestAdminService(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	admin := &Admin{
@@ -26,21 +26,21 @@ func TestAdminService(T *testing.T) {
 	}
 
 	createdAdmin, err := client.Admins.Create(defaultCtx, admin)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdAdmin)
 
 	admin, err = client.Admins.Get(defaultCtx, createdAdmin.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(admin)
 
 	admin.CustomID = String("admin321")
 	admin, err = client.Admins.Update(defaultCtx, admin)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(admin)
 	assert.Equal("admin321", *admin.CustomID)
 
 	err = client.Admins.Delete(defaultCtx, createdAdmin.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestAdminServiceWorkspace(T *testing.T) {
@@ -48,7 +48,7 @@ func TestAdminServiceWorkspace(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	workspace := Workspace{
@@ -56,11 +56,11 @@ func TestAdminServiceWorkspace(T *testing.T) {
 	}
 
 	createdWorkspace, err := client.Workspaces.Create(defaultCtx, &workspace)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdWorkspace)
 
 	workspaceClient, err := NewTestClient(String(path.Join(defaultBaseURL, *createdWorkspace.Name)), nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(workspaceClient)
 
 	admin := &Admin{
@@ -71,24 +71,24 @@ func TestAdminServiceWorkspace(T *testing.T) {
 	}
 
 	createdAdmin, err := client.Admins.Create(defaultCtx, admin)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdAdmin)
 
 	admin, err = client.Admins.Get(defaultCtx, createdAdmin.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(admin)
 
 	admin.CustomID = String("admin321")
 	admin, err = client.Admins.Update(defaultCtx, admin)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(admin)
 	assert.Equal("admin321", *admin.CustomID)
 
 	err = client.Admins.Delete(defaultCtx, createdAdmin.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	err = client.Workspaces.Delete(defaultCtx, createdWorkspace.Name)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestAdminServiceList(T *testing.T) {
@@ -96,7 +96,7 @@ func TestAdminServiceList(T *testing.T) {
 	client, err := NewTestClient(nil, nil)
 	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{})
 
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	admin1 := &Admin{
@@ -113,19 +113,19 @@ func TestAdminServiceList(T *testing.T) {
 	}
 
 	createdAdmin1, err := client.Admins.Create(defaultCtx, admin1)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdAdmin1)
 	createdAdmin2, err := client.Admins.Create(defaultCtx, admin2)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdAdmin2)
 
 	admins, _, err := client.Admins.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(admins)
 
 	// Check if RBAC is enabled
 	res, err := client.Root(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	rbac := res["configuration"].(map[string]interface{})["rbac"].(string)
 	expectedAdmins := 3
 	if rbac == "off" {
@@ -134,9 +134,9 @@ func TestAdminServiceList(T *testing.T) {
 	assert.Equal(expectedAdmins, len(admins))
 
 	err = client.Admins.Delete(defaultCtx, createdAdmin1.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = client.Admins.Delete(defaultCtx, createdAdmin2.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 // XXX:
@@ -146,7 +146,7 @@ func TestAdminServiceRegisterCredentials(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	admin := &Admin{
@@ -157,23 +157,23 @@ func TestAdminServiceRegisterCredentials(T *testing.T) {
 	}
 
 	admin, err = client.Admins.Invite(defaultCtx, admin)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(admin)
 
 	// Generate a new registration URL for the Admin
 	admin, err = client.Admins.GenerateRegisterURL(defaultCtx, admin.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(admin)
 
 	admin.Password = String("bar")
 
 	err = client.Admins.RegisterCredentials(defaultCtx, admin)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	admin, err = client.Admins.Get(defaultCtx, admin.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(admin)
 
 	err = client.Admins.Delete(defaultCtx, admin.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }

--- a/kong/basic_auth_service_test.go
+++ b/kong/basic_auth_service_test.go
@@ -11,7 +11,7 @@ func TestBasicAuthCreate(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	basicAuth, err := client.BasicAuths.Create(defaultCtx,
@@ -36,7 +36,7 @@ func TestBasicAuthCreate(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	// no username is specified
@@ -52,18 +52,18 @@ func TestBasicAuthCreate(T *testing.T) {
 	}
 	basicAuth, err = client.BasicAuths.Create(defaultCtx,
 		consumer.ID, basicAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(basicAuth)
 	assert.NotEmpty(*basicAuth.Password)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestBasicAuthCreateWithID(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -79,12 +79,12 @@ func TestBasicAuthCreateWithID(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdBasicAuth, err := client.BasicAuths.Create(defaultCtx, consumer.ID,
 		basicAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdBasicAuth)
 
 	assert.Equal(uuid, *createdBasicAuth.ID)
@@ -92,14 +92,14 @@ func TestBasicAuthCreateWithID(T *testing.T) {
 	// password is hashed
 	assert.NotEqual("my-password", *createdBasicAuth.Password)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestBasicAuthGet(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -115,22 +115,22 @@ func TestBasicAuthGet(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdBasicAuth, err := client.BasicAuths.Create(defaultCtx,
 		consumer.ID, basicAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdBasicAuth)
 
 	basicAuth, err = client.BasicAuths.Get(defaultCtx,
 		consumer.ID, basicAuth.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("my-username", *basicAuth.Username)
 
 	basicAuth, err = client.BasicAuths.Get(defaultCtx, consumer.ID,
 		basicAuth.Username)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("my-username", *basicAuth.Username)
 
 	basicAuth, err = client.BasicAuths.Get(defaultCtx, consumer.ID,
@@ -142,14 +142,14 @@ func TestBasicAuthGet(T *testing.T) {
 	assert.Nil(basicAuth)
 	assert.NotNil(err)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestBasicAuthUpdate(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -165,36 +165,36 @@ func TestBasicAuthUpdate(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdBasicAuth, err := client.BasicAuths.Create(defaultCtx,
 		consumer.ID, basicAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdBasicAuth)
 
 	basicAuth, err = client.BasicAuths.Get(defaultCtx,
 		consumer.ID, basicAuth.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("my-username", *basicAuth.Username)
 
 	basicAuth.Username = String("my-new-username")
 	basicAuth.Password = String("my-new-password")
 	updatedBasicAuth, err := client.BasicAuths.Update(defaultCtx,
 		consumer.ID, basicAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(updatedBasicAuth)
 	assert.NotEqual("my-new-password", *updatedBasicAuth.Password)
 	assert.Equal("my-new-username", *updatedBasicAuth.Username)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestBasicAuthDelete(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -210,23 +210,23 @@ func TestBasicAuthDelete(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdBasicAuth, err := client.BasicAuths.Create(defaultCtx,
 		consumer.ID, basicAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdBasicAuth)
 
 	err = client.BasicAuths.Delete(defaultCtx, consumer.ID, basicAuth.Username)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	basicAuth, err = client.BasicAuths.Get(defaultCtx,
 		consumer.ID, basicAuth.Username)
 	assert.NotNil(err)
 	assert.Nil(basicAuth)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestBasicAuthListMethods(T *testing.T) {
@@ -239,7 +239,7 @@ func TestBasicAuthListMethods(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// consumer for the basic-auth:
@@ -248,7 +248,7 @@ func TestBasicAuthListMethods(T *testing.T) {
 	}
 
 	consumer1, err = client.Consumers.Create(defaultCtx, consumer1)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer1)
 
 	consumer2 := &Consumer{
@@ -256,7 +256,7 @@ func TestBasicAuthListMethods(T *testing.T) {
 	}
 
 	consumer2, err = client.Consumers.Create(defaultCtx, consumer2)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer2)
 
 	// fixtures
@@ -287,20 +287,20 @@ func TestBasicAuthListMethods(T *testing.T) {
 	for i := 0; i < len(basicAuths); i++ {
 		basicAuth, err := client.BasicAuths.Create(defaultCtx,
 			basicAuths[i].Consumer.ID, basicAuths[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(basicAuth)
 		basicAuths[i] = basicAuth
 	}
 
 	basicAuthsFromKong, next, err := client.BasicAuths.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(basicAuthsFromKong)
 	assert.Equal(4, len(basicAuthsFromKong))
 
 	// first page
 	page1, next, err := client.BasicAuths.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -308,22 +308,22 @@ func TestBasicAuthListMethods(T *testing.T) {
 	// last page
 	next.Size = 4
 	page2, next, err := client.BasicAuths.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(3, len(page2))
 
 	basicAuthsForConsumer, next, err := client.BasicAuths.ListForConsumer(defaultCtx, consumer1.ID, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(basicAuthsForConsumer)
 	assert.Equal(2, len(basicAuthsForConsumer))
 
 	basicAuths, err = client.BasicAuths.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(basicAuths)
 	assert.Equal(4, len(basicAuths))
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer1.ID))
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer2.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer1.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer2.ID))
 }

--- a/kong/ca_certificate_service_test.go
+++ b/kong/ca_certificate_service_test.go
@@ -100,7 +100,7 @@ func TestCACertificatesService(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	certificate := &CACertificate{
@@ -115,21 +115,21 @@ func TestCACertificatesService(T *testing.T) {
 	certificate.Cert = String(caCert1)
 	createdCertificate, err = client.CACertificates.Create(defaultCtx,
 		certificate)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdCertificate)
 
 	certificate, err = client.CACertificates.Get(defaultCtx,
 		createdCertificate.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(certificate)
 
 	certificate.Cert = String(caCert2)
 	certificate, err = client.CACertificates.Update(defaultCtx, certificate)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(certificate)
 
 	err = client.CACertificates.Delete(defaultCtx, createdCertificate.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// ID can be specified
 	id := uuid.NewString()
@@ -140,12 +140,12 @@ func TestCACertificatesService(T *testing.T) {
 
 	createdCertificate, err = client.CACertificates.Create(defaultCtx,
 		certificate)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdCertificate)
 	assert.Equal(id, *createdCertificate.ID)
 
 	err = client.CACertificates.Delete(defaultCtx, createdCertificate.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestCACertificateWithTags(T *testing.T) {
@@ -153,7 +153,7 @@ func TestCACertificateWithTags(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	certificate := &CACertificate{
@@ -163,12 +163,12 @@ func TestCACertificateWithTags(T *testing.T) {
 
 	createdCertificate, err := client.CACertificates.Create(defaultCtx,
 		certificate)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdCertificate)
 	assert.Equal(StringSlice("tag1", "tag2"), createdCertificate.Tags)
 
 	err = client.CACertificates.Delete(defaultCtx, createdCertificate.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestCACertificateListEndpoint(T *testing.T) {
@@ -176,7 +176,7 @@ func TestCACertificateListEndpoint(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// fixtures
@@ -196,14 +196,14 @@ func TestCACertificateListEndpoint(T *testing.T) {
 	for i := 0; i < len(certificates); i++ {
 		certificate, err := client.CACertificates.Create(defaultCtx,
 			certificates[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(certificate)
 		certificates[i] = certificate
 	}
 
 	certificatesFromKong, next, err := client.CACertificates.List(defaultCtx, nil)
 
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(certificatesFromKong)
 	assert.Equal(3, len(certificatesFromKong))
@@ -218,7 +218,7 @@ func TestCACertificateListEndpoint(T *testing.T) {
 	page1, next, err := client.CACertificates.List(defaultCtx, &ListOpt{
 		Size: 1,
 	})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -227,7 +227,7 @@ func TestCACertificateListEndpoint(T *testing.T) {
 	// last page
 	next.Size = 2
 	page2, next, err := client.CACertificates.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(2, len(page2))
@@ -236,12 +236,12 @@ func TestCACertificateListEndpoint(T *testing.T) {
 	assert.True(compareCACertificates(certificates, certificatesFromKong))
 
 	certificates, err = client.CACertificates.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(certificates)
 	assert.Equal(3, len(certificates))
 
 	for i := 0; i < len(certificates); i++ {
-		assert.Nil(client.CACertificates.Delete(defaultCtx, certificates[i].ID))
+		assert.NoError(client.CACertificates.Delete(defaultCtx, certificates[i].ID))
 	}
 }
 

--- a/kong/certificate_service_test.go
+++ b/kong/certificate_service_test.go
@@ -256,7 +256,7 @@ func TestCertificatesService(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	certificate := &Certificate{
@@ -272,23 +272,23 @@ func TestCertificatesService(T *testing.T) {
 	certificate.Key = String(key1)
 	certificate.Cert = String(cert1)
 	createdCertificate, err = client.Certificates.Create(defaultCtx, certificate)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdCertificate)
 
 	certificate, err = client.Certificates.Get(defaultCtx, createdCertificate.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(certificate)
 	assert.Equal(2, len(createdCertificate.SNIs))
 
 	certificate.Key = String(key2)
 	certificate.Cert = String(cert2)
 	certificate, err = client.Certificates.Update(defaultCtx, certificate)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(certificate)
 	assert.Equal(key2, *certificate.Key)
 
 	err = client.Certificates.Delete(defaultCtx, createdCertificate.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// ID can be specified
 	id := uuid.NewString()
@@ -299,12 +299,12 @@ func TestCertificatesService(T *testing.T) {
 	}
 
 	createdCertificate, err = client.Certificates.Create(defaultCtx, certificate)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdCertificate)
 	assert.Equal(id, *createdCertificate.ID)
 
 	err = client.Certificates.Delete(defaultCtx, createdCertificate.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestCertificateWithTags(T *testing.T) {
@@ -312,7 +312,7 @@ func TestCertificateWithTags(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	certificate := &Certificate{
@@ -322,19 +322,19 @@ func TestCertificateWithTags(T *testing.T) {
 	}
 
 	createdCertificate, err := client.Certificates.Create(defaultCtx, certificate)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdCertificate)
 	assert.Equal(StringSlice("tag1", "tag2"), createdCertificate.Tags)
 
 	err = client.Certificates.Delete(defaultCtx, createdCertificate.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestCertificateListEndpoint(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// fixtures
@@ -356,13 +356,13 @@ func TestCertificateListEndpoint(T *testing.T) {
 	// create fixturs
 	for i := 0; i < len(certificates); i++ {
 		certificate, err := client.Certificates.Create(defaultCtx, certificates[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(certificate)
 		certificates[i] = certificate
 	}
 
 	certificatesFromKong, next, err := client.Certificates.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(certificatesFromKong)
 	assert.Equal(3, len(certificatesFromKong))
@@ -375,7 +375,7 @@ func TestCertificateListEndpoint(T *testing.T) {
 
 	// first page
 	page1, next, err := client.Certificates.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -384,7 +384,7 @@ func TestCertificateListEndpoint(T *testing.T) {
 	// last page
 	next.Size = 2
 	page2, next, err := client.Certificates.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(2, len(page2))
@@ -393,12 +393,12 @@ func TestCertificateListEndpoint(T *testing.T) {
 	assert.True(compareCertificates(certificates, certificatesFromKong))
 
 	certificates, err = client.Certificates.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(certificates)
 	assert.Equal(3, len(certificates))
 
 	for i := 0; i < len(certificates); i++ {
-		assert.Nil(client.Certificates.Delete(defaultCtx, certificates[i].ID))
+		assert.NoError(client.Certificates.Delete(defaultCtx, certificates[i].ID))
 	}
 }
 

--- a/kong/client_test.go
+++ b/kong/client_test.go
@@ -21,11 +21,11 @@ func TestKongStatus(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	status, err := client.Status(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(status)
 }
 
@@ -33,11 +33,11 @@ func TestRoot(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	root, err := client.Root(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(root)
 	assert.NotNil(root["version"])
 }
@@ -50,7 +50,7 @@ func TestRootJSON(T *testing.T) {
 	assert.NotNil(client)
 
 	root, err := client.RootJSON(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotEmpty(root)
 	assert.Contains(string(root), `"version"`)
 }
@@ -59,11 +59,11 @@ func TestDo(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	req, err := client.NewRequest("GET", "/does-not-exist", nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(req)
 	resp, err := client.Do(context.Background(), req, nil)
 	assert.True(IsNotFoundErr(err))
@@ -71,13 +71,13 @@ func TestDo(T *testing.T) {
 	assert.Equal(404, resp.StatusCode)
 
 	req, err = client.NewRequest("POST", "/", nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(req)
 	resp, err = client.Do(context.Background(), req, nil)
 	assert.NotNil(err)
 	assert.NotNil(resp)
 	body, err := ioutil.ReadAll(resp.Body)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Empty(body)
 	assert.Equal(405, resp.StatusCode)
 }
@@ -93,11 +93,11 @@ func TestRunWhenEnterprise(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	root, err := client.Root(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(root)
 	v := root["version"].(string)
 	assert.Contains(v, "enterprise")
@@ -145,28 +145,28 @@ func TestTestWorkspace(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	wsName := "default"
 
 	origWorkspace, err := client.Workspaces.Get(defaultCtx, String(wsName))
-	assert.Nil(err)
+	assert.NoError(err)
 
 	testWs, err := NewTestWorkspace(client, wsName)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal(wsName, *testWs.workspace.Name)
 
 	err = testWs.UpdateConfig(map[string]interface{}{"portal": true, "portal_auto_approve": true})
-	assert.Nil(err)
+	assert.NoError(err)
 	currWorkspace, err := client.Workspaces.Get(defaultCtx, String(wsName))
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal(currWorkspace.Config["portal"], true)
 	assert.Equal(currWorkspace.Config["portal_auto_approve"], true)
 
 	err = testWs.Reset()
-	assert.Nil(err)
+	assert.NoError(err)
 	currWorkspace, err = client.Workspaces.Get(defaultCtx, String(wsName))
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal(currWorkspace.Config, origWorkspace.Config)
 }

--- a/kong/consumer_service_test.go
+++ b/kong/consumer_service_test.go
@@ -13,7 +13,7 @@ func TestConsumersService(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	consumer := &Consumer{
@@ -22,11 +22,11 @@ func TestConsumersService(T *testing.T) {
 	}
 
 	createdConsumer, err := client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdConsumer)
 
 	consumer, err = client.Consumers.Get(defaultCtx, createdConsumer.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	consumer, err = client.Consumers.GetByCustomID(defaultCtx,
@@ -36,17 +36,17 @@ func TestConsumersService(T *testing.T) {
 
 	consumer, err = client.Consumers.GetByCustomID(defaultCtx,
 		String("custom_id_foo"))
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	consumer.Username = String("bar")
 	consumer, err = client.Consumers.Update(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 	assert.Equal("bar", *consumer.Username)
 
 	err = client.Consumers.Delete(defaultCtx, createdConsumer.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// ID can be specified
 	id := uuid.NewString()
@@ -56,12 +56,12 @@ func TestConsumersService(T *testing.T) {
 	}
 
 	createdConsumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdConsumer)
 	assert.Equal(id, *createdConsumer.ID)
 
 	err = client.Consumers.Delete(defaultCtx, createdConsumer.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestConsumerWithTags(T *testing.T) {
@@ -69,7 +69,7 @@ func TestConsumerWithTags(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	consumer := &Consumer{
@@ -78,12 +78,12 @@ func TestConsumerWithTags(T *testing.T) {
 	}
 
 	createdConsumer, err := client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdConsumer)
 	assert.Equal(StringSlice("tag1", "tag2"), createdConsumer.Tags)
 
 	err = client.Consumers.Delete(defaultCtx, createdConsumer.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestConsumerListEndpoint(T *testing.T) {
@@ -96,7 +96,7 @@ func TestConsumerListEndpoint(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// fixtures
@@ -115,13 +115,13 @@ func TestConsumerListEndpoint(T *testing.T) {
 	// create fixturs
 	for i := 0; i < len(consumers); i++ {
 		consumer, err := client.Consumers.Create(defaultCtx, consumers[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(consumer)
 		consumers[i] = consumer
 	}
 
 	consumersFromKong, next, err := client.Consumers.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(consumersFromKong)
 	assert.Equal(3, len(consumersFromKong))
@@ -134,7 +134,7 @@ func TestConsumerListEndpoint(T *testing.T) {
 
 	// first page
 	page1, next, err := client.Consumers.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -143,7 +143,7 @@ func TestConsumerListEndpoint(T *testing.T) {
 	// last page
 	next.Size = 2
 	page2, next, err := client.Consumers.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(2, len(page2))
@@ -152,12 +152,12 @@ func TestConsumerListEndpoint(T *testing.T) {
 	assert.True(compareConsumers(consumers, consumersFromKong))
 
 	consumers, err = client.Consumers.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumers)
 	assert.Equal(3, len(consumers))
 
 	for i := 0; i < len(consumers); i++ {
-		assert.Nil(client.Consumers.Delete(defaultCtx, consumers[i].ID))
+		assert.NoError(client.Consumers.Delete(defaultCtx, consumers[i].ID))
 	}
 }
 
@@ -166,7 +166,7 @@ func TestConsumerListWithTags(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// fixtures
@@ -200,7 +200,7 @@ func TestConsumerListWithTags(T *testing.T) {
 	// create fixtures
 	for i := 0; i < len(consumers); i++ {
 		consumer, err := client.Consumers.Create(defaultCtx, consumers[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(consumer)
 		consumers[i] = consumer
 	}
@@ -208,21 +208,21 @@ func TestConsumerListWithTags(T *testing.T) {
 	consumersFromKong, next, err := client.Consumers.List(defaultCtx, &ListOpt{
 		Tags: StringSlice("tag1"),
 	})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.Equal(4, len(consumersFromKong))
 
 	consumersFromKong, next, err = client.Consumers.List(defaultCtx, &ListOpt{
 		Tags: StringSlice("tag2"),
 	})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.Equal(4, len(consumersFromKong))
 
 	consumersFromKong, next, err = client.Consumers.List(defaultCtx, &ListOpt{
 		Tags: StringSlice("tag1", "tag2"),
 	})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.Equal(6, len(consumersFromKong))
 
@@ -230,7 +230,7 @@ func TestConsumerListWithTags(T *testing.T) {
 		Tags:         StringSlice("tag1", "tag2"),
 		MatchAllTags: true,
 	})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.Equal(2, len(consumersFromKong))
 
@@ -238,12 +238,12 @@ func TestConsumerListWithTags(T *testing.T) {
 		Tags: StringSlice("tag1", "tag2"),
 		Size: 3,
 	})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.Equal(3, len(consumersFromKong))
 
 	consumersFromKong, next, err = client.Consumers.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.Equal(3, len(consumersFromKong))
 
@@ -252,17 +252,17 @@ func TestConsumerListWithTags(T *testing.T) {
 		MatchAllTags: true,
 		Size:         1,
 	})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.Equal(1, len(consumersFromKong))
 
 	consumersFromKong, next, err = client.Consumers.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.Equal(1, len(consumersFromKong))
 
 	for i := 0; i < len(consumers); i++ {
-		assert.Nil(client.Consumers.Delete(defaultCtx, consumers[i].Username))
+		assert.NoError(client.Consumers.Delete(defaultCtx, consumers[i].Username))
 	}
 }
 

--- a/kong/custom/entity_crud_test.go
+++ b/kong/custom/entity_crud_test.go
@@ -14,7 +14,7 @@ func TestRender(t *testing.T) {
 	entity := NewEntityObject("key-auth")
 	entity.AddRelation("consumer_id", "bob")
 	result, err := render("/consumers/${consumer_id}/key-auths", entity)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal(result, "/consumers/bob/key-auths")
 
 	result, err = render("/consumers/${random_id}/key-auths", entity)
@@ -43,23 +43,23 @@ func TestEntityCRUDDefinition(t *testing.T) {
 
 	assert.Equal(typ, e.Type())
 	url, err := e.GetEndpoint(entity)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("/consumers/gopher/foo/unique-id", url)
 
 	url, err = e.PatchEndpoint(entity)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("/consumers/gopher/foo/unique-id", url)
 
 	url, err = e.DeleteEndpoint(entity)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("/consumers/gopher/foo/unique-id", url)
 
 	url, err = e.PostEndpoint(entity)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("/consumers/gopher/foo", url)
 
 	url, err = e.ListEndpoint(entity)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("/consumers/gopher/foo", url)
 
 	entity = NewEntityObject(typ)
@@ -103,7 +103,7 @@ func TestEntityCRUDUnmarshal(t *testing.T) {
 		}`)
 		var def EntityCRUDDefinition
 		err := json.Unmarshal(bytes, &def)
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.Equal(Type("name"), def.Name)
 		assert.Equal("crud-path", def.CRUDPath)
 		assert.Equal("primary-key", def.PrimaryKey)
@@ -116,7 +116,7 @@ name: "name"
 crud: "crud-path"
 primary_key: "primary-key"`)
 		err := yaml.Unmarshal(bytes, &def)
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.Equal(Type("name"), def.Name)
 		assert.Equal("crud-path", def.CRUDPath)
 		assert.Equal("primary-key", def.PrimaryKey)

--- a/kong/custom/registry_test.go
+++ b/kong/custom/registry_test.go
@@ -16,7 +16,7 @@ func TestDefaultRegistry(t *testing.T) {
 		Name: typ,
 	}
 	err := r.Register(typ, &entitiy)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = r.Register(typ, &entitiy)
 	assert.NotNil(err)
 
@@ -30,5 +30,5 @@ func TestDefaultRegistry(t *testing.T) {
 	assert.NotNil(err)
 
 	err = r.Unregister(typ)
-	assert.Nil(err)
+	assert.NoError(err)
 }

--- a/kong/custom_entity_service_test.go
+++ b/kong/custom_entity_service_test.go
@@ -13,12 +13,12 @@ func TestCustomEntityService(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 	// fixture consumer
 	consumer, err := client.Consumers.Create(defaultCtx,
 		&Consumer{Username: String("foo")})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	// create a key associated with the consumer
@@ -26,7 +26,7 @@ func TestCustomEntityService(T *testing.T) {
 	k1.AddRelation("consumer_id", *consumer.ID)
 	e1, err := client.CustomEntities.Create(defaultCtx, k1)
 	assert.NotNil(e1)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// look up the key
 	se := custom.NewEntityObject("key-auth")
@@ -35,12 +35,12 @@ func TestCustomEntityService(T *testing.T) {
 	gotE, err := client.CustomEntities.Get(defaultCtx, se)
 	assert.NotNil(gotE)
 	assert.Equal(e1.Object()["key"], gotE.Object()["key"])
-	assert.Nil(err)
+	assert.NoError(err)
 
 	gotE.Object()["key"] = "my-secret"
 	e1, err = client.CustomEntities.Update(defaultCtx, gotE)
 	assert.NotNil(e1)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("my-secret", e1.Object()["key"])
 
 	// PUT request
@@ -53,7 +53,7 @@ func TestCustomEntityService(T *testing.T) {
 	k2.AddRelation("consumer_id", *consumer.ID)
 	e2, err := client.CustomEntities.Create(defaultCtx, k2)
 	assert.NotNil(e2)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("super-secret", e2.Object()["key"])
 	assert.Equal(id, e2.Object()["id"])
 
@@ -61,12 +61,12 @@ func TestCustomEntityService(T *testing.T) {
 	se.AddRelation("consumer_id", *consumer.ID)
 	keyAuths, _, err := client.CustomEntities.List(defaultCtx, nil, se)
 
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal(2, len(keyAuths))
 
 	// list endpoint
 	keyAuths, err = client.CustomEntities.ListAll(defaultCtx, se)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal(2, len(keyAuths))
 
 	expectedKeys := []string{
@@ -80,9 +80,9 @@ func TestCustomEntityService(T *testing.T) {
 	sort.Strings(expectedKeys)
 	sort.Strings(actualKeys)
 	assert.Equal(expectedKeys, actualKeys)
-	assert.Nil(client.CustomEntities.Delete(defaultCtx, e1))
-	assert.Nil(client.CustomEntities.Delete(defaultCtx, e2))
+	assert.NoError(client.CustomEntities.Delete(defaultCtx, e1))
+	assert.NoError(client.CustomEntities.Delete(defaultCtx, e2))
 
 	// delete fixture consumer
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }

--- a/kong/developer_role_service_test.go
+++ b/kong/developer_role_service_test.go
@@ -12,11 +12,11 @@ func TestDeveloperRoleService(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	testWs, err := NewTestWorkspace(client, "default")
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NoError(testWs.UpdateConfig(map[string]interface{}{"portal": true}))
 
 	role := &DeveloperRole{
@@ -24,21 +24,21 @@ func TestDeveloperRoleService(T *testing.T) {
 	}
 
 	createdRole, err := client.DeveloperRoles.Create(defaultCtx, role)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdRole)
 
 	role, err = client.DeveloperRoles.Get(defaultCtx, createdRole.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(role)
 
 	role.Comment = String("new comment")
 	role, err = client.DeveloperRoles.Update(defaultCtx, role)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(role)
 	assert.Equal("roleA", *role.Name)
 
 	err = client.DeveloperRoles.Delete(defaultCtx, createdRole.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// ID can be specified
 	id := uuid.NewString()
@@ -48,12 +48,12 @@ func TestDeveloperRoleService(T *testing.T) {
 	}
 
 	createdRole, err = client.DeveloperRoles.Create(defaultCtx, role)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdRole)
 	assert.Equal(id, *createdRole.ID)
 
 	err = client.DeveloperRoles.Delete(defaultCtx, createdRole.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	assert.NoError(testWs.Reset())
 }
@@ -63,11 +63,11 @@ func TestDeveloperRoleServiceList(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	testWs, err := NewTestWorkspace(client, "default")
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NoError(testWs.UpdateConfig(map[string]interface{}{"portal": true}))
 
 	roleA := &DeveloperRole{
@@ -78,20 +78,20 @@ func TestDeveloperRoleServiceList(T *testing.T) {
 	}
 
 	createdRoleA, err := client.DeveloperRoles.Create(defaultCtx, roleA)
-	assert.Nil(err)
+	assert.NoError(err)
 	createdRoleB, err := client.DeveloperRoles.Create(defaultCtx, roleB)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	roles, next, err := client.DeveloperRoles.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(roles)
 	assert.Equal(2, len(roles))
 
 	err = client.DeveloperRoles.Delete(defaultCtx, createdRoleA.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = client.DeveloperRoles.Delete(defaultCtx, createdRoleB.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	assert.NoError(testWs.Reset())
 }
@@ -101,11 +101,11 @@ func TestDeveloperRoleListEndpoint(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	testWs, err := NewTestWorkspace(client, "default")
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NoError(testWs.UpdateConfig(map[string]interface{}{"portal": true}))
 
 	// fixtures
@@ -124,13 +124,13 @@ func TestDeveloperRoleListEndpoint(T *testing.T) {
 	// create fixturs
 	for i := 0; i < len(roles); i++ {
 		role, err := client.DeveloperRoles.Create(defaultCtx, roles[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(role)
 		roles[i] = role
 	}
 
 	rolesFromKong, next, err := client.DeveloperRoles.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(rolesFromKong)
 	assert.Equal(3, len(rolesFromKong))
@@ -143,7 +143,7 @@ func TestDeveloperRoleListEndpoint(T *testing.T) {
 
 	// first page
 	page1, next, err := client.DeveloperRoles.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -152,7 +152,7 @@ func TestDeveloperRoleListEndpoint(T *testing.T) {
 	// last page
 	next.Size = 2
 	page2, next, err := client.DeveloperRoles.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(2, len(page2))
@@ -161,12 +161,12 @@ func TestDeveloperRoleListEndpoint(T *testing.T) {
 	assert.True(compareDeveloperRoles(roles, rolesFromKong))
 
 	roles, err = client.DeveloperRoles.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(roles)
 	assert.Equal(3, len(roles))
 
 	for i := 0; i < len(roles); i++ {
-		assert.Nil(client.DeveloperRoles.Delete(defaultCtx, roles[i].ID))
+		assert.NoError(client.DeveloperRoles.Delete(defaultCtx, roles[i].ID))
 	}
 
 	assert.NoError(testWs.Reset())

--- a/kong/developer_service_test.go
+++ b/kong/developer_service_test.go
@@ -12,11 +12,11 @@ func TestDevelopersService(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	testWs, err := NewTestWorkspace(client, "default")
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NoError(testWs.UpdateConfig(map[string]interface{}{
 		"portal_auth":         "basic-auth",
 		"portal_session_conf": map[string]interface{}{"secret": "garbage"},
@@ -31,11 +31,11 @@ func TestDevelopersService(T *testing.T) {
 	}
 
 	createdDeveloper, err := client.Developers.Create(defaultCtx, developer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdDeveloper)
 
 	developer, err = client.Developers.Get(defaultCtx, createdDeveloper.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(developer)
 
 	developer, err = client.Developers.GetByCustomID(defaultCtx,
@@ -45,17 +45,17 @@ func TestDevelopersService(T *testing.T) {
 
 	developer, err = client.Developers.GetByCustomID(defaultCtx,
 		String("custom_id_foo"))
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(developer)
 
 	developer.Email = String("bar@example.com")
 	developer, err = client.Developers.Update(defaultCtx, developer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(developer)
 	assert.Equal("bar@example.com", *developer.Email)
 
 	err = client.Developers.Delete(defaultCtx, createdDeveloper.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// ID can be specified
 	id := uuid.NewString()
@@ -67,12 +67,12 @@ func TestDevelopersService(T *testing.T) {
 	}
 
 	createdDeveloper, err = client.Developers.Create(defaultCtx, developer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdDeveloper)
 	assert.Equal(id, *createdDeveloper.ID)
 
 	err = client.Developers.Delete(defaultCtx, createdDeveloper.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	assert.NoError(testWs.Reset())
 }
@@ -82,11 +82,11 @@ func TestDeveloperListEndpoint(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	testWs, err := NewTestWorkspace(client, "default")
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NoError(testWs.UpdateConfig(map[string]interface{}{
 		"portal_auth":         "basic-auth",
 		"portal_session_conf": map[string]interface{}{"secret": "garbage"},
@@ -115,13 +115,13 @@ func TestDeveloperListEndpoint(T *testing.T) {
 	// create fixturs
 	for i := 0; i < len(developers); i++ {
 		developer, err := client.Developers.Create(defaultCtx, developers[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(developer)
 		developers[i] = developer
 	}
 
 	developersFromKong, next, err := client.Developers.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(developersFromKong)
 	assert.Equal(3, len(developersFromKong))
@@ -134,7 +134,7 @@ func TestDeveloperListEndpoint(T *testing.T) {
 
 	// first page
 	page1, next, err := client.Developers.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -143,7 +143,7 @@ func TestDeveloperListEndpoint(T *testing.T) {
 	// last page
 	next.Size = 2
 	page2, next, err := client.Developers.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(2, len(page2))
@@ -152,12 +152,12 @@ func TestDeveloperListEndpoint(T *testing.T) {
 	assert.True(compareDevelopers(developers, developersFromKong))
 
 	developers, err = client.Developers.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(developers)
 	assert.Equal(3, len(developers))
 
 	for i := 0; i < len(developers); i++ {
-		assert.Nil(client.Developers.Delete(defaultCtx, developers[i].ID))
+		assert.NoError(client.Developers.Delete(defaultCtx, developers[i].ID))
 	}
 
 	assert.NoError(testWs.Reset())

--- a/kong/endpoint_permission_service_test.go
+++ b/kong/endpoint_permission_service_test.go
@@ -12,7 +12,7 @@ func TestRBACEndpointPermissionservice(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// Create Workspace
@@ -21,18 +21,18 @@ func TestRBACEndpointPermissionservice(T *testing.T) {
 	}
 
 	createdWorkspace, err := client.Workspaces.Create(defaultCtx, workspace)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdWorkspace)
 
 	// Use new client in workspace context.
 	workspaced, err := NewTestClient(String(defaultBaseURL+"/endpoint-test-workspace"), nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	role := &RBACRole{
 		Name: String("test-role-endpoint-perm"),
 	}
 
 	createdRole, err := workspaced.RBACRoles.Create(defaultCtx, role)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdRole)
 
 	// Add Endpoint Permission to Role
@@ -48,12 +48,12 @@ func TestRBACEndpointPermissionservice(T *testing.T) {
 	}
 
 	createdEndpointPermission, err := workspaced.RBACEndpointPermissions.Create(defaultCtx, origEp)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdEndpointPermission)
 
 	ep, err := workspaced.RBACEndpointPermissions.Get(
 		defaultCtx, createdRole.ID, createdWorkspace.Name, createdEndpointPermission.Endpoint)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(ep)
 	// we test this equality specifically because the Kong API handles this field oddly
 	// see https://github.com/Kong/go-kong/pull/148
@@ -73,16 +73,16 @@ func TestRBACEndpointPermissionservice(T *testing.T) {
 	ep.Comment = String("new comment")
 	ep.Negative = &negative
 	ep, err = workspaced.RBACEndpointPermissions.Update(defaultCtx, ep)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(ep)
 	assert.Equal("new comment", *ep.Comment)
 	assert.Equal(negative, *ep.Negative)
 
 	err = workspaced.RBACEndpointPermissions.Delete(
 		defaultCtx, createdRole.ID, createdWorkspace.ID, createdEndpointPermission.Endpoint)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = workspaced.RBACRoles.Delete(defaultCtx, createdRole.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = client.Workspaces.Delete(defaultCtx, createdWorkspace.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }

--- a/kong/entity_permission_service_test.go
+++ b/kong/entity_permission_service_test.go
@@ -13,7 +13,7 @@ func TestRBACEntityPermissionservice(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// Create Workspace
@@ -22,14 +22,14 @@ func TestRBACEntityPermissionservice(T *testing.T) {
 	}
 
 	createdWorkspace, err := client.Workspaces.Create(defaultCtx, workspace)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdWorkspace)
 	// Create new workspace client
 	url, err := url.Parse(defaultBaseURL)
-	assert.Nil(err)
+	assert.NoError(err)
 	url.Path = path.Join(url.Path, *createdWorkspace.Name)
 	workspaceClient, err := NewTestClient(String(url.String()), nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(workspaceClient)
 	// Use new client in workspace context.
 	role := &RBACRole{
@@ -37,7 +37,7 @@ func TestRBACEntityPermissionservice(T *testing.T) {
 	}
 
 	createdRole, err := workspaceClient.RBACRoles.Create(defaultCtx, role)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdRole)
 
 	// Add Entity Permission to Role
@@ -53,28 +53,28 @@ func TestRBACEntityPermissionservice(T *testing.T) {
 	}
 
 	createdEntityPermission, err := workspaceClient.RBACEntityPermissions.Create(defaultCtx, ep)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdEntityPermission)
 
 	ep, err = workspaceClient.RBACEntityPermissions.Get(defaultCtx, createdRole.ID, createdEntityPermission.EntityID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(ep)
 
 	negative := true
 	ep.Comment = String("new comment")
 	ep.Negative = &negative
 	ep, err = workspaceClient.RBACEntityPermissions.Update(defaultCtx, ep)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(ep)
 	assert.Equal("new comment", *ep.Comment)
 	assert.Equal(negative, *ep.Negative)
 
 	err = workspaceClient.RBACEntityPermissions.Delete(defaultCtx, createdRole.ID, createdEntityPermission.EntityID)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = workspaceClient.RBACRoles.Delete(defaultCtx, createdRole.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = client.Workspaces.Delete(defaultCtx, createdWorkspace.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestRBACEntityPermissionserviceList(T *testing.T) {
@@ -82,7 +82,7 @@ func TestRBACEntityPermissionserviceList(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// Create a workspace
@@ -91,7 +91,7 @@ func TestRBACEntityPermissionserviceList(T *testing.T) {
 	}
 
 	createdWorkspace, err := client.Workspaces.Create(defaultCtx, workspace)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdWorkspace)
 
 	// Create a role
@@ -99,7 +99,7 @@ func TestRBACEntityPermissionserviceList(T *testing.T) {
 		Name: String("test-role-entity-perm"),
 	}
 	createdRole, err := client.RBACRoles.Create(defaultCtx, role)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdRole)
 
 	ep1 := &RBACEntityPermission{
@@ -127,22 +127,22 @@ func TestRBACEntityPermissionserviceList(T *testing.T) {
 	}
 
 	createdEntityPermissionA, err := client.RBACEntityPermissions.Create(defaultCtx, ep1)
-	assert.Nil(err)
+	assert.NoError(err)
 	createdEntityPermissionB, err := client.RBACEntityPermissions.Create(defaultCtx, ep2)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	eps, err := client.RBACEntityPermissions.ListAllForRole(defaultCtx, createdRole.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(eps)
 	// Counts default ep
 	assert.Equal(2, len(eps))
 
 	err = client.RBACEntityPermissions.Delete(defaultCtx, createdRole.ID, createdEntityPermissionA.EntityID)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = client.RBACEntityPermissions.Delete(defaultCtx, createdRole.ID, createdEntityPermissionB.EntityID)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = client.RBACRoles.Delete(defaultCtx, createdRole.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = client.Workspaces.Delete(defaultCtx, createdWorkspace.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }

--- a/kong/error_test.go
+++ b/kong/error_test.go
@@ -22,7 +22,7 @@ func TestIsNotFoundErrE2E(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	consumer, err := client.Consumers.Get(defaultCtx, String("does-not-exists"))
@@ -35,7 +35,7 @@ func TestAPIError_Code(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	consumer, err := client.Consumers.Get(defaultCtx, String("does-not-exists"))

--- a/kong/hmac_auth_service_test.go
+++ b/kong/hmac_auth_service_test.go
@@ -11,7 +11,7 @@ func TestHMACAuthCreate(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	hmacAuth, err := client.HMACAuths.Create(defaultCtx,
@@ -31,7 +31,7 @@ func TestHMACAuthCreate(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	// no username is specified
@@ -44,18 +44,18 @@ func TestHMACAuthCreate(T *testing.T) {
 		Username: String("foo"),
 	}
 	hmacAuth, err = client.HMACAuths.Create(defaultCtx, consumer.ID, hmacAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(hmacAuth)
 	assert.NotNil(hmacAuth.Secret)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestHMACAuthCreateWithID(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -71,26 +71,26 @@ func TestHMACAuthCreateWithID(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdHMACAuth, err := client.HMACAuths.Create(defaultCtx, consumer.ID,
 		hmacAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdHMACAuth)
 
 	assert.Equal(uuid, *createdHMACAuth.ID)
 	assert.Equal("my-username", *createdHMACAuth.Username)
 	assert.Equal("my-secret", *createdHMACAuth.Secret)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestHMACAuthGet(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -105,21 +105,21 @@ func TestHMACAuthGet(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdHMACAuth, err := client.HMACAuths.Create(defaultCtx,
 		consumer.ID, hmacAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdHMACAuth)
 
 	hmacAuth, err = client.HMACAuths.Get(defaultCtx, consumer.ID, hmacAuth.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("my-username", *hmacAuth.Username)
 
 	hmacAuth, err = client.HMACAuths.Get(defaultCtx, consumer.ID,
 		hmacAuth.Username)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("my-username", *hmacAuth.Username)
 
 	hmacAuth, err = client.HMACAuths.Get(defaultCtx, consumer.ID,
@@ -131,14 +131,14 @@ func TestHMACAuthGet(T *testing.T) {
 	assert.Nil(hmacAuth)
 	assert.NotNil(err)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestHMACAuthUpdate(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -154,35 +154,35 @@ func TestHMACAuthUpdate(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdHMACAuth, err := client.HMACAuths.Create(defaultCtx,
 		consumer.ID, hmacAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdHMACAuth)
 
 	hmacAuth, err = client.HMACAuths.Get(defaultCtx, consumer.ID, hmacAuth.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("my-username", *hmacAuth.Username)
 
 	hmacAuth.Username = String("my-new-username")
 	hmacAuth.Secret = String("my-new-secret")
 	updatedHMACAuth, err := client.HMACAuths.Update(defaultCtx,
 		consumer.ID, hmacAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(updatedHMACAuth)
 	assert.Equal("my-new-secret", *updatedHMACAuth.Secret)
 	assert.Equal("my-new-username", *updatedHMACAuth.Username)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestHMACAuthDelete(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -197,30 +197,30 @@ func TestHMACAuthDelete(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdHMACAuth, err := client.HMACAuths.Create(defaultCtx,
 		consumer.ID, hmacAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdHMACAuth)
 
 	err = client.HMACAuths.Delete(defaultCtx, consumer.ID, hmacAuth.Username)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	hmacAuth, err = client.HMACAuths.Get(defaultCtx,
 		consumer.ID, hmacAuth.Username)
 	assert.NotNil(err)
 	assert.Nil(hmacAuth)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestHMACAuthListMethods(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// consumer for the hmac-auth:
@@ -229,7 +229,7 @@ func TestHMACAuthListMethods(T *testing.T) {
 	}
 
 	consumer1, err = client.Consumers.Create(defaultCtx, consumer1)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer1)
 
 	consumer2 := &Consumer{
@@ -237,7 +237,7 @@ func TestHMACAuthListMethods(T *testing.T) {
 	}
 
 	consumer2, err = client.Consumers.Create(defaultCtx, consumer2)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer2)
 
 	// fixtures
@@ -264,20 +264,20 @@ func TestHMACAuthListMethods(T *testing.T) {
 	for i := 0; i < len(hmacAuths); i++ {
 		hmacAuth, err := client.HMACAuths.Create(defaultCtx,
 			hmacAuths[i].Consumer.ID, hmacAuths[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(hmacAuth)
 		hmacAuths[i] = hmacAuth
 	}
 
 	hmacAuthsFromKong, next, err := client.HMACAuths.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(hmacAuthsFromKong)
 	assert.Equal(4, len(hmacAuthsFromKong))
 
 	// first page
 	page1, next, err := client.HMACAuths.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -285,22 +285,22 @@ func TestHMACAuthListMethods(T *testing.T) {
 	// last page
 	next.Size = 3
 	page2, next, err := client.HMACAuths.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(3, len(page2))
 
 	hmacAuthsForConsumer, next, err := client.HMACAuths.ListForConsumer(defaultCtx, consumer1.ID, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(hmacAuthsForConsumer)
 	assert.Equal(2, len(hmacAuthsForConsumer))
 
 	hmacAuths, err = client.HMACAuths.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(hmacAuths)
 	assert.Equal(4, len(hmacAuths))
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer1.ID))
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer2.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer1.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer2.ID))
 }

--- a/kong/information_service_test.go
+++ b/kong/information_service_test.go
@@ -11,11 +11,11 @@ func TestInfoService(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	info, err := client.Info.Get(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(info)
 	assert.NotNil(info.Version)
 	assert.NotNil(info.Configuration)

--- a/kong/jwt_auth_service_test.go
+++ b/kong/jwt_auth_service_test.go
@@ -11,7 +11,7 @@ func TestJWTCreate(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	jwt, err := client.JWTAuths.Create(defaultCtx, String("foo"), nil)
@@ -34,7 +34,7 @@ func TestJWTCreate(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	jwt = &JWTAuth{
@@ -42,20 +42,20 @@ func TestJWTCreate(T *testing.T) {
 		RSAPublicKey: String("bar"),
 	}
 	jwt, err = client.JWTAuths.Create(defaultCtx, consumer.ID, jwt)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(jwt)
 	assert.NotEmpty(*jwt.Secret)
 	assert.Equal("bar", *jwt.RSAPublicKey)
 	assert.NotEmpty(*jwt.Algorithm)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestJWTCreateWithID(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -71,26 +71,26 @@ func TestJWTCreateWithID(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdJWT, err := client.JWTAuths.Create(defaultCtx, consumer.ID,
 		jwt)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdJWT)
 
 	assert.Equal(uuid, *createdJWT.ID)
 	assert.Equal("my-key", *createdJWT.Key)
 	assert.Equal("my-secret", *createdJWT.Secret)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestJWTGet(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -105,20 +105,20 @@ func TestJWTGet(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdJWT, err := client.JWTAuths.Create(defaultCtx, consumer.ID, jwt)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdJWT)
 
 	jwt, err = client.JWTAuths.Get(defaultCtx, consumer.ID, jwt.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("my-key", *jwt.Key)
 
 	jwt, err = client.JWTAuths.Get(defaultCtx, consumer.ID,
 		jwt.Key)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("my-key", *jwt.Key)
 
 	jwt, err = client.JWTAuths.Get(defaultCtx, consumer.ID,
@@ -130,14 +130,14 @@ func TestJWTGet(T *testing.T) {
 	assert.Nil(jwt)
 	assert.NotNil(err)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestJWTUpdate(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -152,33 +152,33 @@ func TestJWTUpdate(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdJWT, err := client.JWTAuths.Create(defaultCtx, consumer.ID, jwt)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdJWT)
 
 	jwt, err = client.JWTAuths.Get(defaultCtx, consumer.ID, jwt.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("my-key", *jwt.Key)
 
 	jwt.Key = String("my-new-key")
 	jwt.Secret = String("my-new-secret")
 	updatedJWT, err := client.JWTAuths.Update(defaultCtx, consumer.ID, jwt)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(updatedJWT)
 	assert.Equal("my-new-secret", *updatedJWT.Secret)
 	assert.Equal("my-new-key", *updatedJWT.Key)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestJWTDelete(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -193,28 +193,28 @@ func TestJWTDelete(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdJWT, err := client.JWTAuths.Create(defaultCtx, consumer.ID, jwt)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdJWT)
 
 	err = client.JWTAuths.Delete(defaultCtx, consumer.ID, jwt.Key)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	jwt, err = client.JWTAuths.Get(defaultCtx, consumer.ID, jwt.Key)
 	assert.NotNil(err)
 	assert.Nil(jwt)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestJWTListMethods(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// consumer for the JWT
@@ -223,7 +223,7 @@ func TestJWTListMethods(T *testing.T) {
 	}
 
 	consumer1, err = client.Consumers.Create(defaultCtx, consumer1)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer1)
 
 	consumer2 := &Consumer{
@@ -231,7 +231,7 @@ func TestJWTListMethods(T *testing.T) {
 	}
 
 	consumer2, err = client.Consumers.Create(defaultCtx, consumer2)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer2)
 
 	// fixtures
@@ -258,20 +258,20 @@ func TestJWTListMethods(T *testing.T) {
 	for i := 0; i < len(jwts); i++ {
 		jwt, err := client.JWTAuths.Create(defaultCtx,
 			jwts[i].Consumer.ID, jwts[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(jwt)
 		jwts[i] = jwt
 	}
 
 	jwtsFromKong, next, err := client.JWTAuths.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(jwtsFromKong)
 	assert.Equal(4, len(jwtsFromKong))
 
 	// first page
 	page1, next, err := client.JWTAuths.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -279,23 +279,23 @@ func TestJWTListMethods(T *testing.T) {
 	// last page
 	next.Size = 3
 	page2, next, err := client.JWTAuths.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(3, len(page2))
 
 	jwtsForConsumer, next, err := client.JWTAuths.ListForConsumer(defaultCtx,
 		consumer1.ID, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(jwtsForConsumer)
 	assert.Equal(2, len(jwtsForConsumer))
 
 	jwts, err = client.JWTAuths.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(jwts)
 	assert.Equal(4, len(jwts))
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer1.ID))
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer2.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer1.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer2.ID))
 }

--- a/kong/key_auth_service_test.go
+++ b/kong/key_auth_service_test.go
@@ -11,7 +11,7 @@ func TestKeyAuthCreate(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	keyAuth, err := client.KeyAuths.Create(defaultCtx,
@@ -36,23 +36,23 @@ func TestKeyAuthCreate(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	keyAuth = &KeyAuth{}
 	createdKeyAuth, err := client.KeyAuths.Create(defaultCtx,
 		consumer.ID, keyAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdKeyAuth)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestKeyAuthCreateWithID(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -67,25 +67,25 @@ func TestKeyAuthCreateWithID(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdKeyAuth, err := client.KeyAuths.Create(defaultCtx,
 		consumer.ID, keyAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdKeyAuth)
 
 	assert.Equal(uuid, *createdKeyAuth.ID)
 	assert.Equal("my-apikey", *createdKeyAuth.Key)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestKeyAuthGet(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -100,22 +100,22 @@ func TestKeyAuthGet(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdKeyAuth, err := client.KeyAuths.Create(defaultCtx,
 		consumer.ID, keyAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdKeyAuth)
 
 	searchKeyAuth, err := client.KeyAuths.Get(defaultCtx,
 		consumer.ID, keyAuth.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("my-apikey", *searchKeyAuth.Key)
 
 	searchKeyAuth, err = client.KeyAuths.Get(defaultCtx,
 		consumer.ID, keyAuth.Key)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("my-apikey", *searchKeyAuth.Key)
 
 	searchKeyAuth, err = client.KeyAuths.Get(defaultCtx, consumer.ID,
@@ -128,14 +128,14 @@ func TestKeyAuthGet(T *testing.T) {
 	assert.Nil(searchKeyAuth)
 	assert.NotNil(err)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestKeyAuthUpdate(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -150,34 +150,34 @@ func TestKeyAuthUpdate(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdKeyAuth, err := client.KeyAuths.Create(defaultCtx,
 		consumer.ID, keyAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdKeyAuth)
 
 	searchKeyAuth, err := client.KeyAuths.Get(defaultCtx,
 		consumer.ID, keyAuth.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("my-apikey", *searchKeyAuth.Key)
 
 	keyAuth.Key = String("my-new-apikey")
 	updatedKeyAuth, err := client.KeyAuths.Update(defaultCtx,
 		consumer.ID, keyAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(updatedKeyAuth)
 	assert.Equal("my-new-apikey", *updatedKeyAuth.Key)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestKeyAuthDelete(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -192,30 +192,30 @@ func TestKeyAuthDelete(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdKeyAuth, err := client.KeyAuths.Create(defaultCtx,
 		consumer.ID, keyAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdKeyAuth)
 
 	err = client.KeyAuths.Delete(defaultCtx, consumer.ID, keyAuth.Key)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	searchKeyAuth, err := client.KeyAuths.Get(defaultCtx,
 		consumer.ID, keyAuth.ID)
 	assert.NotNil(err)
 	assert.Nil(searchKeyAuth)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestKeyAuthListMethods(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// consumer for the key-auth:
@@ -224,7 +224,7 @@ func TestKeyAuthListMethods(T *testing.T) {
 	}
 
 	consumer1, err = client.Consumers.Create(defaultCtx, consumer1)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer1)
 
 	consumer2 := &Consumer{
@@ -232,7 +232,7 @@ func TestKeyAuthListMethods(T *testing.T) {
 	}
 
 	consumer2, err = client.Consumers.Create(defaultCtx, consumer2)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer2)
 
 	// fixtures
@@ -259,20 +259,20 @@ func TestKeyAuthListMethods(T *testing.T) {
 	for i := 0; i < len(keyAuths); i++ {
 		keyAuth, err := client.KeyAuths.Create(defaultCtx,
 			keyAuths[i].Consumer.ID, keyAuths[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(keyAuth)
 		keyAuths[i] = keyAuth
 	}
 
 	keyAuthsFromKong, next, err := client.KeyAuths.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(keyAuthsFromKong)
 	assert.Equal(4, len(keyAuthsFromKong))
 
 	// first page
 	page1, next, err := client.KeyAuths.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -280,24 +280,24 @@ func TestKeyAuthListMethods(T *testing.T) {
 	// last page
 	next.Size = 3
 	page2, next, err := client.KeyAuths.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(3, len(page2))
 
 	keyAuthsForConsumer, next, err := client.KeyAuths.ListForConsumer(defaultCtx, consumer1.ID, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(keyAuthsForConsumer)
 	assert.Equal(2, len(keyAuthsForConsumer))
 
 	keyAuths, err = client.KeyAuths.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(keyAuths)
 	assert.Equal(4, len(keyAuths))
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer1.ID))
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer2.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer1.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer2.ID))
 }
 
 func TestKeyAuthCreateWithTTL(T *testing.T) {
@@ -305,7 +305,7 @@ func TestKeyAuthCreateWithTTL(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	keyAuth := &KeyAuth{
@@ -319,16 +319,16 @@ func TestKeyAuthCreateWithTTL(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdKeyAuth, err := client.KeyAuths.Create(defaultCtx,
 		consumer.ID, keyAuth)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdKeyAuth)
 
 	assert.True(*createdKeyAuth.TTL < 10)
 	assert.Equal("my-apikey", *createdKeyAuth.Key)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }

--- a/kong/mtls_auth_service_test.go
+++ b/kong/mtls_auth_service_test.go
@@ -14,7 +14,7 @@ func TestMTLSCreate(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	mtls, err := client.MTLSAuths.Create(defaultCtx, String("foo"), nil)
@@ -38,22 +38,22 @@ func TestMTLSCreate(T *testing.T) {
 
 	// without a CA certificate attached
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	mtls = &MTLSAuth{
 		SubjectName: String("test@example.com"),
 	}
 	mtls, err = client.MTLSAuths.Create(defaultCtx, consumer.ID, mtls)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(mtls)
 	assert.Equal("test@example.com", *mtls.SubjectName)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 
 	// with a CA certificate attached
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	certificate := &CACertificate{
@@ -61,7 +61,7 @@ func TestMTLSCreate(T *testing.T) {
 	}
 	createdCertificate, err := client.CACertificates.Create(defaultCtx,
 		certificate)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	assert.NotNil(createdCertificate)
 	mtls = &MTLSAuth{
@@ -69,18 +69,18 @@ func TestMTLSCreate(T *testing.T) {
 		CACertificate: createdCertificate,
 	}
 	mtls, err = client.MTLSAuths.Create(defaultCtx, consumer.ID, mtls)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(mtls)
 	assert.Equal("test@example.com", *mtls.SubjectName)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestMTLSCreateWithID(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -95,25 +95,25 @@ func TestMTLSCreateWithID(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdMTLS, err := client.MTLSAuths.Create(defaultCtx, consumer.ID,
 		mtls)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdMTLS)
 
 	assert.Equal(uuid, *createdMTLS.ID)
 	assert.Equal("test@example.com", *mtls.SubjectName)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestMTLSGet(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -128,15 +128,15 @@ func TestMTLSGet(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdMTLS, err := client.MTLSAuths.Create(defaultCtx, consumer.ID, mtls)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdMTLS)
 
 	mtls, err = client.MTLSAuths.Get(defaultCtx, consumer.ID, mtls.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("test@example.com", *mtls.SubjectName)
 
 	mtls, err = client.MTLSAuths.Get(defaultCtx, consumer.ID,
@@ -148,14 +148,14 @@ func TestMTLSGet(T *testing.T) {
 	assert.Nil(mtls)
 	assert.NotNil(err)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestMTLSUpdate(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -170,31 +170,31 @@ func TestMTLSUpdate(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdMTLS, err := client.MTLSAuths.Create(defaultCtx, consumer.ID, mtls)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdMTLS)
 
 	mtls, err = client.MTLSAuths.Get(defaultCtx, consumer.ID, mtls.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("test@example.com", *mtls.SubjectName)
 
 	mtls.SubjectName = String("different@example.com")
 	updatedMTLS, err := client.MTLSAuths.Update(defaultCtx, consumer.ID, mtls)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(updatedMTLS)
 	assert.Equal("different@example.com", *updatedMTLS.SubjectName)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestMTLSDelete(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -209,28 +209,28 @@ func TestMTLSDelete(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdMTLS, err := client.MTLSAuths.Create(defaultCtx, consumer.ID, mtls)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdMTLS)
 
 	err = client.MTLSAuths.Delete(defaultCtx, consumer.ID, mtls.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	mtls, err = client.MTLSAuths.Get(defaultCtx, consumer.ID, mtls.ID)
 	assert.NotNil(err)
 	assert.Nil(mtls)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestMTLSListMethods(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// consumer for the MTLS
@@ -239,7 +239,7 @@ func TestMTLSListMethods(T *testing.T) {
 	}
 
 	consumer1, err = client.Consumers.Create(defaultCtx, consumer1)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer1)
 
 	consumer2 := &Consumer{
@@ -247,7 +247,7 @@ func TestMTLSListMethods(T *testing.T) {
 	}
 
 	consumer2, err = client.Consumers.Create(defaultCtx, consumer2)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer2)
 
 	// fixtures
@@ -274,20 +274,20 @@ func TestMTLSListMethods(T *testing.T) {
 	for i := 0; i < len(mtlss); i++ {
 		mtls, err := client.MTLSAuths.Create(defaultCtx,
 			mtlss[i].Consumer.ID, mtlss[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(mtls)
 		mtlss[i] = mtls
 	}
 
 	mtlssFromKong, next, err := client.MTLSAuths.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(mtlssFromKong)
 	assert.Equal(4, len(mtlssFromKong))
 
 	// first page
 	page1, next, err := client.MTLSAuths.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -295,23 +295,23 @@ func TestMTLSListMethods(T *testing.T) {
 	// last page
 	next.Size = 3
 	page2, next, err := client.MTLSAuths.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(3, len(page2))
 
 	mtlssForConsumer, next, err := client.MTLSAuths.ListForConsumer(defaultCtx,
 		consumer1.ID, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(mtlssForConsumer)
 	assert.Equal(2, len(mtlssForConsumer))
 
 	mtlss, err = client.MTLSAuths.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(mtlss)
 	assert.Equal(4, len(mtlss))
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer1.ID))
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer2.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer1.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer2.ID))
 }

--- a/kong/oauth2_auth_service_test.go
+++ b/kong/oauth2_auth_service_test.go
@@ -11,7 +11,7 @@ func TestOauth2CredentialCreate(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	oauth2Cred, err := client.Oauth2Credentials.Create(defaultCtx,
@@ -31,7 +31,7 @@ func TestOauth2CredentialCreate(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	oauth2Cred = &Oauth2Credential{
@@ -41,18 +41,18 @@ func TestOauth2CredentialCreate(T *testing.T) {
 	}
 	oauth2Cred, err = client.Oauth2Credentials.Create(defaultCtx,
 		consumer.ID, oauth2Cred)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(oauth2Cred)
 	assert.NotNil(oauth2Cred.ClientSecret)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestOauth2CredentialCreateWithID(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -70,26 +70,26 @@ func TestOauth2CredentialCreateWithID(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdOauth2Credential, err := client.Oauth2Credentials.Create(
 		defaultCtx, consumer.ID, oauth2Cred)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdOauth2Credential)
 
 	assert.Equal(uuid, *createdOauth2Credential.ID)
 	assert.Equal("my-clientid", *createdOauth2Credential.ClientID)
 	assert.Equal("my-client-secret", *createdOauth2Credential.ClientSecret)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestOauth2CredentialGet(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -106,22 +106,22 @@ func TestOauth2CredentialGet(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdOauth2Credential, err := client.Oauth2Credentials.Create(defaultCtx,
 		consumer.ID, oauth2Cred)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdOauth2Credential)
 
 	oauth2Cred, err = client.Oauth2Credentials.Get(defaultCtx,
 		consumer.ID, oauth2Cred.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("foo-clientid", *oauth2Cred.ClientID)
 
 	oauth2Cred, err = client.Oauth2Credentials.Get(defaultCtx, consumer.ID,
 		String("foo-clientid"))
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(oauth2Cred)
 
 	oauth2Cred, err = client.Oauth2Credentials.Get(defaultCtx, consumer.ID,
@@ -134,7 +134,7 @@ func TestOauth2CredentialGet(T *testing.T) {
 	assert.Nil(oauth2Cred)
 	assert.NotNil(err)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestOauth2CredentialUpdate(T *testing.T) {
@@ -142,7 +142,7 @@ func TestOauth2CredentialUpdate(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -159,35 +159,35 @@ func TestOauth2CredentialUpdate(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdOauth2Credential, err := client.Oauth2Credentials.Create(
 		defaultCtx, consumer.ID, oauth2Cred)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdOauth2Credential)
 
 	oauth2Cred, err = client.Oauth2Credentials.Get(defaultCtx,
 		consumer.ID, oauth2Cred.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("foo-name", *oauth2Cred.Name)
 
 	oauth2Cred.Name = String("new-foo-name")
 	oauth2Cred.ClientSecret = String("my-new-secret")
 	updatedOauth2Credential, err := client.Oauth2Credentials.Update(defaultCtx, consumer.ID, oauth2Cred)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(updatedOauth2Credential)
 	assert.Equal("new-foo-name", *updatedOauth2Credential.Name)
 	assert.Equal("my-new-secret", *updatedOauth2Credential.ClientSecret)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestOauth2CredentialDelete(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	uuid := uuid.NewString()
@@ -204,30 +204,30 @@ func TestOauth2CredentialDelete(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer)
 
 	createdOauth2Credential, err := client.Oauth2Credentials.Create(defaultCtx, consumer.ID, oauth2Cred)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdOauth2Credential)
 
 	err = client.Oauth2Credentials.Delete(defaultCtx,
 		consumer.ID, oauth2Cred.ClientID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	oauth2Cred, err = client.Oauth2Credentials.Get(defaultCtx,
 		consumer.ID, oauth2Cred.ClientID)
 	assert.NotNil(err)
 	assert.Nil(oauth2Cred)
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
 func TestOauth2CredentialListMethods(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// consumer for the oauth2 cred
@@ -236,7 +236,7 @@ func TestOauth2CredentialListMethods(T *testing.T) {
 	}
 
 	consumer1, err = client.Consumers.Create(defaultCtx, consumer1)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer1)
 
 	consumer2 := &Consumer{
@@ -244,7 +244,7 @@ func TestOauth2CredentialListMethods(T *testing.T) {
 	}
 
 	consumer2, err = client.Consumers.Create(defaultCtx, consumer2)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(consumer2)
 
 	// fixtures
@@ -279,20 +279,20 @@ func TestOauth2CredentialListMethods(T *testing.T) {
 	for i := 0; i < len(oauth2Creds); i++ {
 		oauth2Cred, err := client.Oauth2Credentials.Create(defaultCtx,
 			oauth2Creds[i].Consumer.ID, oauth2Creds[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(oauth2Cred)
 		oauth2Creds[i] = oauth2Cred
 	}
 
 	oauth2CredsFromKong, next, err := client.Oauth2Credentials.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(oauth2CredsFromKong)
 	assert.Equal(4, len(oauth2CredsFromKong))
 
 	// first page
 	page1, next, err := client.Oauth2Credentials.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -300,22 +300,22 @@ func TestOauth2CredentialListMethods(T *testing.T) {
 	// last page
 	next.Size = 3
 	page2, next, err := client.Oauth2Credentials.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(3, len(page2))
 
 	oauth2CredsForConsumer, next, err := client.Oauth2Credentials.ListForConsumer(defaultCtx, consumer1.ID, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(oauth2CredsForConsumer)
 	assert.Equal(2, len(oauth2CredsForConsumer))
 
 	oauth2Creds, err = client.Oauth2Credentials.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(oauth2Creds)
 	assert.Equal(4, len(oauth2Creds))
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer1.ID))
-	assert.Nil(client.Consumers.Delete(defaultCtx, consumer2.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer1.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, consumer2.ID))
 }

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -12,7 +12,7 @@ func TestPluginsServiceValidation(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	goodPlugin := &Plugin{
@@ -31,11 +31,11 @@ func TestPluginsServiceValidation(T *testing.T) {
 
 	valid, _, err := client.Plugins.Validate(defaultCtx, goodPlugin)
 	assert.True(valid)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	valid, msg, err := client.Plugins.Validate(defaultCtx, badPlugin)
 	assert.False(valid)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal("schema violation (config.garbage: unknown field)", msg)
 }
 
@@ -43,7 +43,7 @@ func TestPluginsService(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	plugin := &Plugin{
@@ -51,21 +51,21 @@ func TestPluginsService(T *testing.T) {
 	}
 
 	createdPlugin, err := client.Plugins.Create(defaultCtx, plugin)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdPlugin)
 
 	plugin, err = client.Plugins.Get(defaultCtx, createdPlugin.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(plugin)
 
 	plugin.Config["key_in_body"] = true
 	plugin, err = client.Plugins.Update(defaultCtx, plugin)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(plugin)
 	assert.Equal(true, plugin.Config["key_in_body"])
 
 	err = client.Plugins.Delete(defaultCtx, createdPlugin.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// ID can be specified
 	id := uuid.NewString()
@@ -75,12 +75,12 @@ func TestPluginsService(T *testing.T) {
 	}
 
 	createdPlugin, err = client.Plugins.Create(defaultCtx, plugin)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdPlugin)
 	assert.Equal(id, *createdPlugin.ID)
 
 	err = client.Plugins.Delete(defaultCtx, createdPlugin.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestPluginWithTags(T *testing.T) {
@@ -88,7 +88,7 @@ func TestPluginWithTags(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	plugin := &Plugin{
@@ -97,19 +97,19 @@ func TestPluginWithTags(T *testing.T) {
 	}
 
 	createdPlugin, err := client.Plugins.Create(defaultCtx, plugin)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdPlugin)
 	assert.Equal(StringSlice("tag1", "tag2"), createdPlugin.Tags)
 
 	err = client.Plugins.Delete(defaultCtx, createdPlugin.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestUnknownPlugin(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	plugin, err := client.Plugins.Create(defaultCtx, &Plugin{
@@ -123,7 +123,7 @@ func TestPluginListEndpoint(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// fixtures
@@ -142,16 +142,16 @@ func TestPluginListEndpoint(T *testing.T) {
 	// create fixturs
 	for i := 0; i < len(plugins); i++ {
 		schema, err := client.Plugins.GetSchema(defaultCtx, plugins[i].Name)
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(schema)
 		plugin, err := client.Plugins.Create(defaultCtx, plugins[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(plugin)
 		plugins[i] = plugin
 	}
 
 	pluginsFromKong, next, err := client.Plugins.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(pluginsFromKong)
 	assert.Equal(3, len(pluginsFromKong))
@@ -164,7 +164,7 @@ func TestPluginListEndpoint(T *testing.T) {
 
 	// first page
 	page1, next, err := client.Plugins.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -172,7 +172,7 @@ func TestPluginListEndpoint(T *testing.T) {
 
 	// second page
 	page2, next, err := client.Plugins.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page2)
 	assert.Equal(1, len(page2))
@@ -180,7 +180,7 @@ func TestPluginListEndpoint(T *testing.T) {
 
 	// last page
 	page3, next, err := client.Plugins.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page3)
 	assert.Equal(1, len(page3))
@@ -189,12 +189,12 @@ func TestPluginListEndpoint(T *testing.T) {
 	assert.True(comparePlugins(plugins, pluginsFromKong))
 
 	plugins, err = client.Plugins.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(plugins)
 	assert.Equal(3, len(plugins))
 
 	for i := 0; i < len(plugins); i++ {
-		assert.Nil(client.Plugins.Delete(defaultCtx, plugins[i].ID))
+		assert.NoError(client.Plugins.Delete(defaultCtx, plugins[i].ID))
 	}
 }
 
@@ -202,7 +202,7 @@ func TestPluginListAllForEntityEndpoint(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// fixtures
@@ -213,20 +213,20 @@ func TestPluginListAllForEntityEndpoint(T *testing.T) {
 		Port: Int(42),
 		Path: String("/path"),
 	})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdService)
 
 	createdRoute, err := client.Routes.Create(defaultCtx, &Route{
 		Hosts:   StringSlice("host1.com", "host2.com"),
 		Service: createdService,
 	})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdRoute)
 
 	createdConsumer, err := client.Consumers.Create(defaultCtx, &Consumer{
 		Username: String("foo"),
 	})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdConsumer)
 
 	plugins := []*Plugin{
@@ -271,16 +271,16 @@ func TestPluginListAllForEntityEndpoint(T *testing.T) {
 	// create fixturs
 	for i := 0; i < len(plugins); i++ {
 		schema, err := client.Plugins.GetSchema(defaultCtx, plugins[i].Name)
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(schema)
 		plugin, err := client.Plugins.Create(defaultCtx, plugins[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(plugin)
 		plugins[i] = plugin
 	}
 
 	pluginsFromKong, err := client.Plugins.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(pluginsFromKong)
 	assert.Equal(len(plugins), len(pluginsFromKong))
 
@@ -290,48 +290,48 @@ func TestPluginListAllForEntityEndpoint(T *testing.T) {
 	assert.True(comparePlugins(plugins, pluginsFromKong))
 
 	pluginsFromKong, err = client.Plugins.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(pluginsFromKong)
 	assert.Equal(8, len(pluginsFromKong))
 
 	pluginsFromKong, err = client.Plugins.ListAllForConsumer(defaultCtx,
 		createdConsumer.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(pluginsFromKong)
 	assert.Equal(1, len(pluginsFromKong))
 
 	pluginsFromKong, err = client.Plugins.ListAllForService(defaultCtx,
 		createdService.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(pluginsFromKong)
 	assert.Equal(2, len(pluginsFromKong))
 
 	pluginsFromKong, err = client.Plugins.ListAllForRoute(defaultCtx,
 		createdRoute.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(pluginsFromKong)
 	assert.Equal(2, len(pluginsFromKong))
 
 	for i := 0; i < len(plugins); i++ {
-		assert.Nil(client.Plugins.Delete(defaultCtx, plugins[i].ID))
+		assert.NoError(client.Plugins.Delete(defaultCtx, plugins[i].ID))
 	}
 
-	assert.Nil(client.Consumers.Delete(defaultCtx, createdConsumer.ID))
-	assert.Nil(client.Routes.Delete(defaultCtx, createdRoute.ID))
-	assert.Nil(client.Services.Delete(defaultCtx, createdService.ID))
+	assert.NoError(client.Consumers.Delete(defaultCtx, createdConsumer.ID))
+	assert.NoError(client.Routes.Delete(defaultCtx, createdRoute.ID))
+	assert.NoError(client.Services.Delete(defaultCtx, createdService.ID))
 }
 
 func TestPluginGetFullSchema(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	schema, err := client.Plugins.GetFullSchema(defaultCtx, String("key-auth"))
 	_, ok := schema["fields"]
 	assert.True(ok)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	schema, err = client.Plugins.GetFullSchema(defaultCtx, String("noexist"))
 	assert.Nil(schema)
@@ -343,7 +343,7 @@ func TestFillPluginDefaults(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	tests := []struct {
@@ -447,7 +447,7 @@ func TestFillPluginDefaults(T *testing.T) {
 		T.Run(tc.name, func(t *testing.T) {
 			p := tc.plugin
 			fullSchema, err := client.Plugins.GetFullSchema(defaultCtx, p.Name)
-			assert.Nil(err)
+			assert.NoError(err)
 			assert.NotNil(fullSchema)
 			if err := FillPluginsDefaults(p, fullSchema); err != nil {
 				t.Errorf(err.Error())

--- a/kong/rbac_role_service_test.go
+++ b/kong/rbac_role_service_test.go
@@ -12,7 +12,7 @@ func TestRBACRoleService(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	workspace := &Workspace{
@@ -21,32 +21,32 @@ func TestRBACRoleService(T *testing.T) {
 
 	createdWorkspace, err := client.Workspaces.Create(defaultCtx, workspace)
 
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdWorkspace)
 
 	workspaced, err := NewTestClient(String(defaultBaseURL+"/rbac-role-test-workspace"), nil)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	role := &RBACRole{
 		Name: String("roleA"),
 	}
 
 	createdRole, err := workspaced.RBACRoles.Create(defaultCtx, role)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdRole)
 
 	role, err = workspaced.RBACRoles.Get(defaultCtx, createdRole.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(role)
 
 	role.Comment = String("new comment")
 	role, err = workspaced.RBACRoles.Update(defaultCtx, role)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(role)
 	assert.Equal("roleA", *role.Name)
 
 	err = workspaced.RBACRoles.Delete(defaultCtx, createdRole.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// ID can be specified
 	id := uuid.NewString()
@@ -56,15 +56,15 @@ func TestRBACRoleService(T *testing.T) {
 	}
 
 	createdRole, err = workspaced.RBACRoles.Create(defaultCtx, role)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdRole)
 	assert.Equal(id, *createdRole.ID)
 
 	err = workspaced.RBACRoles.Delete(defaultCtx, createdRole.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	err = client.Workspaces.Delete(defaultCtx, createdWorkspace.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestRBACRoleServiceList(T *testing.T) {
@@ -72,7 +72,7 @@ func TestRBACRoleServiceList(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	workspace := &Workspace{
@@ -81,11 +81,11 @@ func TestRBACRoleServiceList(T *testing.T) {
 
 	createdWorkspace, err := client.Workspaces.Create(defaultCtx, workspace)
 
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdWorkspace)
 
 	workspaced, err := NewTestClient(String(defaultBaseURL+"/rbac-role-list-test-workspace"), nil)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	roleA := &RBACRole{
 		Name: String("roleA"),
@@ -95,23 +95,23 @@ func TestRBACRoleServiceList(T *testing.T) {
 	}
 
 	createdRoleA, err := workspaced.RBACRoles.Create(defaultCtx, roleA)
-	assert.Nil(err)
+	assert.NoError(err)
 	createdRoleB, err := workspaced.RBACRoles.Create(defaultCtx, roleB)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	roles, next, err := workspaced.RBACRoles.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(roles)
 	assert.Equal(2, len(roles))
 
 	err = workspaced.RBACRoles.Delete(defaultCtx, createdRoleA.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = workspaced.RBACRoles.Delete(defaultCtx, createdRoleB.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	err = client.Workspaces.Delete(defaultCtx, createdWorkspace.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestRBACRoleListEndpoint(T *testing.T) {
@@ -119,7 +119,7 @@ func TestRBACRoleListEndpoint(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	workspace := &Workspace{
@@ -128,11 +128,11 @@ func TestRBACRoleListEndpoint(T *testing.T) {
 
 	createdWorkspace, err := client.Workspaces.Create(defaultCtx, workspace)
 
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdWorkspace)
 
 	workspaced, err := NewTestClient(String(defaultBaseURL+"/rbac-role-list-endpoint-test-workspace"), nil)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// fixtures
 	roles := []*RBACRole{
@@ -150,13 +150,13 @@ func TestRBACRoleListEndpoint(T *testing.T) {
 	// create fixturs
 	for i := 0; i < len(roles); i++ {
 		role, err := workspaced.RBACRoles.Create(defaultCtx, roles[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(role)
 		roles[i] = role
 	}
 
 	rolesFromKong, next, err := workspaced.RBACRoles.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(rolesFromKong)
 	assert.Equal(3, len(rolesFromKong))
@@ -169,7 +169,7 @@ func TestRBACRoleListEndpoint(T *testing.T) {
 
 	// first page
 	page1, next, err := workspaced.RBACRoles.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -178,7 +178,7 @@ func TestRBACRoleListEndpoint(T *testing.T) {
 	// last page
 	next.Size = 2
 	page2, next, err := workspaced.RBACRoles.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(2, len(page2))
@@ -187,7 +187,7 @@ func TestRBACRoleListEndpoint(T *testing.T) {
 	assert.True(compareRBACRoles(roles, rolesFromKong))
 
 	roles, err = workspaced.RBACRoles.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(roles)
 	assert.Equal(3, len(roles))
 
@@ -196,7 +196,7 @@ func TestRBACRoleListEndpoint(T *testing.T) {
 	}
 
 	err = client.Workspaces.Delete(defaultCtx, createdWorkspace.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func compareRBACRoles(expected, actual []*RBACRole) bool {

--- a/kong/rbac_user_service_test.go
+++ b/kong/rbac_user_service_test.go
@@ -13,7 +13,7 @@ func TestRBACUserService(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	user := &RBACUser{
@@ -24,21 +24,21 @@ func TestRBACUserService(T *testing.T) {
 	}
 
 	createdUser, err := client.RBACUsers.Create(defaultCtx, user)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdUser)
 
 	user, err = client.RBACUsers.Get(defaultCtx, createdUser.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(user)
 
 	user.Comment = String("new comment")
 	user, err = client.RBACUsers.Update(defaultCtx, user)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(user)
 	assert.Equal("new comment", *user.Comment)
 
 	err = client.RBACUsers.Delete(defaultCtx, createdUser.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestRBACUserServiceWorkspace(T *testing.T) {
@@ -46,7 +46,7 @@ func TestRBACUserServiceWorkspace(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	workspace := Workspace{
@@ -54,14 +54,14 @@ func TestRBACUserServiceWorkspace(T *testing.T) {
 	}
 
 	createdWorkspace, err := client.Workspaces.Create(defaultCtx, &workspace)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdWorkspace)
 	// Setup Workspace aware client
 	url, err := url.Parse(defaultBaseURL)
-	assert.Nil(err)
+	assert.NoError(err)
 	url.Path = path.Join(url.Path, *createdWorkspace.Name)
 	workspaceClient, err := NewTestClient(String(url.String()), nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(workspaceClient)
 
 	user := &RBACUser{
@@ -72,24 +72,24 @@ func TestRBACUserServiceWorkspace(T *testing.T) {
 	}
 
 	createdUser, err := workspaceClient.RBACUsers.Create(defaultCtx, user)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdUser)
 
 	user, err = workspaceClient.RBACUsers.Get(defaultCtx, createdUser.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(user)
 
 	user.Comment = String("new comment")
 	user, err = workspaceClient.RBACUsers.Update(defaultCtx, user)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(user)
 	assert.Equal("new comment", *user.Comment)
 
 	err = workspaceClient.RBACUsers.Delete(defaultCtx, createdUser.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	err = client.Workspaces.Delete(defaultCtx, createdWorkspace.Name)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestUserRoles(T *testing.T) {
@@ -97,7 +97,7 @@ func TestUserRoles(T *testing.T) {
 	assert := assert.New(T)
 	client, err := NewTestClient(nil, nil)
 
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	roleA := &RBACRole{
@@ -108,9 +108,9 @@ func TestUserRoles(T *testing.T) {
 	}
 
 	createdRoleA, err := client.RBACRoles.Create(defaultCtx, roleA)
-	assert.Nil(err)
+	assert.NoError(err)
 	createdRoleB, err := client.RBACRoles.Create(defaultCtx, roleB)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	ep := &RBACEndpointPermission{
 		Role: &RBACRole{
@@ -124,7 +124,7 @@ func TestUserRoles(T *testing.T) {
 	}
 
 	createdEndpointPermission, err := client.RBACEndpointPermissions.Create(defaultCtx, ep)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdEndpointPermission)
 
 	user := &RBACUser{
@@ -135,7 +135,7 @@ func TestUserRoles(T *testing.T) {
 	}
 
 	createdUser, err := client.RBACUsers.Create(defaultCtx, user)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdUser)
 
 	roles := []*RBACRole{
@@ -144,26 +144,26 @@ func TestUserRoles(T *testing.T) {
 	}
 
 	updatedUser, err := client.RBACUsers.AddRoles(defaultCtx, createdUser.ID, roles)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(updatedUser)
 
 	roleList, err := client.RBACUsers.ListRoles(defaultCtx, createdUser.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(roleList)
 	assert.Equal(2, len(roleList))
 
 	permissionsList, err := client.RBACUsers.ListPermissions(defaultCtx, createdUser.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(permissionsList)
 	assert.Equal(1, len(permissionsList.Endpoints))
 
 	err = client.RBACEndpointPermissions.Delete(
 		defaultCtx, createdRoleA.ID, String("default"), createdEndpointPermission.Endpoint)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = client.RBACUsers.Delete(defaultCtx, createdUser.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = client.RBACRoles.Delete(defaultCtx, createdRoleA.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = client.RBACRoles.Delete(defaultCtx, createdRoleB.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }

--- a/kong/route_service_test.go
+++ b/kong/route_service_test.go
@@ -11,7 +11,7 @@ func TestRoutesRoute(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	route := &Route{}
@@ -29,7 +29,7 @@ func TestRoutesRoute(T *testing.T) {
 	}
 
 	service, err = client.Services.Create(defaultCtx, service)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(service)
 
 	route = &Route{
@@ -37,11 +37,11 @@ func TestRoutesRoute(T *testing.T) {
 		Service: service,
 	}
 	createdRoute, err := client.Routes.Create(defaultCtx, route)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdRoute)
 
 	route, err = client.Routes.Get(defaultCtx, createdRoute.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(route)
 	assert.Empty(route.Methods)
 	assert.Empty(route.Paths)
@@ -49,13 +49,13 @@ func TestRoutesRoute(T *testing.T) {
 	route.Hosts = StringSlice("newHost.com")
 	route.Methods = StringSlice("GET", "POST")
 	route, err = client.Routes.Update(defaultCtx, route)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(route)
 	assert.Equal(1, len(route.Hosts))
 	assert.Equal("newHost.com", *route.Hosts[0])
 
 	err = client.Routes.Delete(defaultCtx, createdRoute.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// ID can be specified
 	id := uuid.NewString()
@@ -74,7 +74,7 @@ func TestRoutesRoute(T *testing.T) {
 	}
 
 	createdRoute, err = client.Routes.Create(defaultCtx, route)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdRoute)
 	assert.Equal(id, *createdRoute.ID)
 	assert.Equal(2, len(createdRoute.SNIs))
@@ -84,10 +84,10 @@ func TestRoutesRoute(T *testing.T) {
 	assert.Equal(80, *createdRoute.Destinations[0].Port)
 
 	err = client.Routes.Delete(defaultCtx, createdRoute.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	err = client.Services.Delete(defaultCtx, service.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	_, err = client.Routes.Create(defaultCtx, nil)
 	assert.NotNil(err)
@@ -101,7 +101,7 @@ func TestRouteWithTags(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	route := &Route{
@@ -111,19 +111,19 @@ func TestRouteWithTags(T *testing.T) {
 	}
 
 	createdRoute, err := client.Routes.Create(defaultCtx, route)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdRoute)
 	assert.Equal(StringSlice("tag1", "tag2"), createdRoute.Tags)
 
 	err = client.Routes.Delete(defaultCtx, createdRoute.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestCreateInRoute(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	service := &Service{
@@ -134,7 +134,7 @@ func TestCreateInRoute(T *testing.T) {
 	}
 
 	createdService, err := client.Services.Create(defaultCtx, service)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdService)
 
 	route := &Route{
@@ -149,18 +149,18 @@ func TestCreateInRoute(T *testing.T) {
 
 	createdRoute, err := client.Routes.CreateInService(defaultCtx,
 		createdService.ID, route)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdRoute)
 
-	assert.Nil(client.Routes.Delete(defaultCtx, createdRoute.ID))
-	assert.Nil(client.Services.Delete(defaultCtx, createdService.ID))
+	assert.NoError(client.Routes.Delete(defaultCtx, createdRoute.ID))
+	assert.NoError(client.Services.Delete(defaultCtx, createdService.ID))
 }
 
 func TestRouteListEndpoint(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	service := &Service{
@@ -171,7 +171,7 @@ func TestRouteListEndpoint(T *testing.T) {
 	}
 
 	createdService, err := client.Services.Create(defaultCtx, service)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdService)
 
 	// fixtures
@@ -193,13 +193,13 @@ func TestRouteListEndpoint(T *testing.T) {
 	// create fixturs
 	for i := 0; i < len(routes); i++ {
 		route, err := client.Routes.Create(defaultCtx, routes[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(route)
 		routes[i] = route
 	}
 
 	routesFromKong, next, err := client.Routes.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(routesFromKong)
 	assert.Equal(3, len(routesFromKong))
@@ -212,7 +212,7 @@ func TestRouteListEndpoint(T *testing.T) {
 
 	// first page
 	page1, next, err := client.Routes.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -221,7 +221,7 @@ func TestRouteListEndpoint(T *testing.T) {
 	// last page
 	next.Size = 2
 	page2, next, err := client.Routes.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(2, len(page2))
@@ -231,21 +231,21 @@ func TestRouteListEndpoint(T *testing.T) {
 
 	routesForService, next, err := client.Routes.ListForService(defaultCtx,
 		createdService.ID, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(routesForService)
 	assert.True(compareRoutes(routes, routesForService))
 
 	routes, err = client.Routes.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(routes)
 	assert.Equal(3, len(routes))
 
 	for i := 0; i < len(routes); i++ {
-		assert.Nil(client.Routes.Delete(defaultCtx, routes[i].ID))
+		assert.NoError(client.Routes.Delete(defaultCtx, routes[i].ID))
 	}
 
-	assert.Nil(client.Services.Delete(defaultCtx, createdService.ID))
+	assert.NoError(client.Services.Delete(defaultCtx, createdService.ID))
 }
 
 func compareRoutes(expected, actual []*Route) bool {
@@ -266,7 +266,7 @@ func TestRouteWithHeaders(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	route := &Route{
@@ -278,11 +278,11 @@ func TestRouteWithHeaders(T *testing.T) {
 	}
 
 	createdRoute, err := client.Routes.Create(defaultCtx, route)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdRoute)
 	assert.Equal(StringSlice("tag1", "tag2"), createdRoute.Tags)
 	assert.Equal(map[string][]string{"foo": {"bar"}}, createdRoute.Headers)
 
 	err = client.Routes.Delete(defaultCtx, createdRoute.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }

--- a/kong/schema_service_test.go
+++ b/kong/schema_service_test.go
@@ -10,7 +10,7 @@ func TestSchemaService(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	entities := []string{
@@ -29,6 +29,6 @@ func TestSchemaService(T *testing.T) {
 		schema, err := client.Schemas.Get(defaultCtx, entity)
 		_, ok := schema["fields"]
 		assert.True(ok)
-		assert.Nil(err)
+		assert.NoError(err)
 	}
 }

--- a/kong/service_service_test.go
+++ b/kong/service_service_test.go
@@ -11,7 +11,7 @@ func TestServicesService(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	service := &Service{
@@ -22,17 +22,17 @@ func TestServicesService(T *testing.T) {
 	}
 
 	createdService, err := client.Services.Create(defaultCtx, service)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdService)
 
 	service, err = client.Services.Get(defaultCtx, createdService.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(service)
 
 	service.Name = String("bar")
 	service.Host = String("newUpstream")
 	service, err = client.Services.Update(defaultCtx, service)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(service)
 	assert.Equal("bar", *service.Name)
 	assert.Equal("newUpstream", *service.Host)
@@ -41,20 +41,20 @@ func TestServicesService(T *testing.T) {
 	route, err := client.Routes.CreateInService(defaultCtx, service.ID, &Route{
 		Paths: StringSlice("/route"),
 	})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(route)
 
 	serviceForRoute, err := client.Services.GetForRoute(defaultCtx, route.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(serviceForRoute)
 
 	assert.Equal(*service.ID, *serviceForRoute.ID)
 
 	err = client.Routes.Delete(defaultCtx, route.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	err = client.Services.Delete(defaultCtx, service.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// ID can be specified
 	id := uuid.NewString()
@@ -65,13 +65,13 @@ func TestServicesService(T *testing.T) {
 	}
 
 	createdService, err = client.Services.Create(defaultCtx, service)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdService)
 	assert.Equal(id, *createdService.ID)
 	assert.Equal("buzz", *createdService.Host)
 
 	err = client.Services.Delete(defaultCtx, createdService.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	_, err = client.Services.Create(defaultCtx, nil)
 	assert.NotNil(err)
@@ -85,7 +85,7 @@ func TestServiceWithTags(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	service := &Service{
@@ -95,19 +95,19 @@ func TestServiceWithTags(T *testing.T) {
 	}
 
 	createdService, err := client.Services.Create(defaultCtx, service)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdService)
 	assert.Equal(StringSlice("tag1", "tag2"), createdService.Tags)
 
 	err = client.Services.Delete(defaultCtx, createdService.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestServiceListEndpoint(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// fixtures
@@ -129,13 +129,13 @@ func TestServiceListEndpoint(T *testing.T) {
 	// create fixturs
 	for i := 0; i < len(services); i++ {
 		service, err := client.Services.Create(defaultCtx, services[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(service)
 		services[i] = service
 	}
 
 	servicesFromKong, next, err := client.Services.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(servicesFromKong)
 	assert.Equal(3, len(servicesFromKong))
@@ -148,7 +148,7 @@ func TestServiceListEndpoint(T *testing.T) {
 
 	// first page
 	page1, next, err := client.Services.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -157,7 +157,7 @@ func TestServiceListEndpoint(T *testing.T) {
 	// last page
 	next.Size = 2
 	page2, next, err := client.Services.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(2, len(page2))
@@ -166,12 +166,12 @@ func TestServiceListEndpoint(T *testing.T) {
 	assert.True(compareServices(services, servicesFromKong))
 
 	services, err = client.Services.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(services)
 	assert.Equal(3, len(services))
 
 	for i := 0; i < len(services); i++ {
-		assert.Nil(client.Services.Delete(defaultCtx, services[i].ID))
+		assert.NoError(client.Services.Delete(defaultCtx, services[i].ID))
 	}
 }
 
@@ -193,7 +193,7 @@ func TestServiceWithClientCert(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	certificate := &Certificate{
@@ -201,7 +201,7 @@ func TestServiceWithClientCert(T *testing.T) {
 		Cert: String(cert1),
 	}
 	createdCertificate, err := client.Certificates.Create(defaultCtx, certificate)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdCertificate)
 
 	service := &Service{
@@ -212,13 +212,13 @@ func TestServiceWithClientCert(T *testing.T) {
 	}
 
 	createdService, err := client.Services.Create(defaultCtx, service)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdService)
 	assert.Equal(*createdCertificate.ID, *createdService.ClientCertificate.ID)
 
 	err = client.Services.Delete(defaultCtx, createdService.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	err = client.Certificates.Delete(defaultCtx, createdCertificate.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }

--- a/kong/sni_service_test.go
+++ b/kong/sni_service_test.go
@@ -11,7 +11,7 @@ func TestSNIsCertificate(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	sni := &SNI{
@@ -29,7 +29,7 @@ func TestSNIsCertificate(T *testing.T) {
 			Key:  String(key1),
 			Cert: String(cert1),
 		})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(fixtureCertificate)
 	assert.NotNil(fixtureCertificate.ID)
 
@@ -37,21 +37,21 @@ func TestSNIsCertificate(T *testing.T) {
 		Name:        String("host1.com"),
 		Certificate: fixtureCertificate,
 	})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdSNI)
 
 	sni, err = client.SNIs.Get(defaultCtx, createdSNI.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(sni)
 
 	sni.Name = String("host2.com")
 	sni, err = client.SNIs.Update(defaultCtx, sni)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(sni)
 	assert.Equal("host2.com", *sni.Name)
 
 	err = client.SNIs.Delete(defaultCtx, createdSNI.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// ID can be specified
 	id := uuid.NewString()
@@ -62,12 +62,12 @@ func TestSNIsCertificate(T *testing.T) {
 	}
 
 	createdSNI, err = client.SNIs.Create(defaultCtx, sni)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdSNI)
 	assert.Equal(id, *createdSNI.ID)
 
 	err = client.Certificates.Delete(defaultCtx, fixtureCertificate.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestSNIWithTags(T *testing.T) {
@@ -75,7 +75,7 @@ func TestSNIWithTags(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	fixtureCertificate, err := client.Certificates.Create(defaultCtx,
@@ -83,26 +83,26 @@ func TestSNIWithTags(T *testing.T) {
 			Key:  String(key1),
 			Cert: String(cert1),
 		})
-	assert.Nil(err)
+	assert.NoError(err)
 
 	createdSNI, err := client.SNIs.Create(defaultCtx, &SNI{
 		Name:        String("host1.com"),
 		Certificate: fixtureCertificate,
 		Tags:        StringSlice("tag1", "tag2"),
 	})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdSNI)
 	assert.Equal(StringSlice("tag1", "tag2"), createdSNI.Tags)
 
 	err = client.Certificates.Delete(defaultCtx, fixtureCertificate.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestSNIListEndpoint(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	certificate := &Certificate{
@@ -112,7 +112,7 @@ func TestSNIListEndpoint(T *testing.T) {
 
 	createdCertificate, err := client.Certificates.Create(defaultCtx,
 		certificate)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdCertificate)
 
 	// fixtures
@@ -134,13 +134,13 @@ func TestSNIListEndpoint(T *testing.T) {
 	// create fixturs
 	for i := 0; i < len(snis); i++ {
 		sni, err := client.SNIs.Create(defaultCtx, snis[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(sni)
 		snis[i] = sni
 	}
 
 	snisFromKong, next, err := client.SNIs.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(snisFromKong)
 	assert.Equal(3, len(snisFromKong))
@@ -153,7 +153,7 @@ func TestSNIListEndpoint(T *testing.T) {
 
 	// first page
 	page1, next, err := client.SNIs.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -162,7 +162,7 @@ func TestSNIListEndpoint(T *testing.T) {
 	// last page
 	next.Size = 2
 	page2, next, err := client.SNIs.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(2, len(page2))
@@ -172,22 +172,22 @@ func TestSNIListEndpoint(T *testing.T) {
 
 	snisForCert, next, err := client.SNIs.ListForCertificate(defaultCtx,
 		createdCertificate.ID, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(snisForCert)
 
 	assert.True(compareSNIs(snis, snisForCert))
 
 	snis, err = client.SNIs.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(snis)
 	assert.Equal(3, len(snis))
 
 	for i := 0; i < len(snis); i++ {
-		assert.Nil(client.SNIs.Delete(defaultCtx, snis[i].ID))
+		assert.NoError(client.SNIs.Delete(defaultCtx, snis[i].ID))
 	}
 
-	assert.Nil(client.Certificates.Delete(defaultCtx, createdCertificate.ID))
+	assert.NoError(client.Certificates.Delete(defaultCtx, createdCertificate.ID))
 }
 
 func compareSNIs(expected, actual []*SNI) bool {

--- a/kong/tag_service_test.go
+++ b/kong/tag_service_test.go
@@ -11,11 +11,11 @@ func TestTagExists(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	exists, err := client.Tags.Exists(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.True(exists)
 }
 
@@ -24,10 +24,10 @@ func TestTagDoesNotExists(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	exists, err := client.Tags.Exists(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.False(exists)
 }

--- a/kong/target_service_test.go
+++ b/kong/target_service_test.go
@@ -11,7 +11,7 @@ func TestTargetsUpstream(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	target := &Target{
@@ -27,7 +27,7 @@ func TestTargetsUpstream(T *testing.T) {
 	fixtureUpstream, err := client.Upstreams.Create(defaultCtx, &Upstream{
 		Name: String("vhost.com"),
 	})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(fixtureUpstream)
 	assert.NotNil(fixtureUpstream.ID)
 
@@ -35,12 +35,12 @@ func TestTargetsUpstream(T *testing.T) {
 		fixtureUpstream.ID, &Target{
 			Target: String("10.0.0.1:80"),
 		})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdTarget)
 
 	err = client.Targets.Delete(defaultCtx, fixtureUpstream.ID,
 		createdTarget.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// ID can be specified
 	id := uuid.NewString()
@@ -52,26 +52,26 @@ func TestTargetsUpstream(T *testing.T) {
 
 	createdTarget, err = client.Targets.Create(defaultCtx,
 		fixtureUpstream.ID, target)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdTarget)
 	assert.Equal(id, *createdTarget.ID)
 
 	err = client.Upstreams.Delete(defaultCtx, fixtureUpstream.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestTargetsUpdate(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// create a upstream
 	fixtureUpstream, err := client.Upstreams.Create(defaultCtx, &Upstream{
 		Name: String("vhost.com"),
 	})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(fixtureUpstream)
 	assert.NotNil(fixtureUpstream.ID)
 
@@ -81,26 +81,26 @@ func TestTargetsUpdate(T *testing.T) {
 			ID:     &targetID,
 			Target: String("10.0.0.1:80"),
 		})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdTarget)
 	assert.Equal(targetID, *createdTarget.ID)
 
 	err = client.Targets.Delete(defaultCtx, fixtureUpstream.ID,
 		createdTarget.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	createdTarget, err = client.Targets.Create(defaultCtx,
 		fixtureUpstream.ID, &Target{
 			ID:     &targetID,
 			Target: String("10.0.0.2:80"),
 		})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdTarget)
 	assert.Equal(targetID, *createdTarget.ID)
 	assert.Equal("10.0.0.2:80", *createdTarget.Target)
 
 	err = client.Upstreams.Delete(defaultCtx, fixtureUpstream.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestTargetWithTags(T *testing.T) {
@@ -108,32 +108,32 @@ func TestTargetWithTags(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	fixtureUpstream, err := client.Upstreams.Create(defaultCtx, &Upstream{
 		Name: String("vhost.com"),
 	})
-	assert.Nil(err)
+	assert.NoError(err)
 
 	createdTarget, err := client.Targets.Create(defaultCtx,
 		fixtureUpstream.ID, &Target{
 			Target: String("10.0.0.1:80"),
 			Tags:   StringSlice("tag1", "tag2"),
 		})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdTarget)
 	assert.Equal(StringSlice("tag1", "tag2"), createdTarget.Tags)
 
 	err = client.Upstreams.Delete(defaultCtx, fixtureUpstream.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestTargetListEndpoint(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	upstream := &Upstream{
@@ -141,7 +141,7 @@ func TestTargetListEndpoint(T *testing.T) {
 	}
 
 	createdUpstream, err := client.Upstreams.Create(defaultCtx, upstream)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdUpstream)
 
 	// fixtures
@@ -163,14 +163,14 @@ func TestTargetListEndpoint(T *testing.T) {
 	for i := 0; i < len(targets); i++ {
 		target, err := client.Targets.Create(defaultCtx,
 			createdUpstream.ID, targets[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(target)
 		targets[i] = target
 	}
 
 	targetsFromKong, next, err := client.Targets.List(defaultCtx,
 		createdUpstream.ID, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(targetsFromKong)
 	assert.Equal(3, len(targetsFromKong))
@@ -184,7 +184,7 @@ func TestTargetListEndpoint(T *testing.T) {
 	// first page
 	page1, next, err := client.Targets.List(defaultCtx,
 		createdUpstream.ID, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -194,7 +194,7 @@ func TestTargetListEndpoint(T *testing.T) {
 	next.Size = 2
 	page2, next, err := client.Targets.List(defaultCtx,
 		createdUpstream.ID, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(2, len(page2))
@@ -203,11 +203,11 @@ func TestTargetListEndpoint(T *testing.T) {
 	assert.True(compareTargets(targets, targetsFromKong))
 
 	targets, err = client.Targets.ListAll(defaultCtx, createdUpstream.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(targets)
 	assert.Equal(3, len(targets))
 
-	assert.Nil(client.Upstreams.Delete(defaultCtx, createdUpstream.ID))
+	assert.NoError(client.Upstreams.Delete(defaultCtx, createdUpstream.ID))
 }
 
 func compareTargets(expected, actual []*Target) bool {
@@ -227,7 +227,7 @@ func TestTargetMarkHealthy(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	upstream := &Upstream{
@@ -242,28 +242,28 @@ func TestTargetMarkHealthy(T *testing.T) {
 	}
 
 	createdUpstream, err := client.Upstreams.Create(defaultCtx, upstream)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdUpstream)
 
 	createdTarget, err := client.Targets.Create(defaultCtx,
 		createdUpstream.ID, &Target{
 			Target: String("10.0.0.1:80"),
 		})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdTarget)
 
 	assert.NotNil(client.Targets.MarkHealthy(defaultCtx, createdTarget.Upstream.ID, nil))
 	assert.NotNil(client.Targets.MarkHealthy(defaultCtx, nil, createdTarget))
-	assert.Nil(client.Targets.MarkHealthy(defaultCtx, createdTarget.Upstream.ID, createdTarget))
+	assert.NoError(client.Targets.MarkHealthy(defaultCtx, createdTarget.Upstream.ID, createdTarget))
 
-	assert.Nil(client.Upstreams.Delete(defaultCtx, createdUpstream.ID))
+	assert.NoError(client.Upstreams.Delete(defaultCtx, createdUpstream.ID))
 }
 
 func TestTargetMarkUnhealthy(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	upstream := &Upstream{
@@ -278,19 +278,19 @@ func TestTargetMarkUnhealthy(T *testing.T) {
 	}
 
 	createdUpstream, err := client.Upstreams.Create(defaultCtx, upstream)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdUpstream)
 
 	createdTarget, err := client.Targets.Create(defaultCtx,
 		createdUpstream.ID, &Target{
 			Target: String("10.0.0.1:80"),
 		})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdTarget)
 
 	assert.NotNil(client.Targets.MarkUnhealthy(defaultCtx, createdTarget.Upstream.ID, nil))
 	assert.NotNil(client.Targets.MarkUnhealthy(defaultCtx, nil, createdTarget))
-	assert.Nil(client.Targets.MarkUnhealthy(defaultCtx, createdTarget.Upstream.ID, createdTarget))
+	assert.NoError(client.Targets.MarkUnhealthy(defaultCtx, createdTarget.Upstream.ID, createdTarget))
 
-	assert.Nil(client.Upstreams.Delete(defaultCtx, createdUpstream.ID))
+	assert.NoError(client.Upstreams.Delete(defaultCtx, createdUpstream.ID))
 }

--- a/kong/upstream_node_health_service_test.go
+++ b/kong/upstream_node_health_service_test.go
@@ -10,7 +10,7 @@ func TestUpstreamNodeHealthService(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// create a upstream
@@ -20,7 +20,7 @@ func TestUpstreamNodeHealthService(T *testing.T) {
 			Name: String("vhost.com"),
 		},
 	)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(fixtureUpstream)
 	assert.NotNil(fixtureUpstream.ID)
 
@@ -32,23 +32,23 @@ func TestUpstreamNodeHealthService(T *testing.T) {
 			Target: String("10.0.0.1:80"),
 		},
 	)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdTarget)
 
 	// upstream node health
 	nodeHealths, err := client.UpstreamNodeHealth.ListAll(
 		defaultCtx, fixtureUpstream.ID,
 	)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(nodeHealths)
 
 	// cleanup targets
 	err = client.Targets.Delete(
 		defaultCtx, fixtureUpstream.ID, createdTarget.ID,
 	)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// cleanup upstream
 	err = client.Upstreams.Delete(defaultCtx, fixtureUpstream.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }

--- a/kong/upstream_service_test.go
+++ b/kong/upstream_service_test.go
@@ -11,7 +11,7 @@ func TestUpstreamsService(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	upstream := &Upstream{
@@ -19,21 +19,21 @@ func TestUpstreamsService(T *testing.T) {
 	}
 
 	createdUpstream, err := client.Upstreams.Create(defaultCtx, upstream)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdUpstream)
 
 	upstream, err = client.Upstreams.Get(defaultCtx, createdUpstream.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(upstream)
 
 	upstream.Name = String("virtual-host2")
 	upstream, err = client.Upstreams.Update(defaultCtx, upstream)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(upstream)
 	assert.Equal("virtual-host2", *upstream.Name)
 
 	err = client.Upstreams.Delete(defaultCtx, createdUpstream.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// ID can be specified
 	id := uuid.NewString()
@@ -43,12 +43,12 @@ func TestUpstreamsService(T *testing.T) {
 	}
 
 	createdUpstream, err = client.Upstreams.Create(defaultCtx, upstream)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdUpstream)
 	assert.Equal(id, *createdUpstream.ID)
 
 	err = client.Upstreams.Delete(defaultCtx, createdUpstream.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestUpstreamWithTags(T *testing.T) {
@@ -56,7 +56,7 @@ func TestUpstreamWithTags(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	upstream := &Upstream{
@@ -65,12 +65,12 @@ func TestUpstreamWithTags(T *testing.T) {
 	}
 
 	createdUpstream, err := client.Upstreams.Create(defaultCtx, upstream)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdUpstream)
 	assert.Equal(StringSlice("tag1", "tag2"), createdUpstream.Tags)
 
 	err = client.Upstreams.Delete(defaultCtx, createdUpstream.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 // regression test for #6
@@ -78,7 +78,7 @@ func TestUpstreamWithActiveUnHealthyInterval(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	upstream := &Upstream{
@@ -93,11 +93,11 @@ func TestUpstreamWithActiveUnHealthyInterval(T *testing.T) {
 	}
 
 	createdUpstream, err := client.Upstreams.Create(defaultCtx, upstream)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdUpstream)
 
 	err = client.Upstreams.Delete(defaultCtx, createdUpstream.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 // regression test for #6
@@ -105,7 +105,7 @@ func TestUpstreamWithPassiveUnHealthyInterval(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	upstream := &Upstream{
@@ -128,7 +128,7 @@ func TestUpstreamWithPassiveHealthy(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	upstream := &Upstream{
@@ -145,12 +145,12 @@ func TestUpstreamWithPassiveHealthy(T *testing.T) {
 	}
 
 	createdUpstream, err := client.Upstreams.Create(defaultCtx, upstream)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdUpstream)
 	assert.Equal("http", *createdUpstream.Healthchecks.Passive.Type)
 
 	err = client.Upstreams.Delete(defaultCtx, createdUpstream.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestUpstreamWithAlgorithm(T *testing.T) {
@@ -158,7 +158,7 @@ func TestUpstreamWithAlgorithm(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	upstream := &Upstream{
@@ -167,19 +167,19 @@ func TestUpstreamWithAlgorithm(T *testing.T) {
 	}
 
 	createdUpstream, err := client.Upstreams.Create(defaultCtx, upstream)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdUpstream)
 	assert.Equal("least-connections", *createdUpstream.Algorithm)
 
 	err = client.Upstreams.Delete(defaultCtx, createdUpstream.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestUpstreamListEndpoint(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	// fixtures
@@ -198,13 +198,13 @@ func TestUpstreamListEndpoint(T *testing.T) {
 	// create fixturs
 	for i := 0; i < len(upstreams); i++ {
 		upstream, err := client.Upstreams.Create(defaultCtx, upstreams[i])
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.NotNil(upstream)
 		upstreams[i] = upstream
 	}
 
 	upstreamsFromKong, next, err := client.Upstreams.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(upstreamsFromKong)
 	assert.Equal(3, len(upstreamsFromKong))
@@ -217,7 +217,7 @@ func TestUpstreamListEndpoint(T *testing.T) {
 
 	// first page
 	page1, next, err := client.Upstreams.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -225,7 +225,7 @@ func TestUpstreamListEndpoint(T *testing.T) {
 
 	// second page
 	page2, next, err := client.Upstreams.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page2)
 	assert.Equal(1, len(page2))
@@ -233,7 +233,7 @@ func TestUpstreamListEndpoint(T *testing.T) {
 
 	// last page
 	page3, next, err := client.Upstreams.List(defaultCtx, next)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page3)
 	assert.Equal(1, len(page3))
@@ -242,12 +242,12 @@ func TestUpstreamListEndpoint(T *testing.T) {
 	assert.True(compareUpstreams(upstreams, upstreamsFromKong))
 
 	upstreams, err = client.Upstreams.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(upstreams)
 	assert.Equal(3, len(upstreams))
 
 	for i := 0; i < len(upstreams); i++ {
-		assert.Nil(client.Upstreams.Delete(defaultCtx, upstreams[i].ID))
+		assert.NoError(client.Upstreams.Delete(defaultCtx, upstreams[i].ID))
 	}
 }
 
@@ -269,7 +269,7 @@ func TestUpstreamsWithHostHeader(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	upstream := &Upstream{
@@ -278,10 +278,10 @@ func TestUpstreamsWithHostHeader(T *testing.T) {
 	}
 
 	createdUpstream, err := client.Upstreams.Create(defaultCtx, upstream)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdUpstream)
 	assert.Equal("example.com", *createdUpstream.HostHeader)
 
 	err = client.Upstreams.Delete(defaultCtx, createdUpstream.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -166,7 +166,7 @@ func TestFillRoutesDefaults(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	tests := []struct {
@@ -232,7 +232,7 @@ func TestFillRoutesDefaults(T *testing.T) {
 		T.Run(tc.name, func(t *testing.T) {
 			r := tc.route
 			fullSchema, err := client.Schemas.Get(defaultCtx, "routes")
-			assert.Nil(err)
+			assert.NoError(err)
 			assert.NotNil(fullSchema)
 			if err = FillEntityDefaults(r, fullSchema); err != nil {
 				t.Errorf(err.Error())
@@ -253,7 +253,7 @@ func TestFillServiceDefaults(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	tests := []struct {
@@ -322,7 +322,7 @@ func TestFillServiceDefaults(T *testing.T) {
 		T.Run(tc.name, func(t *testing.T) {
 			s := tc.service
 			fullSchema, err := client.Schemas.Get(defaultCtx, "services")
-			assert.Nil(err)
+			assert.NoError(err)
 			assert.NotNil(fullSchema)
 			if err := FillEntityDefaults(s, fullSchema); err != nil {
 				t.Errorf(err.Error())
@@ -341,7 +341,7 @@ func TestFillTargetDefaults(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	tests := []struct {
@@ -371,7 +371,7 @@ func TestFillTargetDefaults(T *testing.T) {
 		T.Run(tc.name, func(t *testing.T) {
 			target := tc.target
 			fullSchema, err := client.Schemas.Get(defaultCtx, "targets")
-			assert.Nil(err)
+			assert.NoError(err)
 			assert.NotNil(fullSchema)
 			if err := FillEntityDefaults(target, fullSchema); err != nil {
 				t.Errorf(err.Error())
@@ -387,7 +387,7 @@ func TestFillUpstreamsDefaults(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	tests := []struct {
@@ -511,7 +511,7 @@ func TestFillUpstreamsDefaults(T *testing.T) {
 		T.Run(tc.name, func(t *testing.T) {
 			u := tc.upstream
 			fullSchema, err := client.Schemas.Get(defaultCtx, "upstreams")
-			assert.Nil(err)
+			assert.NoError(err)
 			assert.NotNil(fullSchema)
 			if err = FillEntityDefaults(u, fullSchema); err != nil {
 				t.Errorf(err.Error())

--- a/kong/workspace_service_test.go
+++ b/kong/workspace_service_test.go
@@ -14,7 +14,7 @@ func TestWorkspaceService(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	workspace := &Workspace{
@@ -26,34 +26,34 @@ func TestWorkspaceService(T *testing.T) {
 	}
 
 	createdWorkspace, err := client.Workspaces.Create(defaultCtx, workspace)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdWorkspace)
 
 	workspace, err = client.Workspaces.Get(defaultCtx, createdWorkspace.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(workspace)
 
 	exists, err := client.Workspaces.Exists(defaultCtx, createdWorkspace.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.True(exists)
 
 	exists, err = client.Workspaces.ExistsByName(defaultCtx, createdWorkspace.Name)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.True(exists)
 
 	fakeID := *createdWorkspace.ID + "garbage"
 	exists, err = client.Workspaces.Exists(defaultCtx, &fakeID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.False(exists)
 
 	fakeName := *createdWorkspace.Name + "garbage"
 	exists, err = client.Workspaces.ExistsByName(defaultCtx, &fakeName)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.False(exists)
 
 	workspace.Comment = String("new comment")
 	workspace, err = client.Workspaces.Update(defaultCtx, workspace)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(workspace)
 	assert.NotNil(workspace.Config)
 	assert.Equal("teamA", *workspace.Name)
@@ -61,7 +61,7 @@ func TestWorkspaceService(T *testing.T) {
 	assert.Equal("#814CA6", workspace.Meta["color"])
 
 	err = client.Workspaces.Delete(defaultCtx, createdWorkspace.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// ID can be specified
 	id := uuid.NewString()
@@ -71,19 +71,19 @@ func TestWorkspaceService(T *testing.T) {
 	}
 
 	createdWorkspace, err = client.Workspaces.Create(defaultCtx, workspace)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdWorkspace)
 	assert.Equal(id, *createdWorkspace.ID)
 
 	err = client.Workspaces.Delete(defaultCtx, createdWorkspace.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestWorkspaceServiceList(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	workspaceA := &Workspace{
@@ -94,34 +94,34 @@ func TestWorkspaceServiceList(T *testing.T) {
 	}
 
 	createdWorkspaceA, err := client.Workspaces.Create(defaultCtx, workspaceA)
-	assert.Nil(err)
+	assert.NoError(err)
 	createdWorkspaceB, err := client.Workspaces.Create(defaultCtx, workspaceB)
-	assert.Nil(err)
+	assert.NoError(err)
 	// paged List
 	page1, next, err := client.Workspaces.List(defaultCtx, &ListOpt{Size: 1})
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
 	// nil ListOpt List
 	workspaces, next, err := client.Workspaces.List(defaultCtx, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(workspaces)
 	// Counts default workspace
 	assert.Equal(3, len(workspaces))
 
 	err = client.Workspaces.Delete(defaultCtx, createdWorkspaceA.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = client.Workspaces.Delete(defaultCtx, createdWorkspaceB.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 func TestWorkspaceServiceListAll(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	workspaceA := &Workspace{
@@ -132,20 +132,20 @@ func TestWorkspaceServiceListAll(T *testing.T) {
 	}
 
 	createdWorkspaceA, err := client.Workspaces.Create(defaultCtx, workspaceA)
-	assert.Nil(err)
+	assert.NoError(err)
 	createdWorkspaceB, err := client.Workspaces.Create(defaultCtx, workspaceB)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	workspaces, err := client.Workspaces.ListAll(defaultCtx)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(workspaces)
 	// Counts default workspace
 	assert.Equal(3, len(workspaces))
 
 	err = client.Workspaces.Delete(defaultCtx, createdWorkspaceA.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	err = client.Workspaces.Delete(defaultCtx, createdWorkspaceB.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }
 
 // Workspace entities
@@ -155,7 +155,7 @@ func TestWorkspaceService_Entities(T *testing.T) {
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(client)
 
 	workspace := &Workspace{
@@ -168,7 +168,7 @@ func TestWorkspaceService_Entities(T *testing.T) {
 
 	// Create a workspace
 	createdWorkspace, err := client.Workspaces.Create(defaultCtx, workspace)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdWorkspace)
 
 	service := &Service{
@@ -180,31 +180,31 @@ func TestWorkspaceService_Entities(T *testing.T) {
 
 	// Create a service
 	createdService, err := client.Services.Create(defaultCtx, service)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(createdService)
 
 	// Add the service to the workspace
 	entities, err := client.Workspaces.AddEntities(
 		defaultCtx, createdWorkspace.ID, createdService.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(entities)
 
 	// List Entities attached to the workspace
 	entitiesAdded, err := client.Workspaces.ListEntities(defaultCtx, createdWorkspace.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.NotNil(entitiesAdded)
 	// The two entities are records capturing the service name and id
 	assert.Equal(2, len(entitiesAdded))
 
 	// Delete the service from the workspace
 	err = client.Workspaces.DeleteEntities(defaultCtx, createdWorkspace.ID, createdService.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// Delete the service
 	err = client.Services.Delete(defaultCtx, createdService.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	// Delete the workspace
 	err = client.Workspaces.Delete(defaultCtx, createdWorkspace.ID)
-	assert.Nil(err)
+	assert.NoError(err)
 }


### PR DESCRIPTION
In order to get prettier errors in tests outputs use `assert.NoError` instead of `assert.NotNil`