### PR TITLE
fix: correctly ingest entity defaults with maps values

### DIFF
--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -561,6 +561,13 @@ func TestFillPluginDefaults(T *testing.T) {
 						"headers":     "x-new-header:value",
 						"querystring": []interface{}{},
 					},
+					"append": map[string]interface{}{
+						"headers": "x-append-header:value",
+					},
+					"remove": map[string]interface{}{
+						"body":        []interface{}{},
+						"querystring": "?query=val",
+					},
 				},
 				Enabled:   Bool(false),
 				Protocols: []*string{String("grpc"), String("grpcs")},
@@ -576,13 +583,13 @@ func TestFillPluginDefaults(T *testing.T) {
 					},
 					"append": map[string]interface{}{
 						"body":        []interface{}{},
-						"headers":     []interface{}{},
+						"headers":     "x-append-header:value",
 						"querystring": []interface{}{},
 					},
 					"remove": map[string]interface{}{
 						"body":        []interface{}{},
 						"headers":     []interface{}{},
-						"querystring": []interface{}{},
+						"querystring": "?query=val",
 					},
 					"rename": map[string]interface{}{
 						"body":        []interface{}{},

--- a/kong/utils.go
+++ b/kong/utils.go
@@ -218,8 +218,14 @@ func fillConfigRecord(schema gjson.Result, config Configuration) Configuration {
 
 		// check if key is already set in the config
 		if _, ok := config[fname]; ok {
-			// yes, don't set it
-			return true
+			// the field is set. If it's not a map, then
+			// the field is fully set. If it's a map, we
+			// need to make sure that all fields are properly
+			// filled.
+			if _, ok := config[fname].(map[string]interface{}); !ok {
+				// not a map, field is already set.
+				return true
+			}
 		}
 		ftype := value.Get(fname + ".type")
 		if ftype.String() == "record" {


### PR DESCRIPTION
The current implementation of the `fillConfigRecord` function works as follows:
- navigate the entity structure
- for each field, check whether it's set or not
- if it's already set, move onto the next field
- if it's not set, check the entity schema and set a default if that's defined

This works well in most cases, except for plugins fields being maps. For such fields, this simple check may not be enough since the field may be composed of several sub-fields possibly having their own default values. This means that moving onto the next field when the current map field is set may results into its inner sub-fields not being set with default values.

In decK, where this function is heavily used, this issue results in misleading deployment diffs.

This commit expands the check logic to also verify that all default values are set, even those of maps fields.