### PR TITLE
ci: unlock CI golangci-lint version and add more rules

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,7 +22,5 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v3.3.1
-        with:
-          version: v1.48.0
       - name: Verify Codegen
         run: make verify-codegen

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,8 @@
+run:
+  timeout: 5m
+  build-tags:
+  - enterprise
+
 linters:
   enable:
   - asciicheck
@@ -8,6 +13,7 @@ linters:
   - durationcheck
   - errcheck
   - errname
+  - errorlint
   - exhaustive
   - exportloopref
   - gci
@@ -17,8 +23,10 @@ linters:
   - goimports
   - gomnd
   - gosec
+  - gosimple
   - govet
   - importas
+  - ineffassign
   - lll
   - megacheck
   - misspell
@@ -27,7 +35,13 @@ linters:
   - nolintlint
   - predeclared
   - revive
+  - staticcheck
   - stylecheck
+  - typecheck
   - unconvert
   - unparam
+  - unused
   - wastedassign
+
+issues:
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test-enterprise:
 
 .PHONY: lint
 lint:
-	golangci-lint run ./...
+	golangci-lint run -v ./...
 
 .PHONY: verify-codegen
 verify-codegen:

--- a/kong/admin_service.go
+++ b/kong/admin_service.go
@@ -234,7 +234,7 @@ func (s *AdminService) ListWorkspaces(ctx context.Context,
 	var workspaces []*Workspace
 	_, err = s.client.Do(ctx, req, &workspaces)
 	if err != nil {
-		return nil, fmt.Errorf("error updating admin workspaces: %v", err)
+		return nil, fmt.Errorf("error updating admin workspaces: %w", err)
 	}
 	return workspaces, nil
 }
@@ -254,7 +254,7 @@ func (s *AdminService) ListRoles(ctx context.Context,
 	}
 	_, err = s.client.Do(ctx, req, &listRoles)
 	if err != nil {
-		return nil, fmt.Errorf("error listing admin roles: %v", err)
+		return nil, fmt.Errorf("error listing admin roles: %w", err)
 	}
 
 	return listRoles.Roles, nil
@@ -287,7 +287,7 @@ func (s *AdminService) UpdateRoles(ctx context.Context,
 	}
 	_, err = s.client.Do(ctx, req, &listRoles)
 	if err != nil {
-		return nil, fmt.Errorf("error updating admin roles: %v", err)
+		return nil, fmt.Errorf("error updating admin roles: %w", err)
 	}
 	return listRoles.Roles, nil
 }
@@ -317,7 +317,7 @@ func (s *AdminService) DeleteRoles(ctx context.Context,
 
 	_, err = s.client.Do(ctx, req, nil)
 	if err != nil {
-		return fmt.Errorf("error deleting admin roles: %v", err)
+		return fmt.Errorf("error deleting admin roles: %w", err)
 	}
 
 	return nil

--- a/kong/rbac_user_service.go
+++ b/kong/rbac_user_service.go
@@ -199,7 +199,7 @@ func (s *RBACUserService) AddRoles(ctx context.Context,
 	}
 	_, err = s.client.Do(ctx, req, &listRoles)
 	if err != nil {
-		return nil, fmt.Errorf("error updating roles: %v", err)
+		return nil, fmt.Errorf("error updating roles: %w", err)
 	}
 	return listRoles.Roles, nil
 }
@@ -229,7 +229,7 @@ func (s *RBACUserService) DeleteRoles(ctx context.Context,
 
 	_, err = s.client.Do(ctx, req, nil)
 	if err != nil {
-		return fmt.Errorf("error deleting roles: %v", err)
+		return fmt.Errorf("error deleting roles: %w", err)
 	}
 
 	return nil
@@ -250,7 +250,7 @@ func (s *RBACUserService) ListRoles(ctx context.Context,
 	}
 	_, err = s.client.Do(ctx, req, &listRoles)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving list of roles: %v", err)
+		return nil, fmt.Errorf("error retrieving list of roles: %w", err)
 	}
 	return listRoles.Roles, nil
 }
@@ -268,7 +268,7 @@ func (s *RBACUserService) ListPermissions(ctx context.Context,
 	var permissionsList RBACPermissionsList
 	_, err = s.client.Do(ctx, req, &permissionsList)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving list of permissions for role: %v", err)
+		return nil, fmt.Errorf("error retrieving list of permissions for role: %w", err)
 	}
 
 	return &permissionsList, nil

--- a/kong/utils.go
+++ b/kong/utils.go
@@ -433,15 +433,15 @@ func FillEntityDefaults(entity interface{}, schema Schema) error {
 	}
 	defaults, err := getDefaultsObj(schema)
 	if err != nil {
-		return fmt.Errorf("parse schema for defaults: %v", err)
+		return fmt.Errorf("parse schema for defaults: %w", err)
 	}
 	if err := json.Unmarshal(defaults, &tmpEntity); err != nil {
-		return fmt.Errorf("unmarshal entity with defaults: %v", err)
+		return fmt.Errorf("unmarshal entity with defaults: %w", err)
 	}
 	if err := mergo.Merge(
 		entity, tmpEntity, mergo.WithTransformers(zeroValueTransformer{}),
 	); err != nil {
-		return fmt.Errorf("merge entity with its defaults: %v", err)
+		return fmt.Errorf("merge entity with its defaults: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR unpins `v1.48.0` `golangci-lint` version and adds more rules to its config. It also makes sure that files with build tag `enterprise` are also checked with the linter.