### PR TITLE
fix - let the PluginId be optional like the create method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v0.31.1](#v0311)
 - [v0.31.0](#v0310)
 - [v0.30.0](#v0300)
 - [v0.29.0](#v0290)
@@ -37,6 +38,13 @@
 - [0.3.0](#030)
 - [0.2.0](#020)
 - [0.1.0](#010)
+
+## [v0.31.1]
+
+> Release date: 2022/08/23
+
+- Fixed support for plugins with IDs in `ForService` variants of plugin calls.
+  [#205](https://github.com/Kong/go-kong/pull/205)
 
 ## [v0.31.0]
 
@@ -586,6 +594,7 @@ authentication credentials in Kong.
   releases of Kong since every release of Kong is introducing breaking changes
   to the Admin API.
 
+[v0.31.1]: https://github.com/Kong/go-kong/compare/v0.31.0...v0.31.1
 [v0.31.0]: https://github.com/Kong/go-kong/compare/v0.30.0...v0.31.0
 [v0.30.0]: https://github.com/Kong/go-kong/compare/v0.29.0...v0.30.0
 [v0.29.0]: https://github.com/Kong/go-kong/compare/v0.28.1...v0.29.0

--- a/kong/plugin_service.go
+++ b/kong/plugin_service.go
@@ -113,14 +113,17 @@ func (s *PluginService) Create(ctx context.Context,
 func (s *PluginService) CreateForService(ctx context.Context,
 	serviceIDorName *string, plugin *Plugin,
 ) (*Plugin, error) {
-	if isEmptyString(plugin.ID) {
-		return nil, fmt.Errorf("ID cannot be nil for Update operation")
+	queryPath := "/plugins"
+	method := "POST"
+	if plugin.ID != nil {
+		queryPath = queryPath + "/" + *plugin.ID
+		method = "PUT"
 	}
 	if isEmptyString(serviceIDorName) {
 		return nil, fmt.Errorf("serviceIDorName cannot be nil")
 	}
 
-	return s.sendRequest(ctx, plugin, fmt.Sprintf("/services/%v/plugins", *serviceIDorName), "POST")
+	return s.sendRequest(ctx, plugin, fmt.Sprintf("/services/%v"+queryPath, *serviceIDorName), method)
 }
 
 // Get fetches a Plugin in Kong.

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -122,6 +122,12 @@ func TestPluginsService(T *testing.T) {
 	err = client.Plugins.DeleteForService(defaultCtx, createdService.Name, updatedPlugin.ID)
 	assert.NoError(err)
 
+	//Create plugin without ID
+	_, err = client.Plugins.CreateForService(defaultCtx, createdService.Name, &Plugin{Name: String("key-auth")})
+	assert.NoError(err)
+	assert.NotNil(createdPlugin)
+	assert.NotNil(createdPlugin.ID)
+
 	assert.NoError(client.Services.Delete(defaultCtx, createdService.ID))
 }
 

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -122,7 +122,7 @@ func TestPluginsService(T *testing.T) {
 	err = client.Plugins.DeleteForService(defaultCtx, createdService.Name, updatedPlugin.ID)
 	assert.NoError(err)
 
-	//Create plugin without ID
+	// Create plugin without ID
 	_, err = client.Plugins.CreateForService(defaultCtx, createdService.Name, &Plugin{Name: String("key-auth")})
 	assert.NoError(err)
 	assert.NotNil(createdPlugin)


### PR DESCRIPTION
Small fix for the PR : https://github.com/Kong/go-kong/pull/192

It seems that we let a small error within the PR, the PluginID was mandatory, sorry.