### PR TITLE
feat: include raw response bodies in APIErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v0.36.0](#v0360)
 - [v0.35.0](#v0350)
 - [v0.34.1](#v0341)
 - [v0.34.0](#v0340)
@@ -43,6 +44,13 @@
 - [0.3.0](#030)
 - [0.2.0](#020)
 - [0.1.0](#010)
+
+## [v0.36.0]
+
+> Release date: 2023/01/20
+
+- Added `NewAPIErrorWithRaw` error API, which returns a go-kong APIError along with the original raw error body.
+  [#237](https://github.com/Kong/go-kong/pull/237)
 
 ## [v0.35.0]
 
@@ -657,6 +665,8 @@ authentication credentials in Kong.
   releases of Kong since every release of Kong is introducing breaking changes
   to the Admin API.
 
+[v0.36.0]: https://github.com/Kong/go-kong/compare/v0.35.0...v0.36.0
+[v0.35.0]: https://github.com/Kong/go-kong/compare/v0.34.1...v0.35.0
 [v0.34.1]: https://github.com/Kong/go-kong/compare/v0.34.0...v0.34.1
 [v0.34.0]: https://github.com/Kong/go-kong/compare/v0.33.0...v0.34.0
 [v0.33.0]: https://github.com/Kong/go-kong/compare/v0.32.0...v0.33.0

--- a/kong/error.go
+++ b/kong/error.go
@@ -10,12 +10,21 @@ import (
 type APIError struct {
 	httpCode int
 	message  string
+	raw      []byte
 }
 
 func NewAPIError(code int, msg string) *APIError {
 	return &APIError{
 		httpCode: code,
 		message:  msg,
+	}
+}
+
+func NewAPIErrorWithRaw(code int, msg string, raw []byte) *APIError {
+	return &APIError{
+		httpCode: code,
+		message:  msg,
+		raw:      raw,
 	}
 }
 
@@ -26,6 +35,11 @@ func (e *APIError) Error() string {
 // Code returns the HTTP status code for the error.
 func (e *APIError) Code() int {
 	return e.httpCode
+}
+
+// Raw returns the raw HTTP error response body.
+func (e *APIError) Raw() []byte {
+	return e.raw
 }
 
 // IsNotFoundErr returns true if the error or it's cause is

--- a/kong/error_test.go
+++ b/kong/error_test.go
@@ -76,5 +76,7 @@ type forbiddenTransport struct{}
 
 func (ft *forbiddenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Create a new response with 403 status code
-	return nil, NewAPIError(http.StatusForbidden, "Enterprise license missing or expired")
+	return nil, NewAPIError(
+		http.StatusForbidden,
+		"Enterprise license missing or expired")
 }

--- a/kong/response_test.go
+++ b/kong/response_test.go
@@ -31,6 +31,7 @@ func TestHasError(T *testing.T) {
 			want: &APIError{
 				httpCode: 404,
 				message:  "potayto pohtato",
+				raw:      []byte(`{"message": "potayto pohtato", "some": "other field"}`),
 			},
 		},
 		{
@@ -42,6 +43,7 @@ func TestHasError(T *testing.T) {
 			want: &APIError{
 				httpCode: 404,
 				message:  "",
+				raw:      []byte(`{"nothing": "nothing"}`),
 			},
 		},
 		{
@@ -53,6 +55,7 @@ func TestHasError(T *testing.T) {
 			want: &APIError{
 				httpCode: 404,
 				message:  "<failed to parse response body: unexpected end of JSON input>",
+				raw:      []byte(``),
 			},
 		},
 		{
@@ -64,6 +67,7 @@ func TestHasError(T *testing.T) {
 			want: &APIError{
 				httpCode: 404,
 				message:  "<failed to parse response body: invalid character 'T' looking for beginning of value>",
+				raw:      []byte(`This is not json`),
 			},
 		},
 	} {

--- a/kong/response_test.go
+++ b/kong/response_test.go
@@ -31,6 +31,71 @@ func TestHasError(T *testing.T) {
 			want: &APIError{
 				httpCode: 404,
 				message:  "potayto pohtato",
+			},
+		},
+		{
+			name: "code 404, message field missing",
+			response: http.Response{
+				StatusCode: 404,
+				Body:       io.NopCloser(strings.NewReader(`{"nothing": "nothing"}`)),
+			},
+			want: &APIError{
+				httpCode: 404,
+				message:  "",
+			},
+		},
+		{
+			name: "code 404, empty body",
+			response: http.Response{
+				StatusCode: 404,
+				Body:       io.NopCloser(strings.NewReader(``)),
+			},
+			want: &APIError{
+				httpCode: 404,
+				message:  "<failed to parse response body: unexpected end of JSON input>",
+			},
+		},
+		{
+			name: "code 404, unparseable json",
+			response: http.Response{
+				StatusCode: 404,
+				Body:       io.NopCloser(strings.NewReader(`This is not json`)),
+			},
+			want: &APIError{
+				httpCode: 404,
+				message:  "<failed to parse response body: invalid character 'T' looking for beginning of value>",
+			},
+		},
+	} {
+		T.Run(tt.name, func(T *testing.T) {
+			got := hasError(&tt.response)
+			assert.Equal(T, tt.want, got)
+		})
+	}
+}
+
+func TestHasErrorRaw(T *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		response http.Response
+		want     error
+	}{
+		{
+			name: "code 200",
+			response: http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader("")),
+			},
+		},
+		{
+			name: "code 404",
+			response: http.Response{
+				StatusCode: 404,
+				Body:       io.NopCloser(strings.NewReader(`{"message": "potayto pohtato", "some": "other field"}`)),
+			},
+			want: &APIError{
+				httpCode: 404,
+				message:  "potayto pohtato",
 				raw:      []byte(`{"message": "potayto pohtato", "some": "other field"}`),
 			},
 		},


### PR DESCRIPTION
This adds raw error response bodies to APIErrors. This is a breaking change, as it modifies the public `kong.NewAPIError()` function signature, adding a new `raw []byte` parameter for the raw body.

go-kong does not provide universal coverage of all Kong endpoints, and does not have rich error handling for all endpoints it does cover. Currently, go-kong reads the body of any admin API error response (consuming it, so nothing downstream can read it) and extracts the `message` field for inclusion in the APIError it returns. It is not possible to perform further parsing on error bodies if desired.

Adding the raw response allows downstream clients to handle their own error parsing, primarily for ad-hoc requests where downstream builds its own requests and runs it via a go-kong client. I think this is also necessary for further parsing inside go-kong (I don't think raw bodies were available to go-kong services either), but need to confirm.

---

This came up in the context of KIC handling `POST /config` requests. go-kong does not provide a service for `/config` and does not provide error parsing for it as such. `message` isn't useful for this endpoint because it's a compressed version of the more machine-readable `fields` field those error responses.