### PR TITLE
ci: run CI checks only for PRs and selected branches

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,6 +1,13 @@
 name: golangci-lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - 'main'
+    - 'release/*'
+  pull_request:
+    branches:
+    - '*'
 
 jobs:
   golangci:

--- a/.github/workflows/integration-test-enterprise.yaml
+++ b/.github/workflows/integration-test-enterprise.yaml
@@ -1,6 +1,13 @@
 name: 'Integration Test : Enterprise'
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - 'main'
+    - 'release/*'
+  pull_request:
+    branches:
+    - '*'
 
 jobs:
   test:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,6 +1,13 @@
 name: 'Integration Test : Community'
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - 'main'
+    - 'release/*'
+  pull_request:
+    branches:
+    - '*'
 
 jobs:
   test:


### PR DESCRIPTION
This PR limits the events on which the CI actions will run in order to run them only once (for `pull_request` event, not for `push` event).

<img width="771" alt="image" src="https://user-images.githubusercontent.com/739996/171598868-611bd4a6-ec2b-4a86-8ff3-f5f3dbfc47be.png">

For now the `push` trigger will only run actions on `main` and `release/*` branches.

---

#### Open questions

Do we want to trigger CI checks on release branches? Do we want to run them on any other branches?