### PR TITLE
chore: add pre-flight license check

### DIFF
--- a/.github/workflows/integration-test-enterprise.yaml
+++ b/.github/workflows/integration-test-enterprise.yaml
@@ -10,8 +10,25 @@ on:
     - '*'
 
 jobs:
+  secret-available:
+    outputs:
+      ok: ${{ steps.exists.outputs.ok }}
+    runs-on: ubuntu-latest
+    env:
+      PULP_PASSWORD: ${{ secrets.PULP_PASSWORD }}
+    steps:
+    - name: check for secret availability
+      id: exists
+      run: |
+        if [ ! -z "$PULP_PASSWORD" ]; then
+          echo "ok=true" >> $GITHUB_OUTPUT
+        fi
+
   test-enterprise:
     continue-on-error: true
+    needs:
+    - secret-available
+    if: needs.secret-available.outputs.ok == 'true'
     strategy:
       matrix:
         kong_version:


### PR DESCRIPTION
[Pre-flight](https://github.com/Kong/go-kong/pull/245#pullrequestreview-1210533100) version of #245.

This PR actually runs the tests, since it's local.

https://github.com/Kong/go-kong/pull/246 is from a fork, and does not.

This does explicitly skip `test-enterprise-passed`. We don't have this currently required, but if we do I'm not sure if there's a way to make it pass like the skipped steps.