### PR TITLE
feat: add support for Kong Gateway four digit versioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.19
 replace github.com/imdario/mergo v0.3.12 => github.com/Kong/mergo v0.3.13
 
 require (
-	github.com/blang/semver/v4 v4.0.0
 	github.com/google/go-cmp v0.5.8
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.3.0
 	github.com/imdario/mergo v0.3.12
+	github.com/kong/semver/v4 v4.0.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/stretchr/testify v1.8.0
 	github.com/tidwall/gjson v1.14.3

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
-github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -79,6 +77,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kong/semver/v4 v4.0.1 h1:DIcNR8W3gfx0KabFBADPalxxsp+q/5COwIFkkhrFQ2Y=
+github.com/kong/semver/v4 v4.0.1/go.mod h1:LImQ0oT15pJvSns/hs2laLca2zcYoHu5EsSNY0J6/QA=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -563,6 +563,7 @@ func TestFillPluginDefaults(T *testing.T) {
 			if err := FillPluginsDefaults(p, fullSchema); err != nil {
 				t.Errorf(err.Error())
 			}
+
 			if diff := cmp.Diff(p, tc.expected); diff != "" {
 				t.Errorf(diff)
 			}

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -59,24 +59,65 @@ func TestStringSlice(t *testing.T) {
 }
 
 func TestFixVersion(t *testing.T) {
-	validVersions := map[string]string{
-		"0.14.1":                          "0.14.1",
-		"0.14.2rc":                        "0.14.2-rc",
-		"0.14.2rc1":                       "0.14.2-rc1",
-		"0.14.2preview":                   "0.14.2-preview",
-		"0.14.2preview1":                  "0.14.2-preview1",
-		"0.33-enterprise-edition":         "0.33.0+enterprise",
-		"0.33-1-enterprise-edition":       "0.33.1+enterprise",
-		"1.3.0.0-enterprise-edition-lite": "1.3.0+0-enterprise-lite",
-		"1.3.0.0-enterprise-lite":         "1.3.0+0-enterprise-lite",
+	tests := []struct {
+		version         string
+		expectedVersion string
+		isEnterprise    bool
+	}{
+		{
+			version:         "0.14.1",
+			expectedVersion: "0.14.1",
+		},
+		{
+			version:         "0.14.2rc",
+			expectedVersion: "0.14.2",
+		},
+		{
+			version:         "0.14.2rc1",
+			expectedVersion: "0.14.2",
+		},
+		{
+			version:         "0.14.2preview",
+			expectedVersion: "0.14.2",
+		},
+		{
+			version:         "0.14.2preview1",
+			expectedVersion: "0.14.2",
+		},
+		{
+			version:         "0.33-enterprise-edition",
+			expectedVersion: "0.33.0",
+			isEnterprise:    true,
+		},
+		{
+			version:         "0.33-1-enterprise-edition",
+			expectedVersion: "0.33.1",
+			isEnterprise:    true,
+		},
+		{
+			version:         "1.3.0.0-enterprise-edition-lite",
+			expectedVersion: "1.3.0.0",
+			isEnterprise:    true,
+		},
+		{
+			version:         "3.0.0.0",
+			expectedVersion: "3.0.0.0",
+			isEnterprise:    true,
+		},
+		{
+			version:         "3.0.0.0-enterprise-edition",
+			expectedVersion: "3.0.0.0",
+			isEnterprise:    true,
+		},
 	}
-	for inputVersion, expectedVersion := range validVersions {
-		v, err := ParseSemanticVersion(inputVersion)
+	for _, test := range tests {
+		v, err := ParseSemanticVersion(test.version)
 		if err != nil {
-			t.Errorf("error converting %s: %v", inputVersion, err)
-		} else if v.String() != expectedVersion {
-			t.Errorf("converting %s, expecting %s, getting %s", inputVersion, expectedVersion, v.String())
+			t.Errorf("error converting %s: %v", test.version, err)
+		} else if v.String() != test.expectedVersion {
+			t.Errorf("converting %s, expecting %s, getting %s", test.version, test.expectedVersion, v.String())
 		}
+		assert.Equal(t, test.isEnterprise, v.IsKongGatewayEnterprise())
 	}
 
 	invalidVersions := []string{

--- a/kong/versioning.go
+++ b/kong/versioning.go
@@ -1,0 +1,157 @@
+package kong
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/kong/semver/v4"
+)
+
+// Version represents a three or four digit version.
+type Version struct {
+	// version represents a three of four digit version using the forked kong/semver
+	// library.
+	version semver.Version
+	// str represents the original version string when creating Version.
+	str string
+}
+
+// Range represents a range of versions which can be use to validate if a Version is valid
+// for a Range.
+type Range func(Version) bool
+
+// NewVersion creates a new instance of a Version.
+func NewVersion(versionStr string) (Version, error) {
+	version, err := semver.Parse(versionStr)
+	if err != nil {
+		return Version{}, fmt.Errorf("unable to create version: %w", err)
+	}
+
+	// Remove pre-release and build metadata versioning for finalized version comparisons
+	version.Pre = []semver.PRVersion{}
+	version.Build = []string{}
+
+	return Version{
+		version: version,
+		str:     versionStr,
+	}, nil
+}
+
+// MustNewVersion creates a new instance of a Version; however it will panic if it cannot
+// be created.
+func MustNewVersion(versionStr string) Version {
+	version, err := NewVersion(versionStr)
+	if err != nil {
+		panic(err)
+	}
+	return version
+}
+
+// Major returns the major digit of Version.
+func (v Version) Major() uint64 {
+	return v.version.Major
+}
+
+// Minor returns the minor digit of Version.
+func (v Version) Minor() uint64 {
+	return v.version.Minor
+}
+
+// Patch returns the patch digit of Version.
+func (v Version) Patch() uint64 {
+	return v.version.Patch
+}
+
+// Revision returns the revision digit of Version; if revision has not been set then an error
+// will be returned.
+func (v Version) Revision() (uint64, error) {
+	if v.version.Revision < 0 {
+		return 0, errors.New("revision is unavailable for version")
+	}
+	return uint64(v.version.Revision), nil
+}
+
+// PreRelease returns the pre-release string of Version.
+func (v Version) PreRelease() string {
+	var preReleaseStr strings.Builder
+	if len(v.version.Pre) > 0 {
+		fmt.Fprintf(&preReleaseStr, "-%s", v.version.Pre[0].String())
+		for _, preRelease := range v.version.Pre[1:] {
+			preReleaseStr.WriteString(".")
+			preReleaseStr.WriteString(preRelease.String())
+		}
+	}
+	return preReleaseStr.String()
+}
+
+// Build returns the build metadata string of Version.
+func (v Version) Build() string {
+	var buildStr strings.Builder
+	if len(v.version.Build) > 0 {
+		fmt.Fprintf(&buildStr, "+%s", v.version.Build[0])
+		for _, build := range v.version.Build[1:] {
+			buildStr.WriteString(".")
+			buildStr.WriteString(build)
+		}
+	}
+	return buildStr.String()
+}
+
+// String returns the textual or display value of the Version.
+func (v Version) String() string {
+	return v.version.String()
+}
+
+// IsKongGatewayEnterprise determines if a Version represents a Kong Gateway enterprise edition.
+func (v Version) IsKongGatewayEnterprise() bool {
+	return v.version.Revision >= 0 || strings.Contains(v.str, "enterprise")
+}
+
+// NewRange creates an instance of a Range.
+// Valid ranges can consist of multiple comparisons and three/four digit versions:
+//   - "<1.0.0" || "<v1.0.0.0"
+//   - "<=1.0.0" || "<=1.0.0.0"
+//   - ">1.0.0" || ">1.0.0.0"
+//   - ">=1.0.0" || >= 1.0.0.0
+//   - "1.0.0", "=1.0.0", "==1.0.0" || "1.0.0.0", "=1.0.0.0", "==1.0.0.0"
+//   - "!1.0.0", "!=1.0.0" || "!1.0.0.0", "!=1.0.0.0"
+//
+// A Range can consist of multiple ranges separated by space:
+// Ranges can be linked by logical AND:
+//   - ">1.0.0 <2.0.0" would match between both ranges, so "1.1.1" and "1.8.7" but not "1.0.0" or "2.0.0"
+//   - ">1.0.0 <3.0.0 !2.0.3-beta.2" would match every version between 1.0.0 and 3.0.0 except 2.0.3-beta.2
+//
+// Four digit versions can be used in ranges with three digit version and linked by logical AND:
+//   - ">1.0.0 <2.0.0.0" would match between both ranges, so "1.0.0.1" and "1.8.7" but not "1.0.0", "2.0.0"
+//   - ">1.0.0 <3.0.0 !2.0.3.0-beta.2" would match every version between 1.0.0 and 3.0.0 except 2.0.3-beta.2 and
+//     2.0.3.0-beta2
+//
+// Ranges can also be linked by logical OR:
+//   - "<2.0.0 || >=3.0.0" would match "1.x.x" and "3.x.x" but not "2.x.x"
+//
+// Four digit versions can be used in ranges with three digit version and linked by logical OR:
+//
+// AND has a higher precedence than OR. It's not possible to use brackets.
+//
+// Ranges can be combined by both AND and OR:
+//   - ">1.0.0 <2.0.0.0 || >3.0.0 !4.2.1" would match "1.2.3", "1.0.0.1", "1.9.9", "3.1.1", but not "4.2.1", "2.1.1"
+func NewRange(rangeStr string) (Range, error) {
+	rng, err := semver.ParseRange(rangeStr)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create range: %w", err)
+	}
+	return Range(func(version Version) bool {
+		return rng(version.version)
+	}), nil
+}
+
+// MustNewRange creates a new instance of a Version; however it will panic if it cannot
+// be created.
+func MustNewRange(rangeStr string) Range {
+	rng, err := NewRange(rangeStr)
+	if err != nil {
+		panic(err)
+	}
+	return rng
+}

--- a/kong/versioning.go
+++ b/kong/versioning.go
@@ -17,7 +17,7 @@ type Version struct {
 	str string
 }
 
-// Range represents a range of versions which can be use to validate if a Version is valid
+// Range represents a range of versions which can be used to validate if a Version is valid
 // for a Range.
 type Range func(Version) bool
 

--- a/kong/versioning_test.go
+++ b/kong/versioning_test.go
@@ -1,0 +1,419 @@
+package kong
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersioning_Version(t *testing.T) {
+	t.Run("valid version string with three or four digits creates a version", func(t *testing.T) {
+		tests := []struct {
+			versionStr         string
+			expectedVersionStr string
+			expectedMajor      uint64
+			expectedMinor      uint64
+			expectedPatch      uint64
+			expectedRevision   uint64
+			isEnterprise       bool
+			hasRevision        bool
+		}{
+			// Three digit versions OSS
+			{
+				versionStr:         "0.33.3",
+				expectedVersionStr: "0.33.3",
+				expectedMajor:      0,
+				expectedMinor:      33,
+				expectedPatch:      3,
+			},
+			{
+				versionStr:         "1.2.0-alpha",
+				expectedVersionStr: "1.2.0",
+				expectedMajor:      1,
+				expectedMinor:      2,
+			},
+			{
+				versionStr:         "2.1.1+build.metadata",
+				expectedVersionStr: "2.1.1",
+				expectedMajor:      2,
+				expectedMinor:      1,
+				expectedPatch:      1,
+			},
+			{
+				versionStr:         "2.6.10-alpha+build.metadata",
+				expectedVersionStr: "2.6.10",
+				expectedMajor:      2,
+				expectedMinor:      6,
+				expectedPatch:      10,
+			},
+			{
+				versionStr:         "3.0.0+alpha-build.metadata",
+				expectedVersionStr: "3.0.0",
+				expectedMajor:      3,
+				expectedMinor:      0,
+				expectedPatch:      0,
+			},
+			// Three digit versions enterprise
+			{
+				versionStr:         "0.33.3-enterprise",
+				expectedVersionStr: "0.33.3",
+				expectedMajor:      0,
+				expectedMinor:      33,
+				expectedPatch:      3,
+				isEnterprise:       true,
+			},
+			{
+				versionStr:         "1.2.0-alpha-enterprise",
+				expectedVersionStr: "1.2.0",
+				expectedMajor:      1,
+				expectedMinor:      2,
+				isEnterprise:       true,
+			},
+			{
+				versionStr:         "2.1.1+build.metadata-enterprise-edition",
+				expectedVersionStr: "2.1.1",
+				expectedMajor:      2,
+				expectedMinor:      1,
+				expectedPatch:      1,
+				isEnterprise:       true,
+			},
+			{
+				versionStr:         "2.6.10-alpha+build.metadataenterprise",
+				expectedVersionStr: "2.6.10",
+				expectedMajor:      2,
+				expectedMinor:      6,
+				expectedPatch:      10,
+				isEnterprise:       true,
+			},
+			{
+				versionStr:         "3.0.0+alphaenterpriseedition-build.metadata",
+				expectedVersionStr: "3.0.0",
+				expectedMajor:      3,
+				expectedMinor:      0,
+				expectedPatch:      0,
+				isEnterprise:       true,
+			},
+
+			// Four digit versions enterprise
+			{
+				versionStr:         "0.33.3.1",
+				expectedVersionStr: "0.33.3.1",
+				expectedMajor:      0,
+				expectedMinor:      33,
+				expectedPatch:      3,
+				expectedRevision:   1,
+				isEnterprise:       true,
+				hasRevision:        true,
+			},
+			{
+				versionStr:         "2.8.1.3-1",
+				expectedVersionStr: "2.8.1.3",
+				expectedMajor:      2,
+				expectedMinor:      8,
+				expectedPatch:      1,
+				expectedRevision:   3,
+				isEnterprise:       true,
+				hasRevision:        true,
+			},
+			{
+				versionStr:         "3.0.0.0",
+				expectedVersionStr: "3.0.0.0",
+				expectedMajor:      3,
+				expectedMinor:      0,
+				expectedPatch:      0,
+				expectedRevision:   0,
+				isEnterprise:       true,
+				hasRevision:        true,
+			},
+			{
+				versionStr:         "1.2.0.0-alpha",
+				expectedVersionStr: "1.2.0.0",
+				expectedMajor:      1,
+				expectedMinor:      2,
+				expectedRevision:   0,
+				isEnterprise:       true,
+				hasRevision:        true,
+			},
+			{
+				versionStr:         "2.1.1.3+build.metadata",
+				expectedVersionStr: "2.1.1.3",
+				expectedMajor:      2,
+				expectedMinor:      1,
+				expectedPatch:      1,
+				expectedRevision:   3,
+				isEnterprise:       true,
+				hasRevision:        true,
+			},
+			{
+				versionStr:         "2.6.10.1234-alpha+build.metadata",
+				expectedVersionStr: "2.6.10.1234",
+				expectedMajor:      2,
+				expectedMinor:      6,
+				expectedPatch:      10,
+				expectedRevision:   1234,
+				isEnterprise:       true,
+				hasRevision:        true,
+			},
+			{
+				versionStr:         "3.0.0.56+alpha-build.metadata",
+				expectedVersionStr: "3.0.0.56",
+				expectedMajor:      3,
+				expectedMinor:      0,
+				expectedPatch:      0,
+				expectedRevision:   56,
+				isEnterprise:       true,
+				hasRevision:        true,
+			},
+		}
+
+		for _, test := range tests {
+			version, err := NewVersion(test.versionStr)
+			require.NoError(t, err)
+			require.Equal(t, test.versionStr, version.str)
+			require.Equal(t, test.expectedVersionStr, version.String())
+			require.Equal(t, test.expectedMajor, version.Major())
+			require.Equal(t, test.expectedMinor, version.Minor())
+			require.Equal(t, test.expectedPatch, version.Patch())
+			revision, err := version.Revision()
+			if test.hasRevision {
+				require.Equal(t, test.expectedRevision, revision)
+			} else {
+				require.EqualError(t, err, "revision is unavailable for version")
+			}
+			require.Equal(t, test.isEnterprise, version.IsKongGatewayEnterprise())
+			require.Empty(t, version.PreRelease()) // Pre-release has been removed after parsing
+			require.Empty(t, version.Build())      // Build has been removed after parsing
+		}
+	})
+
+	t.Run("invalid version string returns error when creating a new version", func(t *testing.T) {
+		tests := []string{
+			"3.0",
+			"one.two.three",
+			"one.two.three.four",
+			"1.000.1",
+			"1.001.1",
+			"1.01.1.1",
+			"1.1.1alpha",
+			"1.1.1.1alpha",
+		}
+
+		for _, invalidVersion := range tests {
+			version, err := NewVersion(invalidVersion)
+			require.ErrorContains(t, err, invalidVersion)
+			require.Equal(t, Version{}, version)
+		}
+	})
+}
+
+func TestVersioning_ForceNewVersion(t *testing.T) {
+	t.Run("ensure valid version does not panic with three and four digit version", func(t *testing.T) {
+		tests := []string{
+			"1.2.3",
+			"1.2.3.4",
+		}
+		for _, test := range tests {
+			version := MustNewVersion(test)
+			require.Equal(t, test, version.String())
+		}
+	})
+
+	t.Run("ensure panic occurs for invalid version", func(t *testing.T) {
+		defer func() {
+			if err := recover(); err == nil {
+				t.Error("panic test did not panic")
+			}
+		}()
+		_ = MustNewVersion("invalid.version")
+	})
+}
+
+func TestVersioning_Range(t *testing.T) {
+	// Create two versions, three and four digits, for comparison checks with ranges
+	v123, err := NewVersion("1.2.3")
+	require.NoError(t, err)
+	v1234, err := NewVersion("1.2.3.4")
+	require.NoError(t, err)
+
+	t.Run("valid range string with three or four digits creates a range comparison function", func(t *testing.T) {
+		// Note: When comparing three digit versions to four digit versions the revision is ignored
+		tests := []struct {
+			rangeStr                 string
+			expectedThreeDigitResult bool
+			expectedFourDigitResult  bool
+		}{
+			// Three digit version ranges
+			{
+				rangeStr:                 "<= 2.0.0",
+				expectedThreeDigitResult: true,
+				expectedFourDigitResult:  true,
+			},
+			{
+				rangeStr:                 "<= 1.2.0",
+				expectedThreeDigitResult: false,
+				expectedFourDigitResult:  false,
+			},
+			{
+				rangeStr:                 ">= 1.2.0",
+				expectedThreeDigitResult: true,
+				expectedFourDigitResult:  true,
+			},
+			{
+				rangeStr:                 "<= 1.2.3",
+				expectedThreeDigitResult: true,
+				expectedFourDigitResult:  true,
+			},
+			{
+				rangeStr:                 "== 1.2.3",
+				expectedThreeDigitResult: true,
+				expectedFourDigitResult:  true,
+			},
+			{
+				rangeStr: "!= 1.2.3",
+			},
+			{
+				rangeStr:                 ">= 1.2.3",
+				expectedThreeDigitResult: true,
+				expectedFourDigitResult:  true,
+			},
+			{
+				rangeStr:                 ">= 1.2.3+build.metadata",
+				expectedThreeDigitResult: true,
+				expectedFourDigitResult:  true,
+			},
+			// Note: Pre-release versions are concerned less than normal versions
+			{
+				rangeStr: "== 1.2.3-alpha",
+			},
+			{
+				rangeStr:                 "> 1.2.3-alpha",
+				expectedThreeDigitResult: true,
+				expectedFourDigitResult:  true,
+			},
+			// Four digit version ranges
+			{
+				rangeStr:                 "<= 2.0.0.0",
+				expectedThreeDigitResult: true,
+				expectedFourDigitResult:  true,
+			},
+			{
+				rangeStr:                 "<= 1.2.3.0",
+				expectedThreeDigitResult: true,
+				expectedFourDigitResult:  false,
+			},
+			{
+				rangeStr:                 ">= 1.2.3.0",
+				expectedThreeDigitResult: true,
+				expectedFourDigitResult:  true,
+			},
+			{
+				rangeStr:                 "<= 1.2.3.4",
+				expectedThreeDigitResult: true,
+				expectedFourDigitResult:  true,
+			},
+			{
+				rangeStr:                 "== 1.2.3.4",
+				expectedThreeDigitResult: true,
+				expectedFourDigitResult:  true,
+			},
+			{
+				rangeStr:                 "!= 1.2.3.2",
+				expectedThreeDigitResult: false,
+				expectedFourDigitResult:  true,
+			},
+			{
+				rangeStr:                 ">= 1.2.3.4",
+				expectedThreeDigitResult: true,
+				expectedFourDigitResult:  true,
+			},
+			{
+				rangeStr:                 ">= 1.2.3.4+build.metadata",
+				expectedThreeDigitResult: true,
+				expectedFourDigitResult:  true,
+			},
+			// Note: Pre-release versions are concerned less than normal versions
+			{
+				rangeStr: "== 1.2.3.4-alpha",
+			},
+			{
+				rangeStr:                 "> 1.2.3.4-beta",
+				expectedThreeDigitResult: true,
+				expectedFourDigitResult:  true,
+			},
+			// Ensure v2 is within range, but three digit v1 is not satisfied
+			{
+				rangeStr:                 ">= 1.2.3 < 1.2.3.5",
+				expectedThreeDigitResult: false,
+				expectedFourDigitResult:  true,
+			},
+			// Ensure v1 is within range, but four digit v2 is not satisfied
+			{
+				rangeStr:                 ">= 1.2.3.5 < 1.2.5",
+				expectedThreeDigitResult: true,
+				expectedFourDigitResult:  false,
+			},
+			// Ensure v1 is excluded from range and four digit v2 is not satisfied
+			{
+				rangeStr:                 ">= 1.2.3.5 < 1.2.5 != 1.2.3",
+				expectedThreeDigitResult: false,
+				expectedFourDigitResult:  false,
+			},
+			// Ensure v1 is excluded by build meta range and four digit v2 is satisfied
+			// since as range is valid for 1.2.3.4 using pre-release and build metadata
+			// in ranges; pre-releases are considered less than normal/finalized versions
+			{
+				rangeStr:                 "> 1.2.3.4-alpha < 1.2.5 != 1.2.3.5+build.metadata",
+				expectedThreeDigitResult: false,
+				expectedFourDigitResult:  true,
+			},
+		}
+
+		for _, test := range tests {
+			rng, err := NewRange(test.rangeStr)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedThreeDigitResult, rng(v123))
+			require.Equal(t, test.expectedFourDigitResult, rng(v1234))
+		}
+	})
+
+	t.Run("invalid range string returns error when creating a new range", func(t *testing.T) {
+		tests := []string{
+			"<= one.two.three",
+			">= one.two.three.four",
+			"!= 1.000.1 < 1.0.0",
+			"~@ 1.001.1",
+			"< 1.01.1.1",
+			"> 1.1.1alpha",
+			"== 1.1.1.1alpha",
+			"$1.1.1",
+		}
+
+		for _, invalidRange := range tests {
+			version, err := NewRange(invalidRange)
+			require.Error(t, err)
+			require.Nil(t, version)
+		}
+	})
+}
+
+func TestVersioning_ForceNewRange(t *testing.T) {
+	t.Run("ensure valid range does not panic with three and four digit version", func(t *testing.T) {
+		tests := []string{
+			"<= 1.2.3",
+			"<= 1.2.3.4",
+		}
+		for _, test := range tests {
+			rng := MustNewRange(test)
+			require.NotNil(t, rng)
+		}
+	})
+
+	t.Run("ensure panic occurs for invalid range", func(t *testing.T) {
+		defer func() {
+			if err := recover(); err == nil {
+				t.Error("panic test did not panic")
+			}
+		}()
+		_ = MustNewRange("<= invalid.range")
+	})
+}


### PR DESCRIPTION
This feature adds four digit versioning for Kong Gateway; OSS and enterprise. Starting with 3.0.0.0 Kong Gateway has dropped the "enterprise-edition" suffix from the version in both the CLI output and the version field from the root endpoint. Moving forward all four digit versions and any version ending with the "enterprise" or "enterprise-edition" suffix will be considered an enterprise edition.

This feature also allows for updated version range comparisons to use the fourth digit. This is beneficial when comparing against revision updates for Kong Gateway allowing for more granular specifications.

Note: This feature also removes pre-release and build metadata information from the underlying kong/semver implementation so that any pre-release can be compared to an actual version number.