### PR TITLE
feat: add new fields in upstreams of kong 3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
@@ -42,7 +43,7 @@ require (
 	golang.org/x/tools v0.1.10-0.20220218145154-897bd77cd717 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/gengo v0.0.0-20211129171323-c02415ce4185 // indirect
+	k8s.io/gengo v0.0.0-20220613173612-397b4ae3bce7 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,8 @@ k8s.io/code-generator v0.24.3/go.mod h1:dpVhs00hTuTdTY6jvVxvTFCk6gSMrtfRydbhZwHI
 k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/gengo v0.0.0-20211129171323-c02415ce4185 h1:TT1WdmqqXareKxZ/oNXEUSwKlLiHzPMyB0t8BaFeBYI=
 k8s.io/gengo v0.0.0-20211129171323-c02415ce4185/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/gengo v0.0.0-20220613173612-397b4ae3bce7 h1:RGb68G3yotdQggcyenx9y0+lnVJCXXcLa6geXOMlf5o=
+k8s.io/gengo v0.0.0-20220613173612-397b4ae3bce7/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.60.1 h1:VW25q3bZx9uE3vvdL6M8ezOX79vA2Aq1nEWLqNQclHc=

--- a/kong/types.go
+++ b/kong/types.go
@@ -218,21 +218,25 @@ type UpstreamNodeHealth struct {
 // Upstream represents an Upstream in Kong.
 // +k8s:deepcopy-gen=true
 type Upstream struct {
-	ID                 *string      `json:"id,omitempty" yaml:"id,omitempty"`
-	Name               *string      `json:"name,omitempty" yaml:"name,omitempty"`
-	HostHeader         *string      `json:"host_header,omitempty" yaml:"host_header,omitempty"`
-	ClientCertificate  *Certificate `json:"client_certificate,omitempty" yaml:"client_certificate,omitempty"`
-	Algorithm          *string      `json:"algorithm,omitempty" yaml:"algorithm,omitempty"`
-	Slots              *int         `json:"slots,omitempty" yaml:"slots,omitempty"`
-	Healthchecks       *Healthcheck `json:"healthchecks,omitempty" yaml:"healthchecks,omitempty"`
-	CreatedAt          *int64       `json:"created_at,omitempty" yaml:"created_at,omitempty"`
-	HashOn             *string      `json:"hash_on,omitempty" yaml:"hash_on,omitempty"`
-	HashFallback       *string      `json:"hash_fallback,omitempty" yaml:"hash_fallback,omitempty"`
-	HashOnHeader       *string      `json:"hash_on_header,omitempty" yaml:"hash_on_header,omitempty"`
-	HashFallbackHeader *string      `json:"hash_fallback_header,omitempty" yaml:"hash_fallback_header,omitempty"`
-	HashOnCookie       *string      `json:"hash_on_cookie,omitempty" yaml:"hash_on_cookie,omitempty"`
-	HashOnCookiePath   *string      `json:"hash_on_cookie_path,omitempty" yaml:"hash_on_cookie_path,omitempty"`
-	Tags               []*string    `json:"tags,omitempty" yaml:"tags,omitempty"`
+	ID                     *string      `json:"id,omitempty" yaml:"id,omitempty"`
+	Name                   *string      `json:"name,omitempty" yaml:"name,omitempty"`
+	HostHeader             *string      `json:"host_header,omitempty" yaml:"host_header,omitempty"`
+	ClientCertificate      *Certificate `json:"client_certificate,omitempty" yaml:"client_certificate,omitempty"`
+	Algorithm              *string      `json:"algorithm,omitempty" yaml:"algorithm,omitempty"`
+	Slots                  *int         `json:"slots,omitempty" yaml:"slots,omitempty"`
+	Healthchecks           *Healthcheck `json:"healthchecks,omitempty" yaml:"healthchecks,omitempty"`
+	CreatedAt              *int64       `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	HashOn                 *string      `json:"hash_on,omitempty" yaml:"hash_on,omitempty"`
+	HashFallback           *string      `json:"hash_fallback,omitempty" yaml:"hash_fallback,omitempty"`
+	HashOnHeader           *string      `json:"hash_on_header,omitempty" yaml:"hash_on_header,omitempty"`
+	HashFallbackHeader     *string      `json:"hash_fallback_header,omitempty" yaml:"hash_fallback_header,omitempty"`
+	HashOnCookie           *string      `json:"hash_on_cookie,omitempty" yaml:"hash_on_cookie,omitempty"`
+	HashOnCookiePath       *string      `json:"hash_on_cookie_path,omitempty" yaml:"hash_on_cookie_path,omitempty"`
+	HashOnQueryArg         *string      `json:"hash_on_query_arg,omitempty" yaml:"hash_on_query_arg,omitempty"`
+	HashFallbackQueryArg   *string      `json:"hash_fallback_query_arg,omitempty" yaml:"hash_fallback_query_arg,omitempty"` //nolint:lll
+	HashOnURICapture       *string      `json:"hash_on_uri_capture,omitempty" yaml:"hash_on_uri_capture,omitempty"`
+	HashFallbackURICapture *string      `json:"hash_fallback_uri_capture,omitempty" yaml:"hash_fallback_uri_capture,omitempty"` //nolint:lll
+	Tags                   []*string    `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 // Target represents a Target in Kong.

--- a/kong/zz_generated.deepcopy.go
+++ b/kong/zz_generated.deepcopy.go
@@ -1917,6 +1917,26 @@ func (in *Upstream) DeepCopyInto(out *Upstream) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.HashOnQueryArg != nil {
+		in, out := &in.HashOnQueryArg, &out.HashOnQueryArg
+		*out = new(string)
+		**out = **in
+	}
+	if in.HashFallbackQueryArg != nil {
+		in, out := &in.HashFallbackQueryArg, &out.HashFallbackQueryArg
+		*out = new(string)
+		**out = **in
+	}
+	if in.HashOnURICapture != nil {
+		in, out := &in.HashOnURICapture, &out.HashOnURICapture
+		*out = new(string)
+		**out = **in
+	}
+	if in.HashFallbackURICapture != nil {
+		in, out := &in.HashFallbackURICapture, &out.HashFallbackURICapture
+		*out = new(string)
+		**out = **in
+	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make([]*string, len(*in))


### PR DESCRIPTION
add the 4 new fields in `Upstream`:
- `hash_on_query_arg`
- `hash_fallback_query_arg`
- `hash_on_uri_capture`
- `hash_fallback_uri_capture`
would fix #199.