### PR TITLE
test: remove TestRunWhenEnterprise

### DIFF
--- a/kong/client_test.go
+++ b/kong/client_test.go
@@ -115,23 +115,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestRunWhenEnterprise(T *testing.T) {
-	// TODO refactor this to test that a version is Enterprise without relying on the IsKongGatewayEnterprise function
-	// that this calls https://github.com/Kong/go-kong/issues/212
-	RunWhenEnterprise(T, ">=0.33.0 <3.0.0", RequiredFeatures{})
-	assert := assert.New(T)
-
-	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
-
-	root, err := client.Root(defaultCtx)
-	assert.NoError(err)
-	assert.NotNil(root)
-	v := root["version"].(string)
-	assert.Contains(v, "enterprise")
-}
-
 type TestWorkspace struct {
 	workspace      *Workspace
 	client         *Client


### PR DESCRIPTION
Remove `TestRunWhenEnterprise` since all it's doing is checking wether the version information retrieved via `client.Root()` is an enterprise version when `RunWhenEnterprise()` check passes which uses the same methods underneath to check whether the used version of Kong Gateway is indeed enterprise 🤯 

Fixes #212 