### PR TITLE
ci: use one go version on CI

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,12 +14,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
-      - name: Checkout repository
-        uses: actions/checkout@v3
+          go-version-file: go.mod
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v3.3.1
       - name: Verify Codegen

--- a/.github/workflows/integration-test-enterprise.yaml
+++ b/.github/workflows/integration-test-enterprise.yaml
@@ -57,12 +57,12 @@ jobs:
         id: license_step
         with:
           password: ${{ secrets.PULP_PASSWORD }}
+      - name: Checkout repository
+        uses: actions/checkout@v3
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.16'
-      - name: Checkout repository
-        uses: actions/checkout@v3
+          go-version-file: go.mod
       - uses: actions/cache@v3.0.11
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -29,12 +29,12 @@ jobs:
       KONG_ANONYMOUS_REPORTS: "off"
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.16'
-      - name: Checkout repository
-        uses: actions/checkout@v3
+          go-version-file: go.mod
       - uses: actions/cache@v3.0.11
         with:
           path: ~/go/pkg/mod


### PR DESCRIPTION
This PR will make it so that we use 1 version of Go in CI, specifically the one from `go.mod`.

Ref: https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file