### PR TITLE
Release 0.32

### DIFF
--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -9,6 +9,7 @@ sudo apt-get install openssl libpcre3 procps perl wget zlibc
 function setup_kong(){
   SWITCH="1.3.000"
   SWITCH2="2.0.000"
+  SWITCH3="2.8.000"
 
   URL="https://download.konghq.com/gateway-1.x-ubuntu-xenial/pool/all/k/kong/kong_${KONG_VERSION}_all.deb"
 
@@ -22,13 +23,26 @@ function setup_kong(){
   URL="https://download.konghq.com/gateway-2.x-ubuntu-xenial/pool/all/k/kong/kong_${KONG_VERSION}_amd64.deb"
   fi
 
-  /usr/bin/curl -sL $URL -o kong.deb
+  if [[ "$KONG_VERSION" > "$SWITCH3" ]];
+  then
+  URL="https://download.konghq.com/gateway-3.x-ubuntu-focal/pool/all/k/kong/kong_${KONG_VERSION}_amd64.deb"
+  fi
+
+  echo "Saving ${URL} to kong.deb"
+  RESPONSE_CODE=$(/usr/bin/curl -sL \
+    -w "%{http_code}" \
+    $URL -o kong.deb)
+  if [[ $RESPONSE_CODE != "200" ]]; then
+    echo "error retrieving kong package from ${URL}. response code ${RESPONSE_CODE}"
+    exit 1 
+  fi
 }
 
 function setup_kong_enterprise(){
   KONG_VERSION="${KONG_VERSION#enterprise-}"
   SWITCH="1.5.0.100"
   SWITCH2="2.0.0.000"
+  SWITCH3="2.8.0.000"
 
   URL="https://download.konghq.com/private/gateway-1.x-ubuntu-xenial/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_${KONG_VERSION}_all.deb"
 
@@ -42,6 +56,12 @@ function setup_kong_enterprise(){
   URL="https://download.konghq.com/gateway-2.x-ubuntu-xenial/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_${KONG_VERSION}_all.deb"
   fi
 
+  if [[ "$KONG_VERSION" > "$SWITCH3" ]];
+  then
+  URL="https://download.konghq.com/gateway-3.x-ubuntu-bionic/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_${KONG_VERSION}_amd64.deb"
+  fi
+
+  echo "Saving ${URL} to kong.deb"
   RESPONSE_CODE=$(/usr/bin/curl -sL \
     -w "%{http_code}" \
     -u $KONG_ENTERPRISE_REPO_USERNAME:$KONG_ENTERPRISE_REPO_PASSSWORD \

--- a/.github/workflows/integration-test-enterprise.yaml
+++ b/.github/workflows/integration-test-enterprise.yaml
@@ -23,6 +23,7 @@ jobs:
         - 'enterprise-2.6.0.2'
         - 'enterprise-2.7.0.0'
         - 'enterprise-2.8.0.0'
+        - 'enterprise-3.0.0.0'
     env:
       KONG_VERSION: ${{ matrix.kong_version }}
       KONG_ENTERPRISE_REPO_USERNAME: ${{ secrets.KONG_ENTERPRISE_REPO_USERNAME }}

--- a/.github/workflows/integration-test-enterprise.yaml
+++ b/.github/workflows/integration-test-enterprise.yaml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         kong_version:
-        - 'enterprise-1.5.0.11'
         - 'enterprise-2.1.4.6'
         - 'enterprise-2.2.1.3'
         - 'enterprise-2.3.3.4'

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -23,6 +23,7 @@ jobs:
         - '2.6.0'
         - '2.7.0'
         - '2.8.0'
+        - '3.0.0'
     env:
       KONG_VERSION: ${{ matrix.kong_version }}
       KONG_ENTERPRISE_REPO_USERNAME: ${{ secrets.KONG_ENTERPRISE_REPO_USERNAME }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,20 @@
 - [0.2.0](#020)
 - [0.1.0](#010)
 
+## [v0.32.0]
+
+> Release date: 2022/08/23
+
+This release is not yet fully compatible with Kong 3.x. The target service `MarkHealthy()` and `MarkUnhealthy()`
+functions do not yet work on 3.x. Other functionality supports 3.x, but may not yet support all new 3.x schema fields.
+
+- Added support for 3.x Enterprise version strings.
+  [#207](https://github.com/Kong/go-kong/pull/207)
+- Added support for `expression` and `priority` route fields.
+  [#210](https://github.com/Kong/go-kong/pull/210)
+- Dropped support for 1.5 Enterprise, which exited sunset support in 2022-04.
+- Added 3.x to test matrices.
+
 ## [v0.31.1]
 
 > Release date: 2022/08/23

--- a/kong/client_test.go
+++ b/kong/client_test.go
@@ -116,7 +116,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestRunWhenEnterprise(T *testing.T) {
-	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{})
+	// TODO refactor this to test that a version is Enterprise without relying on the IsKongGatewayEnterprise function
+	// that this calls https://github.com/Kong/go-kong/issues/212
+	RunWhenEnterprise(T, ">=0.33.0 <3.0.0", RequiredFeatures{})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -451,6 +451,9 @@ func TestPluginGetFullSchema(T *testing.T) {
 }
 
 func TestFillPluginDefaults(T *testing.T) {
+	// TODO https://github.com/Kong/go-kong/issues/214 this should only skip Enterprise 3.x (with a separate test)
+	// not all Enterprise versions.
+	SkipWhenEnterprise(T)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/target_service_test.go
+++ b/kong/target_service_test.go
@@ -228,6 +228,8 @@ func compareTargets(expected, actual []*Target) bool {
 }
 
 func TestTargetMarkHealthy(T *testing.T) {
+	// TODO https://github.com/Kong/go-kong/issues/213 this does not yet work on 3.x
+	RunWhenKong(T, "<3.0.0")
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -265,6 +267,8 @@ func TestTargetMarkHealthy(T *testing.T) {
 }
 
 func TestTargetMarkUnhealthy(T *testing.T) {
+	// TODO https://github.com/Kong/go-kong/issues/213 this does not yet work on 3.x
+	RunWhenKong(T, "<3.0.0")
 	assert := assert.New(T)
 	require := require.New(T)
 


### PR DESCRIPTION
Adds 0.32 changelog and updates test matrices.

This will probably fail initially because 3.0 is still wonky on Docker and can't run on linux/amd64 (or, for that matter, anything) yet.

1.5.0.11 gained a [failure in the plugin service](https://github.com/Kong/go-kong/actions/runs/3048010392/jobs/4912614044) at some point. As it [exited support in April](https://docs.konghq.com/gateway/latest/support-policy/#version-support-for-kong-gateway-enterprise), I think we should just go ahead and remove it from the tests.

This skips several tests that are incompatible with 3.x:
- The target health setters use POST as was required by 2.x. 3.x requires PUT, and there's not an existing pattern that allows us to choose the method (or anything else) in service functions based on the Kong version. However, we don't actually use these functions in the controller or deck, as we rely on Kong to update its own health statuses based on probes, so 
- The RunWhenEnterprise test utility test relied on the old `-enterprise-edition` version suffix. We don't really have options for testing it on 3.x without relying on one of the functions we're testing.
- The plugin defaults test compares against a static value that is incorrect for 3.x Enterprise. The actual result is correct. We cannot yet easily split tests that work one way on OSS and another on Enterprise, only skip Enterprise or OSS runs entirely.