### PR TITLE
fix: correctly fill plugins with arbitrary map fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v0.34.1](#v0341)
 - [v0.34.0](#v0340)
 - [v0.33.0](#v0330)
 - [v0.32.0](#v0320)
@@ -41,6 +42,13 @@
 - [0.3.0](#030)
 - [0.2.0](#020)
 - [0.1.0](#010)
+
+## [v0.34.1]
+
+> Release date: 2022/12/22
+
+- Fix ingestion of entity defaults with arbitray map values
+  [#258](https://github.com/Kong/go-kong/pull/258)
 
 ## [v0.34.0]
 
@@ -639,6 +647,7 @@ authentication credentials in Kong.
   releases of Kong since every release of Kong is introducing breaking changes
   to the Admin API.
 
+[v0.34.1]: https://github.com/Kong/go-kong/compare/v0.34.0...v0.34.1
 [v0.34.0]: https://github.com/Kong/go-kong/compare/v0.33.0...v0.34.0
 [v0.33.0]: https://github.com/Kong/go-kong/compare/v0.32.0...v0.33.0
 [v0.32.0]: https://github.com/Kong/go-kong/compare/v0.31.1...v0.32.0

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -499,6 +499,7 @@ func TestFillPluginDefaults(T *testing.T) {
 	// TODO https://github.com/Kong/go-kong/issues/214 this should only skip Enterprise 3.x (with a separate test)
 	// not all Enterprise versions.
 	SkipWhenEnterprise(T)
+	RunWhenKong(T, ">=2.3.0")
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -605,6 +606,38 @@ func TestFillPluginDefaults(T *testing.T) {
 				},
 				Protocols: []*string{String("grpc"), String("grpcs")},
 				Enabled:   Bool(false),
+			},
+		},
+		{
+			name: "nested config with arbitrary map field",
+			plugin: &Plugin{
+				Name: String("http-log"),
+				Config: Configuration{
+					"custom_fields_by_lua": map[string]interface{}{
+						"foo": "bar",
+					},
+				},
+				Enabled:   Bool(false),
+				Protocols: []*string{String("grpc"), String("grpcs")},
+			},
+			expected: &Plugin{
+				Name: String("http-log"),
+				Config: Configuration{
+					"content_type": string("application/json"),
+					"custom_fields_by_lua": map[string]interface{}{
+						"foo": "bar",
+					},
+					"flush_timeout": float64(2),
+					"headers":       nil,
+					"http_endpoint": nil,
+					"keepalive":     float64(60000),
+					"method":        string("POST"),
+					"queue_size":    float64(1),
+					"retry_count":   float64(10),
+					"timeout":       float64(10000),
+				},
+				Enabled:   Bool(false),
+				Protocols: []*string{String("grpc"), String("grpcs")},
 			},
 		},
 	}

--- a/kong/utils.go
+++ b/kong/utils.go
@@ -217,12 +217,24 @@ func fillConfigRecord(schema gjson.Result, config Configuration) Configuration {
 		}
 
 		// check if key is already set in the config
-		if _, ok := config[fname]; ok {
+		if v, ok := config[fname]; ok {
 			// the field is set. If it's not a map, then
 			// the field is fully set. If it's a map, we
 			// need to make sure that all fields are properly
 			// filled.
-			if _, ok := config[fname].(map[string]interface{}); !ok {
+			//
+			// some fields are defined as arbitrary maps,
+			// containing a 'keys' and 'values' subfields.
+			// in this case, the map is already fully set.
+			switch v.(type) {
+			case map[string]interface{}:
+				keys := value.Get(fname + ".keys")
+				values := value.Get(fname + ".values")
+				if keys.Exists() && values.Exists() {
+					// an arbitrary map, field is already set.
+					return true
+				}
+			default:
 				// not a map, field is already set.
 				return true
 			}


### PR DESCRIPTION
Kong plugin schemas support different type of fields, including maps. Moreover, these can either be arbitrary maps, or maps with their own subschema.

go-kong already supports well the second case, but it falls short with arbitrary maps. An example of arbitrary map field is the `custom_fields_by_lua` from the `http-log` plugin, which is defined as follows:

```
{
  "custom_fields_by_lua": {
    "keys": {
      "len_min": 1,
      "type": "string"
    },
    "type": "map",
    "values": {
      "len_min": 1,
      "type": "string"
    }
  }
}
```

This commit makes sure that go-kong is able to correctly handle such schemas as well.