### PR TITLE
chore(ci): relax github workflow masks to ease license debugging

### DIFF
--- a/.github/workflows/kong-license.yaml
+++ b/.github/workflows/kong-license.yaml
@@ -19,7 +19,13 @@ jobs:
         id: license
         run: |
           LICENSE=$(curl -s -L -u"$PULP_USERNAME:$PULP_PASSWORD" "$PULP_LICENSE_URL")
-          echo "::add-mask::$LICENSE"
+
+          MASKED_SIGNATURE=$(echo $LICENSE | jq '.license.signature[10:]')
+          echo "::add-mask::$MASKED_SIGNATURE"
+
+          LICENSE_KEY=$(echo $LICENSE | jq '.license.payload.license_key')
+          echo "::add-mask::$LICENSE_KEY"
+
           echo "::set-output name=LICENSE::$LICENSE"
 
       - uses: gliech/create-github-secret-action@ea87807ab20663b30a1a2d14d7f6dd9490b1e7a1 # v1.4.10


### PR DESCRIPTION
In order to help in debugging with missing license CI errors, let's relax Github workflow masks to show some parts of the license so that it's easier to figure out if the license indeed is outdated (or missing).

Exemplar CI workflow: https://github.com/pmalek/go-kong/runs/7128060127?check_suite_focus=true#step:3:4

Exemplar logs:

```
Run gliech/create-github-secret-action@ea87807ab20663b30a1a2d14d7f6dd9490b1e7a1
  with:
    name: KONG_LICENSE_DATA
    value: {"license":{"payload":{"***_seats":"5","customer":"automation","dataplanes":"100","license_creation_date":"2022-06-10","license_expiration_date":"2022-07-20","license_key":***,"product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"e3923b0e7f***","version":"1"}}
    pa_token: ***
    org_visibility: private
```

Related CI failures in enterprise tests: https://github.com/Kong/go-kong/pull/185