### PR TITLE
fix: remove license from OSS CI

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -37,16 +37,6 @@ jobs:
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      # This will set KONG_LINCENSE_DATA environment variable.
-      # NOTE:
-      # This could be (?) made a shared step but for some reason it's impossible
-      # to override:
-      # Warning: Skip output 'license' since it may contain secret.
-      # on Github Actions when setting a job output.
-      - uses: Kong/kong-license@9fb64ad7be1ed2b121a70990783d7c0869e531d5
-        id: license_step
-        with:
-          password: ${{ secrets.PULP_PASSWORD }}
       - name: Setup go
         uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
The OSS tests do not need a license, and the environment variable's [original presence in them](https://github.com/Kong/go-kong/commit/fd79bea198187eb794fa89428d3cb3149040daf2#diff-b6766eb8febc0c51651250cd0cdfb44c4f0d3256470d88e62bf82fd46aa73ae0L30) was probably an unnecessary copy-paste. Unfortunately the old variable would be benignly empty for the tests that didn't need it, whereas the new job will actually fail them :fearful: 