### PR TITLE
fix: set default transport when caller provides uninitialized one

### DIFF
--- a/kong/custom_entity_service.go
+++ b/kong/custom_entity_service.go
@@ -88,7 +88,7 @@ func (s *CustomEntityService) Create(ctx context.Context,
 	o := entity.Object()
 	// Necessary to Marshal an empty map
 	// as {} and not null
-	if o == nil || len(o) == 0 {
+	if len(o) == 0 {
 		o = make(map[string]interface{})
 	}
 	req, err := s.client.NewRequest(method, queryPath, nil, o)
@@ -123,7 +123,7 @@ func (s *CustomEntityService) Update(ctx context.Context,
 	o := entity.Object()
 	// Necessary to Marshal an empty map
 	// as {} and not null
-	if o == nil || len(o) == 0 {
+	if len(o) == 0 {
 		o = make(map[string]interface{})
 	}
 	req, err := s.client.NewRequest("PATCH", queryPath, nil, o)

--- a/kong/utils.go
+++ b/kong/utils.go
@@ -115,6 +115,11 @@ func HTTPClientWithHeaders(client *http.Client,
 		res.Transport = defaultTransport
 	} else {
 		res = client
+		// If a client with nil transport has been provided then set it to http's
+		// default transport so that the caller is still able to use it.
+		if res.Transport == nil {
+			res.Transport = http.DefaultTransport.(*http.Transport)
+		}
 	}
 	res.Transport = headerRoundTripper{
 		headers: headers,

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -2,6 +2,7 @@ package kong
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 
@@ -523,4 +524,27 @@ func TestFillUpstreamsDefaults(T *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHTTPClientWithHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	assert.NotPanics(t,
+		func() {
+			client := HTTPClientWithHeaders(&http.Client{}, nil)
+			assert.NotNil(t, client)
+		},
+		"creating Kong's HTTP client using default/uninitialized http.Client shouldn't panic",
+	)
+
+	assert.NotPanics(t,
+		func() {
+			client := HTTPClientWithHeaders(nil, nil)
+			assert.NotNil(t, client)
+		},
+		"creating Kong's HTTP client using nil http.Client shouldn't panic",
+	)
 }


### PR DESCRIPTION
When caller uses

```go
kong.NewClient(<URL>, kong.HTTPClientWithHeaders(&http.Client{}, <HEADERS>))
```

where the `http.Client`'s transport is uninitialized then issuing a request will cause a panic.

This PR addresses that by setting the transport to `http.DefaultTransport` whenever the caller provided the client but didn't set the transport.