### PR TITLE
feat: support JSON schemas in the FillEntityDefaults function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [Unreleased](#Unreleased)
 - [v0.33.0](#v0330)
 - [v0.32.0](#v0320)
 - [v0.31.1](#v0311)
@@ -40,6 +41,13 @@
 - [0.3.0](#030)
 - [0.2.0](#020)
 - [0.1.0](#010)
+
+## [Unreleased]
+
+> Release date: TBD
+
+- Add support to filling entity defaults using JSON schemas.
+  [#231](https://github.com/Kong/go-kong/pull/231)
 
 ## [v0.33.0]
 
@@ -619,6 +627,7 @@ authentication credentials in Kong.
   releases of Kong since every release of Kong is introducing breaking changes
   to the Admin API.
 
+[Unreleased]: https://github.com/Kong/go-kong/compare/v0.33.0...Unreleased
 [v0.33.0]: https://github.com/Kong/go-kong/compare/v0.32.0...v0.33.0
 [v0.32.0]: https://github.com/Kong/go-kong/compare/v0.31.1...v0.32.0
 [v0.31.1]: https://github.com/Kong/go-kong/compare/v0.31.0...v0.31.1

--- a/kong/testdata/routeJSONSchema.json
+++ b/kong/testdata/routeJSONSchema.json
@@ -1,0 +1,752 @@
+{
+    "additionalProperties": false,
+    "allOf": [
+        {
+            "description": "'snis' can be set only when protocols has one of 'https', 'grpcs', 'tls' or 'tls_passthrough'",
+            "if": {
+                "required": [
+                    "snis"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "protocols": {
+                        "contains": {
+                            "oneOf": [
+                                {
+                                    "const": "https",
+                                    "type": "string"
+                                },
+                                {
+                                    "const": "grpcs",
+                                    "type": "string"
+                                },
+                                {
+                                    "const": "tls",
+                                    "type": "string"
+                                },
+                                {
+                                    "const": "tls_passthrough",
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "title": "sni_rule"
+        },
+        {
+            "description": "when protocols has 'http' or 'https', 'sources' or 'destinations' cannot be set",
+            "if": {
+                "properties": {
+                    "protocols": {
+                        "contains": {
+                            "anyOf": [
+                                {
+                                    "const": "https",
+                                    "type": "string"
+                                },
+                                {
+                                    "const": "http",
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "protocols"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "destinations": {
+                        "not": {}
+                    },
+                    "sources": {
+                        "not": {
+                            "description": "when protocols has 'http' or 'https', 'sources' or 'destination' cannot be set"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "description": "when protocols has 'http', at least one of 'hosts', 'methods', 'paths' or 'headers' must be set",
+            "if": {
+                "properties": {
+                    "protocols": {
+                        "contains": {
+                            "const": "http"
+                        }
+                    }
+                },
+                "required": [
+                    "protocols"
+                ]
+            },
+            "then": {
+                "anyOf": [
+                    {
+                        "required": [
+                            "methods"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "hosts"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "paths"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "paths"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "headers"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "description": "when protocols has 'https', at least one of 'snis', 'hosts', 'methods', 'paths' or 'headers' must be set",
+            "if": {
+                "properties": {
+                    "protocols": {
+                        "contains": {
+                            "const": "https"
+                        }
+                    }
+                },
+                "required": [
+                    "protocols"
+                ]
+            },
+            "then": {
+                "anyOf": [
+                    {
+                        "required": [
+                            "methods"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "hosts"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "paths"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "paths"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "headers"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "snis"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "description": "when protocol has 'tcp', 'tls', 'tls_passthrough' or 'udp', 'methods', 'hosts', 'paths', 'headers' cannot be set",
+            "if": {
+                "properties": {
+                    "protocols": {
+                        "contains": {
+                            "anyOf": [
+                                {
+                                    "const": "tcp",
+                                    "type": "string"
+                                },
+                                {
+                                    "const": "udp",
+                                    "type": "string"
+                                },
+                                {
+                                    "const": "tls",
+                                    "type": "string"
+                                },
+                                {
+                                    "const": "tls_passthrough",
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "protocols"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "headers": {
+                        "not": {}
+                    },
+                    "hosts": {
+                        "not": {}
+                    },
+                    "methods": {
+                        "not": {}
+                    },
+                    "paths": {
+                        "not": {}
+                    }
+                }
+            }
+        },
+        {
+            "description": "when protocols has 'tcp', 'tls' or 'udp', then at least one of 'sources', 'destinations' or 'snis' must be set",
+            "if": {
+                "properties": {
+                    "protocols": {
+                        "contains": {
+                            "anyOf": [
+                                {
+                                    "const": "tcp",
+                                    "type": "string"
+                                },
+                                {
+                                    "const": "udp",
+                                    "type": "string"
+                                },
+                                {
+                                    "const": "tls",
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "protocols"
+                ]
+            },
+            "then": {
+                "anyOf": [
+                    {
+                        "required": [
+                            "sources"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "destinations"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "snis"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "description": "when protocol has 'grpc' or 'grpcs', 'strip_path', 'methods', 'sources', 'destinations' cannot be set",
+            "if": {
+                "properties": {
+                    "protocols": {
+                        "contains": {
+                            "anyOf": [
+                                {
+                                    "const": "grpc",
+                                    "type": "string"
+                                },
+                                {
+                                    "const": "grpcs",
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "protocols"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "destinations": {
+                        "not": {}
+                    },
+                    "methods": {
+                        "not": {}
+                    },
+                    "sources": {
+                        "not": {}
+                    },
+                    "strip_path": {
+                        "not": {
+                            "const": true
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "description": "when protocols has 'grpc', at least one of 'hosts', 'headers' or 'paths' must be set",
+            "if": {
+                "properties": {
+                    "protocols": {
+                        "contains": {
+                            "const": "grpc"
+                        }
+                    }
+                },
+                "required": [
+                    "protocols"
+                ]
+            },
+            "then": {
+                "anyOf": [
+                    {
+                        "required": [
+                            "hosts"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "headers"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "paths"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "description": "when protocols has 'grpcs', at least one of 'hosts', 'headers', 'paths' or 'snis' must be set",
+            "if": {
+                "properties": {
+                    "protocols": {
+                        "contains": {
+                            "const": "grpcs"
+                        }
+                    }
+                },
+                "required": [
+                    "protocols"
+                ]
+            },
+            "then": {
+                "anyOf": [
+                    {
+                        "required": [
+                            "hosts"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "headers"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "paths"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "snis"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "description": "when protocols has 'tls_passthrough', 'snis' must be set",
+            "if": {
+                "properties": {
+                    "protocols": {
+                        "contains": {
+                            "const": "tls_passthrough"
+                        }
+                    }
+                },
+                "required": [
+                    "protocols"
+                ]
+            },
+            "then": {
+                "anyOf": [
+                    {
+                        "required": [
+                            "snis"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "description": "'ws' and 'wss' protocols are Kong Enterprise-only features. Please upgrade to Kong Enterprise to use this feature.",
+            "not": {
+                "properties": {
+                    "protocols": {
+                        "contains": {
+                            "anyOf": [
+                                {
+                                    "const": "ws",
+                                    "type": "string"
+                                },
+                                {
+                                    "const": "wss",
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "protocols"
+                ]
+            },
+            "title": "ws_protocols_rule"
+        }
+    ],
+    "properties": {
+        "created_at": {
+            "minimum": 1,
+            "type": "integer"
+        },
+        "destinations": {
+            "items": {
+                "anyOf": [
+                    {
+                        "description": "at least one of 'ip' or 'port' is required",
+                        "required": [
+                            "ip"
+                        ]
+                    },
+                    {
+                        "description": "at least one of 'ip' or 'port' is required",
+                        "required": [
+                            "port"
+                        ]
+                    }
+                ],
+                "properties": {
+                    "ip": {
+                        "anyOf": [
+                            {
+                                "description": "must be a valid IP or CIDR",
+                                "pattern": "^([0-9]{1,3}[.]{1}){3}[0-9]{1,3}$"
+                            },
+                            {
+                                "description": "must be a valid IP or CIDR",
+                                "pattern": "^([0-9]{1,3}[.]{1}){3}[0-9]{1,3}/[0-9]{1,3}$"
+                            }
+                        ],
+                        "type": "string"
+                    },
+                    "port": {
+                        "maximum": 65535,
+                        "minimum": 1,
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "maxItems": 16,
+            "type": "array"
+        },
+        "headers": {
+            "additionalProperties": false,
+            "maxProperties": 16,
+            "patternProperties": {
+                "^[A-Za-z0-9!#$%&'*+-.^_|~]{1,64}$": {
+                    "properties": {
+                        "values": {
+                            "items": {
+                                "maxLength": 64,
+                                "type": "string"
+                            },
+                            "maxItems": 16,
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "^[Hh][Oo][Ss][Tt]$": {
+                    "not": {
+                        "description": "must not contain 'host' header"
+                    }
+                }
+            },
+            "type": "object"
+        },
+        "hosts": {
+            "items": {
+                "description": "must be a valid hostname",
+                "maxLength": 256,
+                "pattern": "^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*$",
+                "type": "string"
+            },
+            "maxItems": 16,
+            "type": "array"
+        },
+        "https_redirect_status_code": {
+            "default": 426,
+            "enum": [
+                426,
+                301,
+                302,
+                307,
+                308
+            ],
+            "type": "integer"
+        },
+        "id": {
+            "description": "must be a valid UUID",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            "type": "string"
+        },
+        "methods": {
+            "items": {
+                "maxItems": 16,
+                "pattern": "^[A-Z]+$",
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "name": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[0-9a-zA-Z.\\-_~]*$",
+            "type": "string"
+        },
+        "path_handling": {
+            "default": "v0",
+            "enum": [
+                "v0",
+                "v1"
+            ],
+            "type": "string"
+        },
+        "paths": {
+            "items": {
+                "allOf": [
+                    {
+                        "description": "must begin with `/` (prefix path) or `~/` (regex path)",
+                        "pattern": "^/.*|^~/.*"
+                    },
+                    {
+                        "description": "length must not exceed 1024",
+                        "maxLength": 1024
+                    },
+                    {
+                        "not": {
+                            "description": "must not contain `//`",
+                            "pattern": "//"
+                        }
+                    }
+                ],
+                "type": "string"
+            },
+            "maxItems": 16,
+            "type": "array"
+        },
+        "preserve_host": {
+            "default": false,
+            "type": "boolean"
+        },
+        "protocols": {
+            "anyOf": [
+                {
+                    "description": "must contain only one subset [ http https ]",
+                    "items": {
+                        "enum": [
+                            "http",
+                            "https"
+                        ],
+                        "type": "string"
+                    }
+                },
+                {
+                    "description": "must contain only one subset [ tcp udp tls ]",
+                    "items": {
+                        "enum": [
+                            "tcp",
+                            "udp",
+                            "tls"
+                        ],
+                        "type": "string"
+                    }
+                },
+                {
+                    "description": "must contain only one subset [ grpc grpcs ]",
+                    "items": {
+                        "enum": [
+                            "grpc",
+                            "grpcs"
+                        ],
+                        "type": "string"
+                    }
+                },
+                {
+                    "description": "must contain only one subset [ tls_passthrough ]",
+                    "items": {
+                        "enum": [
+                            "tls_passthrough"
+                        ],
+                        "type": "string"
+                    }
+                },
+                {
+                    "description": "must contain only one subset [ ws wss ]",
+                    "items": {
+                        "enum": [
+                            "ws",
+                            "wss"
+                        ],
+                        "type": "string"
+                    }
+                }
+            ],
+            "default": [
+                "http",
+                "https"
+            ],
+            "items": {
+                "enum": [
+                    "http",
+                    "https",
+                    "grpc",
+                    "grpcs",
+                    "tcp",
+                    "udp",
+                    "tls",
+                    "tls_passthrough",
+                    "ws",
+                    "wss"
+                ],
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "regex_priority": {
+            "default": 0,
+            "exclusiveMinimum": -1,
+            "type": "integer"
+        },
+        "request_buffering": {
+            "default": true,
+            "type": "boolean"
+        },
+        "response_buffering": {
+            "default": true,
+            "type": "boolean"
+        },
+        "service": {
+            "additionalProperties": false,
+            "description": "foreign",
+            "properties": {
+                "id": {
+                    "description": "must be a valid UUID",
+                    "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id"
+            ],
+            "type": "object"
+        },
+        "snis": {
+            "items": {
+                "description": "must be a valid hostname",
+                "maxLength": 256,
+                "pattern": "^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*$",
+                "type": "string"
+            },
+            "maxItems": 16,
+            "type": "array"
+        },
+        "sources": {
+            "items": {
+                "anyOf": [
+                    {
+                        "description": "at least one of 'ip' or 'port' is required",
+                        "required": [
+                            "ip"
+                        ]
+                    },
+                    {
+                        "description": "at least one of 'ip' or 'port' is required",
+                        "required": [
+                            "port"
+                        ]
+                    }
+                ],
+                "properties": {
+                    "ip": {
+                        "anyOf": [
+                            {
+                                "description": "must be a valid IP or CIDR",
+                                "pattern": "^([0-9]{1,3}[.]{1}){3}[0-9]{1,3}$"
+                            },
+                            {
+                                "description": "must be a valid IP or CIDR",
+                                "pattern": "^([0-9]{1,3}[.]{1}){3}[0-9]{1,3}/[0-9]{1,3}$"
+                            }
+                        ],
+                        "type": "string"
+                    },
+                    "port": {
+                        "maximum": 65535,
+                        "minimum": 1,
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "maxItems": 16,
+            "type": "array"
+        },
+        "strip_path": {
+            "default": true,
+            "type": "boolean"
+        },
+        "tags": {
+            "items": {
+                "maxLength": 128,
+                "minLength": 1,
+                "pattern": "^(?:[0-9a-zA-Z.\\-_~:]+(?: *[0-9a-zA-Z.\\-_~:])*)?$",
+                "type": "string"
+            },
+            "maxItems": 8,
+            "type": "array",
+            "uniqueItems": true
+        },
+        "updated_at": {
+            "minimum": 1,
+            "type": "integer"
+        }
+    },
+    "required": [
+        "id",
+        "protocols"
+    ],
+    "type": "object"
+}

--- a/kong/testdata/serviceJSONSchema.json
+++ b/kong/testdata/serviceJSONSchema.json
@@ -1,0 +1,302 @@
+{
+    "additionalProperties": false,
+    "allOf": [
+        {
+            "description": "client_certificate can be set only when protocol is `https`",
+            "if": {
+                "required": [
+                    "client_certificate"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "protocol": {
+                        "const": "https"
+                    }
+                },
+                "required": [
+                    "protocol"
+                ]
+            },
+            "title": "client_certificate_rule"
+        },
+        {
+            "description": "tls_verify can be set only when protocol is `https`",
+            "if": {
+                "properties": {
+                    "tls_verify": {
+                        "const": true
+                    }
+                },
+                "required": [
+                    "tls_verify"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "protocol": {
+                        "const": "https"
+                    }
+                },
+                "required": [
+                    "protocol"
+                ]
+            },
+            "title": "tls_verify_rule"
+        },
+        {
+            "description": "tls_verify_depth can be set only when protocol is `https`",
+            "if": {
+                "required": [
+                    "tls_verify_depth"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "protocol": {
+                        "const": "https"
+                    }
+                },
+                "required": [
+                    "protocol"
+                ]
+            }
+        },
+        {
+            "description": "ca_certificates can be set only when protocol is `https`",
+            "if": {
+                "required": [
+                    "ca_certificates"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "protocol": {
+                        "const": "https"
+                    }
+                },
+                "required": [
+                    "protocol"
+                ]
+            }
+        },
+        {
+            "description": "path can be set only when protocol is 'http' or 'https'",
+            "if": {
+                "properties": {
+                    "protocol": {
+                        "oneOf": [
+                            {
+                                "const": "grpc"
+                            },
+                            {
+                                "const": "grpcs"
+                            },
+                            {
+                                "const": "tcp"
+                            },
+                            {
+                                "const": "tls"
+                            },
+                            {
+                                "const": "udp"
+                            }
+                        ]
+                    }
+                },
+                "required": [
+                    "protocol"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "path": {
+                        "not": {}
+                    }
+                }
+            }
+        },
+        {
+            "description": "url should not be set",
+            "not": {
+                "required": [
+                    "url"
+                ]
+            }
+        },
+        {
+            "description": "'ws' and 'wss' protocols are Kong Enterprise-only features. Please upgrade to Kong Enterprise to use this feature.",
+            "not": {
+                "properties": {
+                    "protocol": {
+                        "oneOf": [
+                            {
+                                "const": "ws",
+                                "type": "string"
+                            },
+                            {
+                                "const": "wss",
+                                "type": "string"
+                            }
+                        ]
+                    }
+                },
+                "required": [
+                    "protocol"
+                ]
+            },
+            "title": "ws_protocols_rule"
+        }
+    ],
+    "properties": {
+        "ca_certificates": {
+            "items": {
+                "description": "must be a valid UUID",
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "client_certificate": {
+            "additionalProperties": false,
+            "description": "foreign",
+            "properties": {
+                "id": {
+                    "description": "must be a valid UUID",
+                    "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id"
+            ],
+            "type": "object"
+        },
+        "connect_timeout": {
+            "default": 60000,
+            "maximum": 2147483646,
+            "minimum": 1,
+            "type": "integer"
+        },
+        "created_at": {
+            "minimum": 1,
+            "type": "integer"
+        },
+        "enabled": {
+            "default": true,
+            "type": "boolean"
+        },
+        "host": {
+            "description": "must be a valid hostname",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*$",
+            "type": "string"
+        },
+        "id": {
+            "description": "must be a valid UUID",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            "type": "string"
+        },
+        "name": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[0-9a-zA-Z.\\-_~]*$",
+            "type": "string"
+        },
+        "path": {
+            "allOf": [
+                {
+                    "description": "must begin with `/`",
+                    "pattern": "^/.*"
+                },
+                {
+                    "description": "length must not exceed 1024",
+                    "maxLength": 1024
+                },
+                {
+                    "not": {
+                        "description": "must not contain `//`",
+                        "pattern": "//"
+                    }
+                }
+            ],
+            "type": "string"
+        },
+        "port": {
+            "default": 80,
+            "maximum": 65535,
+            "minimum": 1,
+            "type": "integer"
+        },
+        "protocol": {
+            "default": "http",
+            "enum": [
+                "http",
+                "https",
+                "grpc",
+                "grpcs",
+                "tcp",
+                "udp",
+                "tls",
+                "tls_passthrough",
+                "ws",
+                "wss"
+            ],
+            "type": "string"
+        },
+        "read_timeout": {
+            "default": 60000,
+            "maximum": 2147483646,
+            "minimum": 1,
+            "type": "integer"
+        },
+        "retries": {
+            "default": 5,
+            "maximum": 32767,
+            "minimum": 1,
+            "type": "integer"
+        },
+        "tags": {
+            "items": {
+                "maxLength": 128,
+                "minLength": 1,
+                "pattern": "^(?:[0-9a-zA-Z.\\-_~:]+(?: *[0-9a-zA-Z.\\-_~:])*)?$",
+                "type": "string"
+            },
+            "maxItems": 8,
+            "type": "array",
+            "uniqueItems": true
+        },
+        "tls_verify": {
+            "type": "boolean"
+        },
+        "tls_verify_depth": {
+            "maximum": 64,
+            "minimum": 0,
+            "type": "integer"
+        },
+        "updated_at": {
+            "minimum": 1,
+            "type": "integer"
+        },
+        "url": {
+            "type": "string"
+        },
+        "write_timeout": {
+            "default": 60000,
+            "maximum": 2147483646,
+            "minimum": 1,
+            "type": "integer"
+        }
+    },
+    "required": [
+        "id",
+        "protocol",
+        "host",
+        "port",
+        "connect_timeout",
+        "read_timeout",
+        "write_timeout"
+    ],
+    "type": "object"
+}

--- a/kong/testdata/targetJSONSchema.json
+++ b/kong/testdata/targetJSONSchema.json
@@ -1,0 +1,61 @@
+{
+    "additionalProperties": false,
+    "properties": {
+        "created_at": {
+            "minimum": 1,
+            "type": "integer"
+        },
+        "id": {
+            "description": "must be a valid UUID",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            "type": "string"
+        },
+        "tags": {
+            "items": {
+                "maxLength": 128,
+                "minLength": 1,
+                "pattern": "^(?:[0-9a-zA-Z.\\-_~:]+(?: *[0-9a-zA-Z.\\-_~:])*)?$",
+                "type": "string"
+            },
+            "maxItems": 8,
+            "type": "array",
+            "uniqueItems": true
+        },
+        "target": {
+            "maxLength": 1024,
+            "minLength": 1,
+            "type": "string"
+        },
+        "updated_at": {
+            "minimum": 1,
+            "type": "integer"
+        },
+        "upstream": {
+            "additionalProperties": false,
+            "description": "foreign",
+            "properties": {
+                "id": {
+                    "description": "must be a valid UUID",
+                    "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id"
+            ],
+            "type": "object"
+        },
+        "weight": {
+            "default": 100,
+            "maximum": 65535,
+            "minimum": 0,
+            "type": "integer"
+        }
+    },
+    "required": [
+        "id",
+        "target",
+        "upstream"
+    ],
+    "type": "object"
+}

--- a/kong/testdata/upstreamJSONSchema.json
+++ b/kong/testdata/upstreamJSONSchema.json
@@ -1,0 +1,948 @@
+{
+    "additionalProperties": false,
+    "allOf": [
+        {
+            "description": "when 'hash_on' is set to 'header','hash_on_header' must be set",
+            "if": {
+                "properties": {
+                    "hash_on": {
+                        "const": "header"
+                    }
+                },
+                "required": [
+                    "hash_on"
+                ]
+            },
+            "then": {
+                "required": [
+                    "hash_on_header"
+                ]
+            }
+        },
+        {
+            "description": "when 'hash_fallback' is set to 'header','hash_fallback_header' must be set",
+            "if": {
+                "properties": {
+                    "hash_fallback": {
+                        "const": "header"
+                    }
+                },
+                "required": [
+                    "hash_fallback"
+                ]
+            },
+            "then": {
+                "required": [
+                    "hash_fallback_header"
+                ]
+            }
+        },
+        {
+            "description": "when 'hash_on' is set to 'cookie', 'hash_on_cookie' must be set",
+            "if": {
+                "properties": {
+                    "hash_on": {
+                        "const": "cookie"
+                    }
+                },
+                "required": [
+                    "hash_on"
+                ]
+            },
+            "then": {
+                "required": [
+                    "hash_on_cookie"
+                ]
+            }
+        },
+        {
+            "description": "when 'hash_fallback' is set to 'cookie', 'hash_on_cookie' must be set",
+            "if": {
+                "properties": {
+                    "hash_fallback": {
+                        "const": "cookie"
+                    }
+                },
+                "required": [
+                    "hash_fallback"
+                ]
+            },
+            "then": {
+                "required": [
+                    "hash_on_cookie"
+                ]
+            }
+        },
+        {
+            "description": "when 'hash_on' is set to 'none', 'hash_fallback' must be set to 'none'",
+            "if": {
+                "properties": {
+                    "hash_on": {
+                        "const": "none"
+                    }
+                },
+                "required": [
+                    "hash_on"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "hash_fallback": {
+                        "const": "none"
+                    }
+                },
+                "required": [
+                    "hash_fallback"
+                ]
+            }
+        },
+        {
+            "description": "when 'hash_on' is set to 'cookie', 'hash_fallback' must be set to 'none'",
+            "if": {
+                "properties": {
+                    "hash_on": {
+                        "const": "cookie"
+                    }
+                },
+                "required": [
+                    "hash_on"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "hash_fallback": {
+                        "const": "none"
+                    }
+                },
+                "required": [
+                    "hash_fallback"
+                ]
+            }
+        },
+        {
+            "description": "when 'hash_on' is set to 'consumer', 'hash_fallback' must be set to one of 'none', 'ip', 'header', 'cookie', 'path', 'query_arg', 'uri_capture'",
+            "if": {
+                "properties": {
+                    "hash_on": {
+                        "const": "consumer"
+                    }
+                },
+                "required": [
+                    "hash_on"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "hash_fallback": {
+                        "anyOf": [
+                            {
+                                "const": "none",
+                                "type": "string"
+                            },
+                            {
+                                "const": "ip",
+                                "type": "string"
+                            },
+                            {
+                                "const": "header",
+                                "type": "string"
+                            },
+                            {
+                                "const": "cookie",
+                                "type": "string"
+                            },
+                            {
+                                "const": "path",
+                                "type": "string"
+                            },
+                            {
+                                "const": "query_arg",
+                                "type": "string"
+                            },
+                            {
+                                "const": "uri_capture",
+                                "type": "string"
+                            }
+                        ]
+                    }
+                },
+                "required": [
+                    "hash_fallback"
+                ]
+            }
+        },
+        {
+            "description": "when 'hash_on' is set to 'ip', 'hash_fallback' must be set to one of 'none', 'consumer', 'header', 'cookie', 'path', 'query_arg', 'uri_capture'",
+            "if": {
+                "properties": {
+                    "hash_on": {
+                        "const": "ip"
+                    }
+                },
+                "required": [
+                    "hash_on"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "hash_fallback": {
+                        "anyOf": [
+                            {
+                                "const": "none",
+                                "type": "string"
+                            },
+                            {
+                                "const": "consumer",
+                                "type": "string"
+                            },
+                            {
+                                "const": "header",
+                                "type": "string"
+                            },
+                            {
+                                "const": "cookie",
+                                "type": "string"
+                            },
+                            {
+                                "const": "path",
+                                "type": "string"
+                            },
+                            {
+                                "const": "query_arg",
+                                "type": "string"
+                            },
+                            {
+                                "const": "uri_capture",
+                                "type": "string"
+                            }
+                        ]
+                    }
+                },
+                "required": [
+                    "hash_fallback"
+                ]
+            }
+        },
+        {
+            "description": "when 'hash_on' is set to 'path', 'hash_fallback' must be set to one of 'none', 'consumer', 'ip', 'header', 'cookie', 'query_arg', 'uri_capture'",
+            "if": {
+                "properties": {
+                    "hash_on": {
+                        "const": "path"
+                    }
+                },
+                "required": [
+                    "hash_on"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "hash_fallback": {
+                        "anyOf": [
+                            {
+                                "const": "none",
+                                "type": "string"
+                            },
+                            {
+                                "const": "consumer",
+                                "type": "string"
+                            },
+                            {
+                                "const": "header",
+                                "type": "string"
+                            },
+                            {
+                                "const": "cookie",
+                                "type": "string"
+                            },
+                            {
+                                "const": "ip",
+                                "type": "string"
+                            },
+                            {
+                                "const": "query_arg",
+                                "type": "string"
+                            },
+                            {
+                                "const": "uri_capture",
+                                "type": "string"
+                            }
+                        ]
+                    }
+                },
+                "required": [
+                    "hash_fallback"
+                ]
+            }
+        },
+        {
+            "description": "when 'hash_on' is set to 'query_arg', 'hash_on_query_arg' must be set",
+            "if": {
+                "properties": {
+                    "hash_on": {
+                        "const": "query_arg"
+                    }
+                },
+                "required": [
+                    "hash_on"
+                ]
+            },
+            "then": {
+                "required": [
+                    "hash_on_query_arg"
+                ]
+            }
+        },
+        {
+            "description": "when 'hash_fallback' is set to 'query_arg', 'hash_fallback_query_arg' must be set",
+            "if": {
+                "properties": {
+                    "hash_fallback": {
+                        "const": "query_arg"
+                    }
+                },
+                "required": [
+                    "hash_fallback"
+                ]
+            },
+            "then": {
+                "required": [
+                    "hash_fallback_query_arg"
+                ]
+            }
+        },
+        {
+            "description": "when 'hash_on' is set to 'uri_capture', 'hash_on_uri_capture' must be set",
+            "if": {
+                "properties": {
+                    "hash_on": {
+                        "const": "uri_capture"
+                    }
+                },
+                "required": [
+                    "hash_on"
+                ]
+            },
+            "then": {
+                "required": [
+                    "hash_on_uri_capture"
+                ]
+            }
+        },
+        {
+            "description": "when 'hash_fallback' is set to 'uri_capture', 'hash_fallback_uri_capture' must be set",
+            "if": {
+                "properties": {
+                    "hash_fallback": {
+                        "const": "uri_capture"
+                    }
+                },
+                "required": [
+                    "hash_fallback"
+                ]
+            },
+            "then": {
+                "required": [
+                    "hash_fallback_uri_capture"
+                ]
+            }
+        }
+    ],
+    "properties": {
+        "algorithm": {
+            "default": "round-robin",
+            "enum": [
+                "round-robin",
+                "consistent-hashing",
+                "least-connections"
+            ],
+            "type": "string"
+        },
+        "client_certificate": {
+            "additionalProperties": false,
+            "description": "foreign",
+            "properties": {
+                "id": {
+                    "description": "must be a valid UUID",
+                    "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id"
+            ],
+            "type": "object"
+        },
+        "created_at": {
+            "minimum": 1,
+            "type": "integer"
+        },
+        "hash_fallback": {
+            "default": "none",
+            "enum": [
+                "none",
+                "consumer",
+                "ip",
+                "header",
+                "cookie",
+                "path",
+                "query_arg",
+                "uri_capture"
+            ],
+            "type": "string"
+        },
+        "hash_fallback_header": {
+            "pattern": "^[A-Za-z0-9!#$%&'*+-.^_|~]{1,64}$",
+            "type": "string"
+        },
+        "hash_fallback_query_arg": {
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9-_]+$",
+            "type": "string"
+        },
+        "hash_fallback_uri_capture": {
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9-_]+$",
+            "type": "string"
+        },
+        "hash_on": {
+            "default": "none",
+            "enum": [
+                "none",
+                "consumer",
+                "ip",
+                "header",
+                "cookie",
+                "path",
+                "query_arg",
+                "uri_capture"
+            ],
+            "type": "string"
+        },
+        "hash_on_cookie": {
+            "pattern": "^[a-zA-Z0-9-_]+$",
+            "type": "string"
+        },
+        "hash_on_cookie_path": {
+            "allOf": [
+                {
+                    "description": "must begin with `/`",
+                    "pattern": "^/.*"
+                },
+                {
+                    "description": "length must not exceed 1024",
+                    "maxLength": 1024
+                },
+                {
+                    "not": {
+                        "description": "must not contain `//`",
+                        "pattern": "//"
+                    }
+                }
+            ],
+            "default": "/",
+            "type": "string"
+        },
+        "hash_on_header": {
+            "pattern": "^[A-Za-z0-9!#$%&'*+-.^_|~]{1,64}$",
+            "type": "string"
+        },
+        "hash_on_query_arg": {
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9-_]+$",
+            "type": "string"
+        },
+        "hash_on_uri_capture": {
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9-_]+$",
+            "type": "string"
+        },
+        "healthchecks": {
+            "default": {
+                "active": {
+                    "concurrency": 10,
+                    "healthy": {
+                        "http_statuses": [
+                            200,
+                            302
+                        ],
+                        "interval": 0,
+                        "successes": 0
+                    },
+                    "http_path": "/",
+                    "https_verify_certificate": true,
+                    "timeout": 1,
+                    "type": "http",
+                    "unhealthy": {
+                        "http_failures": 0,
+                        "http_statuses": [
+                            429,
+                            404,
+                            500,
+                            501,
+                            502,
+                            503,
+                            504,
+                            505
+                        ],
+                        "interval": 0,
+                        "tcp_failures": 0,
+                        "timeouts": 0
+                    }
+                },
+                "passive": {
+                    "healthy": {
+                        "http_statuses": [
+                            200,
+                            201,
+                            202,
+                            203,
+                            204,
+                            205,
+                            206,
+                            207,
+                            208,
+                            226,
+                            300,
+                            301,
+                            302,
+                            303,
+                            304,
+                            305,
+                            306,
+                            307,
+                            308
+                        ],
+                        "successes": 0
+                    },
+                    "type": "http",
+                    "unhealthy": {
+                        "http_failures": 0,
+                        "http_statuses": [
+                            429,
+                            500,
+                            503
+                        ],
+                        "tcp_failures": 0,
+                        "timeouts": 0
+                    }
+                },
+                "threshold": 0
+            },
+            "properties": {
+                "active": {
+                    "default": {
+                        "concurrency": 10,
+                        "healthy": {
+                            "http_statuses": [
+                                200,
+                                302
+                            ],
+                            "interval": 0,
+                            "successes": 0
+                        },
+                        "http_path": "/",
+                        "https_verify_certificate": true,
+                        "timeout": 1,
+                        "type": "http",
+                        "unhealthy": {
+                            "http_failures": 0,
+                            "http_statuses": [
+                                429,
+                                404,
+                                500,
+                                501,
+                                502,
+                                503,
+                                504,
+                                505
+                            ],
+                            "interval": 0,
+                            "tcp_failures": 0,
+                            "timeouts": 0
+                        }
+                    },
+                    "properties": {
+                        "concurrency": {
+                            "default": 10,
+                            "maximum": 2147483648,
+                            "minimum": 1,
+                            "type": "integer"
+                        },
+                        "healthy": {
+                            "default": {
+                                "http_statuses": [
+                                    200,
+                                    302
+                                ],
+                                "interval": 0,
+                                "successes": 0
+                            },
+                            "properties": {
+                                "http_statuses": {
+                                    "default": [
+                                        200,
+                                        302
+                                    ],
+                                    "items": {
+                                        "maximum": 999,
+                                        "minimum": 100,
+                                        "type": "integer"
+                                    },
+                                    "maxItems": 32,
+                                    "type": "array"
+                                },
+                                "interval": {
+                                    "default": 0,
+                                    "maximum": 65535,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                },
+                                "successes": {
+                                    "default": 0,
+                                    "maximum": 255,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "http_path": {
+                            "allOf": [
+                                {
+                                    "description": "must begin with `/`",
+                                    "pattern": "^/.*"
+                                },
+                                {
+                                    "description": "length must not exceed 1024",
+                                    "maxLength": 1024
+                                },
+                                {
+                                    "not": {
+                                        "description": "must not contain `//`",
+                                        "pattern": "//"
+                                    }
+                                }
+                            ],
+                            "default": "/",
+                            "type": "string"
+                        },
+                        "https_sni": {
+                            "description": "must be a valid hostname",
+                            "maxLength": 256,
+                            "pattern": "^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*$",
+                            "type": "string"
+                        },
+                        "https_verify_certificate": {
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "timeout": {
+                            "default": 1,
+                            "maximum": 65535,
+                            "minimum": 0,
+                            "type": "integer"
+                        },
+                        "type": {
+                            "default": "http",
+                            "enum": [
+                                "tcp",
+                                "http",
+                                "https",
+                                "grpc",
+                                "grpcs"
+                            ],
+                            "type": "string"
+                        },
+                        "unhealthy": {
+                            "default": {
+                                "http_failures": 0,
+                                "http_statuses": [
+                                    429,
+                                    404,
+                                    500,
+                                    501,
+                                    502,
+                                    503,
+                                    504,
+                                    505
+                                ],
+                                "interval": 0,
+                                "tcp_failures": 0,
+                                "timeouts": 0
+                            },
+                            "properties": {
+                                "http_failures": {
+                                    "default": 0,
+                                    "maximum": 255,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                },
+                                "http_statuses": {
+                                    "default": [
+                                        429,
+                                        404,
+                                        500,
+                                        501,
+                                        502,
+                                        503,
+                                        504,
+                                        505
+                                    ],
+                                    "items": {
+                                        "maximum": 999,
+                                        "minimum": 100,
+                                        "type": "integer"
+                                    },
+                                    "maxItems": 32,
+                                    "type": "array"
+                                },
+                                "interval": {
+                                    "default": 0,
+                                    "maximum": 65535,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                },
+                                "tcp_failures": {
+                                    "default": 0,
+                                    "maximum": 255,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                },
+                                "timeouts": {
+                                    "default": 0,
+                                    "maximum": 255,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "passive": {
+                    "default": {
+                        "healthy": {
+                            "http_statuses": [
+                                200,
+                                201,
+                                202,
+                                203,
+                                204,
+                                205,
+                                206,
+                                207,
+                                208,
+                                226,
+                                300,
+                                301,
+                                302,
+                                303,
+                                304,
+                                305,
+                                306,
+                                307,
+                                308
+                            ],
+                            "successes": 0
+                        },
+                        "type": "http",
+                        "unhealthy": {
+                            "http_failures": 0,
+                            "http_statuses": [
+                                429,
+                                500,
+                                503
+                            ],
+                            "tcp_failures": 0,
+                            "timeouts": 0
+                        }
+                    },
+                    "properties": {
+                        "healthy": {
+                            "default": {
+                                "http_statuses": [
+                                    200,
+                                    201,
+                                    202,
+                                    203,
+                                    204,
+                                    205,
+                                    206,
+                                    207,
+                                    208,
+                                    226,
+                                    300,
+                                    301,
+                                    302,
+                                    303,
+                                    304,
+                                    305,
+                                    306,
+                                    307,
+                                    308
+                                ],
+                                "successes": 0
+                            },
+                            "properties": {
+                                "http_statuses": {
+                                    "default": [
+                                        200,
+                                        201,
+                                        202,
+                                        203,
+                                        204,
+                                        205,
+                                        206,
+                                        207,
+                                        208,
+                                        226,
+                                        300,
+                                        301,
+                                        302,
+                                        303,
+                                        304,
+                                        305,
+                                        306,
+                                        307,
+                                        308
+                                    ],
+                                    "items": {
+                                        "maximum": 999,
+                                        "minimum": 100,
+                                        "type": "integer"
+                                    },
+                                    "maxItems": 32,
+                                    "type": "array"
+                                },
+                                "successes": {
+                                    "default": 0,
+                                    "maximum": 255,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "timeout": {
+                            "default": 1,
+                            "maximum": 65535,
+                            "minimum": 0,
+                            "type": "integer"
+                        },
+                        "type": {
+                            "default": "http",
+                            "enum": [
+                                "tcp",
+                                "http",
+                                "https",
+                                "grpc",
+                                "grpcs"
+                            ],
+                            "type": "string"
+                        },
+                        "unhealthy": {
+                            "default": {
+                                "http_failures": 0,
+                                "http_statuses": [
+                                    429,
+                                    500,
+                                    503
+                                ],
+                                "tcp_failures": 0,
+                                "timeouts": 0
+                            },
+                            "properties": {
+                                "http_failures": {
+                                    "default": 0,
+                                    "maximum": 255,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                },
+                                "http_statuses": {
+                                    "default": [
+                                        429,
+                                        500,
+                                        503
+                                    ],
+                                    "items": {
+                                        "maximum": 999,
+                                        "minimum": 100,
+                                        "type": "integer"
+                                    },
+                                    "maxItems": 32,
+                                    "type": "array"
+                                },
+                                "tcp_failures": {
+                                    "default": 0,
+                                    "maximum": 255,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                },
+                                "timeouts": {
+                                    "default": 0,
+                                    "maximum": 255,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "threshold": {
+                    "default": 0,
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "host_header": {
+            "description": "must be a valid hostname",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*$",
+            "type": "string"
+        },
+        "id": {
+            "description": "must be a valid UUID",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            "type": "string"
+        },
+        "name": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[0-9a-zA-Z.\\-_~]*$",
+            "type": "string"
+        },
+        "slots": {
+            "default": 10000,
+            "maximum": 65536,
+            "minimum": 10,
+            "type": "integer"
+        },
+        "tags": {
+            "items": {
+                "maxLength": 128,
+                "minLength": 1,
+                "pattern": "^(?:[0-9a-zA-Z.\\-_~:]+(?: *[0-9a-zA-Z.\\-_~:])*)?$",
+                "type": "string"
+            },
+            "maxItems": 8,
+            "type": "array",
+            "uniqueItems": true
+        },
+        "updated_at": {
+            "minimum": 1,
+            "type": "integer"
+        }
+    },
+    "required": [
+        "id",
+        "name"
+    ],
+    "type": "object"
+}

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStringArrayToString(t *testing.T) {
@@ -570,27 +571,27 @@ func TestFillUpstreamsDefaults(T *testing.T) {
 	}
 }
 
-func getJSONSchemaFromFile(filename string) Schema {
+func getJSONSchemaFromFile(t *testing.T, filename string) Schema {
 	jsonFile, err := os.Open(filename)
 	if err != nil {
-		panic(err)
+		require.NoError(t, err)
 	}
 	defer jsonFile.Close()
 
 	var schema Schema
 	byteValue, err := io.ReadAll(jsonFile)
 	if err != nil {
-		panic(err)
+		require.NoError(t, err)
 	}
 	if err := json.Unmarshal(byteValue, &schema); err != nil {
-		panic(err)
+		require.NoError(t, err)
 	}
 	return schema
 }
 
 func TestFillUpstreamsDefaultsFromJSONSchema(t *testing.T) {
 	// load upstream JSON schema from local file.
-	schema := getJSONSchemaFromFile("testdata/upstreamJSONSchema.json")
+	schema := getJSONSchemaFromFile(t, "testdata/upstreamJSONSchema.json")
 
 	tests := []struct {
 		name     string
@@ -712,9 +713,7 @@ func TestFillUpstreamsDefaultsFromJSONSchema(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			u := tc.upstream
-			if err := FillEntityDefaults(u, schema); err != nil {
-				t.Errorf(err.Error())
-			}
+			require.NoError(t, FillEntityDefaults(u, schema))
 			// Ignore fields to make tests pass despite small differences across releases.
 			opts := cmpopts.IgnoreFields(Healthcheck{}, "Threshold")
 			if diff := cmp.Diff(u, tc.expected, opts); diff != "" {
@@ -726,7 +725,7 @@ func TestFillUpstreamsDefaultsFromJSONSchema(t *testing.T) {
 
 func TestFillServicesDefaultsFromJSONSchema(t *testing.T) {
 	// load service JSON schema from local file.
-	schema := getJSONSchemaFromFile("testdata/serviceJSONSchema.json")
+	schema := getJSONSchemaFromFile(t, "testdata/serviceJSONSchema.json")
 
 	tests := []struct {
 		name     string
@@ -793,9 +792,7 @@ func TestFillServicesDefaultsFromJSONSchema(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			s := tc.service
-			if err := FillEntityDefaults(s, schema); err != nil {
-				t.Errorf(err.Error())
-			}
+			require.NoError(t, FillEntityDefaults(s, schema))
 			opt := []cmp.Option{
 				cmpopts.IgnoreFields(Service{}, "Enabled"),
 			}
@@ -808,7 +805,7 @@ func TestFillServicesDefaultsFromJSONSchema(t *testing.T) {
 
 func TestFillRoutesDefaultsFromJSONSchema(t *testing.T) {
 	// load route JSON schema from local file.
-	schema := getJSONSchemaFromFile("testdata/routeJSONSchema.json")
+	schema := getJSONSchemaFromFile(t, "testdata/routeJSONSchema.json")
 
 	tests := []struct {
 		name     string
@@ -872,9 +869,7 @@ func TestFillRoutesDefaultsFromJSONSchema(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			r := tc.route
-			if err := FillEntityDefaults(r, schema); err != nil {
-				t.Errorf(err.Error())
-			}
+			require.NoError(t, FillEntityDefaults(r, schema))
 			// Ignore fields to make tests pass despite small differences across releases.
 			opts := cmpopts.IgnoreFields(
 				Route{},
@@ -889,7 +884,7 @@ func TestFillRoutesDefaultsFromJSONSchema(t *testing.T) {
 
 func TestFillTargetDefaultsFromJSONSchema(t *testing.T) {
 	// load route JSON schema from local file.
-	schema := getJSONSchemaFromFile("testdata/targetJSONSchema.json")
+	schema := getJSONSchemaFromFile(t, "testdata/targetJSONSchema.json")
 
 	tests := []struct {
 		name     string
@@ -917,9 +912,7 @@ func TestFillTargetDefaultsFromJSONSchema(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			target := tc.target
-			if err := FillEntityDefaults(target, schema); err != nil {
-				t.Errorf(err.Error())
-			}
+			require.NoError(t, FillEntityDefaults(target, schema))
 			if diff := cmp.Diff(target, tc.expected); diff != "" {
 				t.Errorf(diff)
 			}

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -2,7 +2,6 @@ package kong
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -573,19 +572,10 @@ func TestFillUpstreamsDefaults(T *testing.T) {
 
 func getJSONSchemaFromFile(t *testing.T, filename string) Schema {
 	jsonFile, err := os.Open(filename)
-	if err != nil {
-		require.NoError(t, err)
-	}
+	require.NoError(t, err)
 	defer jsonFile.Close()
-
 	var schema Schema
-	byteValue, err := io.ReadAll(jsonFile)
-	if err != nil {
-		require.NoError(t, err)
-	}
-	if err := json.Unmarshal(byteValue, &schema); err != nil {
-		require.NoError(t, err)
-	}
+	require.NoError(t, json.NewDecoder(jsonFile).Decode(&schema))
 	return schema
 }
 
@@ -913,9 +903,7 @@ func TestFillTargetDefaultsFromJSONSchema(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			target := tc.target
 			require.NoError(t, FillEntityDefaults(target, schema))
-			if diff := cmp.Diff(target, tc.expected); diff != "" {
-				t.Errorf(diff)
-			}
+			require.Equal(t, tc.expected, target)
 		})
 	}
 }


### PR DESCRIPTION
FillEntityDefaults can be used to inject Kong entity defaults into a Kong entity struct. This function achieves this by getting entity schemas from the Admin API, flattening the returned schemas and merging these with the input schemas.

Kong CP only works with Lua schemas, while Konnect also supports JSON schemas.

This commit adds support to filling entity defaults from JSON schemas.