### PR TITLE
ci: add testing against dbless

### DIFF
--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -93,7 +93,7 @@ function deploy_kong_dbless()
 
 function create_network()
 {
-  docker network inspect $NETWORK_NAME >/dev/null|| docker network create $NETWORK_NAME
+  docker network inspect $NETWORK_NAME 2>/dev/null >/dev/null || docker network create $NETWORK_NAME
 }
 
 while [[ $# -gt 0 ]]; do
@@ -113,8 +113,6 @@ while [[ $# -gt 0 ]]; do
     *)
   esac
 done
-
-set -x
 
 if [[ "${DBMODE}" == "off" ]]; then
   create_network

--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-KONG_IMAGE=${KONG_IMAGE_REPO:-kong}:${KONG_IMAGE_TAG:-3.0.0}
+KONG_IMAGE=${KONG_IMAGE_REPO:-kong}:${KONG_IMAGE_TAG:-3.1.1}
 NETWORK_NAME=kong-test
 
 PG_CONTAINER_NAME=pg
@@ -16,54 +16,116 @@ GATEWAY_CONTAINER_NAME=kong
 waitContainer() {
   for try in {1..100}; do
     echo "waiting for $1.."
-    nc localhost $2 && break;
+    nc -w 1 localhost $2 && break;
     sleep $3
   done
 }
 
-# create docker network
-docker network create $NETWORK_NAME
+function deploy_pg()
+{
+  # Start a PostgreSQL container
+  docker run --rm -d --name $PG_CONTAINER_NAME \
+    --network=$NETWORK_NAME \
+    -p 5432:5432 \
+    -e "POSTGRES_USER=$DATABASE_USER" \
+    -e "POSTGRES_DB=$DATABASE_NAME" \
+    -e "POSTGRES_PASSWORD=$KONG_DB_PASSWORD" \
+    postgres:9.6
 
-# Start a PostgreSQL container
-docker run --rm -d --name $PG_CONTAINER_NAME \
-  --network=$NETWORK_NAME \
-  -p 5432:5432 \
-  -e "POSTGRES_USER=$DATABASE_USER" \
-  -e "POSTGRES_DB=$DATABASE_NAME" \
-  -e "POSTGRES_PASSWORD=$KONG_DB_PASSWORD" \
-  postgres:9.6
+  waitContainer "PostgreSQL" 5432 0.2
 
-waitContainer "PostgreSQL" 5432 0.2
+  for try in {1..10}; do
+    # Prepare the Kong database
+    docker run --rm --network=$NETWORK_NAME \
+      -e "KONG_DATABASE=postgres" \
+      -e "KONG_PG_HOST=$KONG_PG_HOST" \
+      -e "KONG_PG_PASSWORD=$KONG_DB_PASSWORD" \
+      -e "KONG_PASSWORD=$KONG_DB_PASSWORD" \
+      $KONG_IMAGE kong migrations bootstrap && break
+  done
+}
 
-# Prepare the Kong database
-docker run --rm --network=$NETWORK_NAME \
-  -e "KONG_DATABASE=postgres" \
-  -e "KONG_PG_HOST=$KONG_PG_HOST" \
-  -e "KONG_PG_PASSWORD=$KONG_DB_PASSWORD" \
-  -e "KONG_PASSWORD=$KONG_DB_PASSWORD" \
-  $KONG_IMAGE kong migrations bootstrap
+function deploy_kong_postgres()
+{
+  docker run -d --name $GATEWAY_CONTAINER_NAME \
+    --network=$NETWORK_NAME \
+    -e "KONG_DATABASE=postgres" \
+    -e "KONG_PG_HOST=$KONG_PG_HOST" \
+    -e "KONG_PG_USER=$DATABASE_USER" \
+    -e "KONG_PG_PASSWORD=$KONG_DB_PASSWORD" \
+    -e "KONG_CASSANDRA_CONTACT_POINTS=kong-database" \
+    -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
+    -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
+    -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
+    -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
+    -e "KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl" \
+    -e "KONG_ADMIN_GUI_AUTH=basic-auth" \
+    -e "KONG_ENFORCE_RBAC=on" \
+    -e "KONG_PORTAL=on" \
+    -p 8000:8000 \
+    -p 8443:8443 \
+    -p 127.0.0.1:8001:8001 \
+    -p 127.0.0.1:8444:8444 \
+    $KONG_IMAGE
+  waitContainer "Kong" 8001 0.2
+}
 
-# Start Kong Gateway
-docker run -d --name $GATEWAY_CONTAINER_NAME \
-  --network=$NETWORK_NAME \
-  -e "KONG_DATABASE=postgres" \
-  -e "KONG_PG_HOST=$KONG_PG_HOST" \
-  -e "KONG_PG_USER=$DATABASE_USER" \
-  -e "KONG_PG_PASSWORD=$KONG_DB_PASSWORD" \
-  -e "KONG_CASSANDRA_CONTACT_POINTS=kong-database" \
-  -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
-  -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
-  -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
-  -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
-  -e "KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl" \
-  -e "KONG_ADMIN_GUI_AUTH=basic-auth" \
-  -e "KONG_ENFORCE_RBAC=on" \
-  -e "KONG_PORTAL=on" \
-  -p 8000:8000 \
-  -p 8443:8443 \
-  -p 127.0.0.1:8001:8001 \
-  -p 127.0.0.1:8444:8444 \
-  $KONG_IMAGE
+function deploy_kong_dbless()
+{
+  docker run -d --name $GATEWAY_CONTAINER_NAME \
+    --network=$NETWORK_NAME \
+    -e "KONG_DATABASE=off" \
+    -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
+    -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
+    -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
+    -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
+    -e "KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl" \
+    -e "KONG_ADMIN_GUI_AUTH=basic-auth" \
+    -e "KONG_ENFORCE_RBAC=on" \
+    -e "KONG_PORTAL=on" \
+    -p 8000:8000 \
+    -p 8443:8443 \
+    -p 127.0.0.1:8001:8001 \
+    -p 127.0.0.1:8444:8444 \
+    $KONG_IMAGE
+  waitContainer "Kong" 8001 0.2
+}
 
-waitContainer "Kong" 8001 0.2
+function create_network()
+{
+  docker network inspect $NETWORK_NAME >/dev/null|| docker network create $NETWORK_NAME
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dbless)
+      DBMODE="off"
+      shift # past argument
+      ;;
+    --postgres)
+      DBMODE="postgres"
+      shift # past argument
+      ;;
+    -*|--*)
+      echo "Unknown option ${1}"
+      exit 1
+      ;;
+    *)
+  esac
+done
+
+set -x
+
+if [[ "${DBMODE}" == "off" ]]; then
+  create_network
+  deploy_kong_dbless
+elif [[ "${DBMODE}" == "postgres" ]]; then
+  create_network
+  deploy_pg
+  deploy_kong_postgres
+else
+  echo "ERROR: no dbmode specified. Run this script with --dbless or --postgres"
+  exit 1
+fi
+
 sleep 5

--- a/.github/workflows/integration-test-nightly.yaml
+++ b/.github/workflows/integration-test-nightly.yaml
@@ -11,6 +11,11 @@ on:
 
 jobs:
   test:
+    strategy:
+      matrix:
+        dbmode:
+          - 'dbless'
+          - 'postgres'
     env:
       KONG_IMAGE_REPO: "kong/kong"
       KONG_IMAGE_TAG: "master-alpine"
@@ -30,7 +35,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Setup Kong
-        run: make setup-kong
+        run: make setup-kong-${{ matrix.dbmode }}
       - name: Run tests
         run: make test-coverage
       - name: Upload Code Coverage

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -24,6 +24,9 @@ jobs:
         - '2.8.0'
         - '3.0.1'
         - '3.1.0'
+        dbmode:
+          - 'dbless'
+          - 'postgres'
     env:
       KONG_IMAGE_TAG: ${{ matrix.kong_version }}
       KONG_ANONYMOUS_REPORTS: "off"
@@ -42,7 +45,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Setup Kong
-        run: make setup-kong
+        run: make setup-kong-${{ matrix.dbmode }}
       - name: Run tests
         run: make test-coverage
       - name: Upload Code Coverage

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,13 @@ verify-codegen:
 update-codegen:
 	./hack/update-deepcopy-gen.sh
 
-.PHONY: setup-kong
-setup-kong:
-	bash .ci/setup_kong.sh
+.PHONY: setup-kong-dbless
+setup-kong-dbless:
+	bash .ci/setup_kong.sh --dbless
+
+.PHONY: setup-kong-postgres
+setup-kong-postgres:
+	bash .ci/setup_kong.sh --postgres
 
 .PHONY: setup-kong-ee
 setup-kong-ee:

--- a/kong/acl_service_test.go
+++ b/kong/acl_service_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestACLGroupCreate(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -52,6 +54,8 @@ func TestACLGroupCreate(T *testing.T) {
 }
 
 func TestACLGroupCreateWithID(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -85,6 +89,8 @@ func TestACLGroupCreateWithID(T *testing.T) {
 }
 
 func TestACLGroupGet(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -132,6 +138,8 @@ func TestACLGroupGet(T *testing.T) {
 }
 
 func TestACLGroupUpdate(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -172,6 +180,8 @@ func TestACLGroupUpdate(T *testing.T) {
 }
 
 func TestACLGroupDelete(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -209,6 +219,8 @@ func TestACLGroupDelete(T *testing.T) {
 }
 
 func TestACLGroupListMethods(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 

--- a/kong/basic_auth_service_test.go
+++ b/kong/basic_auth_service_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestBasicAuthCreate(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -62,6 +64,8 @@ func TestBasicAuthCreate(T *testing.T) {
 }
 
 func TestBasicAuthCreateWithID(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -99,6 +103,8 @@ func TestBasicAuthCreateWithID(T *testing.T) {
 }
 
 func TestBasicAuthGet(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -150,6 +156,8 @@ func TestBasicAuthGet(T *testing.T) {
 }
 
 func TestBasicAuthUpdate(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -196,6 +204,8 @@ func TestBasicAuthUpdate(T *testing.T) {
 }
 
 func TestBasicAuthDelete(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -236,6 +246,8 @@ func TestBasicAuthDelete(T *testing.T) {
 }
 
 func TestBasicAuthListMethods(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	// Enterprise tests create an admin, which affects the list endpoints in peculiar ways. although the actual
 	// consumer and credential entities are hidden from the API they still affect pagination. Tests that check
 	// pagination behavior cannot check the same values on community and Enterprise. As such, we just don't run this

--- a/kong/ca_certificate_service_test.go
+++ b/kong/ca_certificate_service_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -96,8 +97,11 @@ R+pHRocvtyc8EnkuMw6+jGHr
 )
 
 func TestCACertificatesService(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.3.0")
+
 	assert := assert.New(T)
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
 	assert.NoError(err)
@@ -115,8 +119,8 @@ func TestCACertificatesService(T *testing.T) {
 	certificate.Cert = String(caCert1)
 	createdCertificate, err = client.CACertificates.Create(defaultCtx,
 		certificate)
-	assert.NoError(err)
-	assert.NotNil(createdCertificate)
+	require.NoError(err)
+	require.NotNil(createdCertificate)
 
 	certificate, err = client.CACertificates.Get(defaultCtx,
 		createdCertificate.ID)
@@ -149,8 +153,11 @@ func TestCACertificatesService(T *testing.T) {
 }
 
 func TestCACertificateWithTags(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.3.0")
+
 	assert := assert.New(T)
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
 	assert.NoError(err)
@@ -163,8 +170,8 @@ func TestCACertificateWithTags(T *testing.T) {
 
 	createdCertificate, err := client.CACertificates.Create(defaultCtx,
 		certificate)
-	assert.NoError(err)
-	assert.NotNil(createdCertificate)
+	require.NoError(err)
+	require.NotNil(createdCertificate)
 	assert.Equal(StringSlice("tag1", "tag2"), createdCertificate.Tags)
 
 	err = client.CACertificates.Delete(defaultCtx, createdCertificate.ID)
@@ -172,8 +179,11 @@ func TestCACertificateWithTags(T *testing.T) {
 }
 
 func TestCACertificateListEndpoint(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.3.0")
+
 	assert := assert.New(T)
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
 	assert.NoError(err)
@@ -203,9 +213,9 @@ func TestCACertificateListEndpoint(T *testing.T) {
 
 	certificatesFromKong, next, err := client.CACertificates.List(defaultCtx, nil)
 
-	assert.NoError(err)
-	assert.Nil(next)
-	assert.NotNil(certificatesFromKong)
+	require.NoError(err)
+	require.Nil(next)
+	require.NotNil(certificatesFromKong)
 	assert.Equal(3, len(certificatesFromKong))
 
 	// check if we see all certificates

--- a/kong/certificate_service_test.go
+++ b/kong/certificate_service_test.go
@@ -254,6 +254,8 @@ StncqiK5F5CsWRrwQCpoNDkOAQE/l7QZgBzYrXw4vQ==
 )
 
 func TestCertificatesService(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -310,8 +312,11 @@ func TestCertificatesService(T *testing.T) {
 }
 
 func TestCertificateWithTags(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.1.0")
+
 	assert := assert.New(T)
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
 	assert.NoError(err)
@@ -324,15 +329,17 @@ func TestCertificateWithTags(T *testing.T) {
 	}
 
 	createdCertificate, err := client.Certificates.Create(defaultCtx, certificate)
-	assert.NoError(err)
-	assert.NotNil(createdCertificate)
-	assert.Equal(StringSlice("tag1", "tag2"), createdCertificate.Tags)
+	require.NoError(err)
+	require.NotNil(createdCertificate)
+	require.Equal(StringSlice("tag1", "tag2"), createdCertificate.Tags)
 
 	err = client.Certificates.Delete(defaultCtx, createdCertificate.ID)
 	assert.NoError(err)
 }
 
 func TestCertificateListEndpoint(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 

--- a/kong/client.go
+++ b/kong/client.go
@@ -238,7 +238,7 @@ func (c *Client) DoRAW(ctx context.Context, req *http.Request) (*http.Response, 
 func (c *Client) Do(ctx context.Context, req *http.Request,
 	v interface{},
 ) (*Response, error) {
-	resp, err := c.DoRAW(ctx, req)
+	resp, err := c.DoRAW(ctx, req) //nolint:bodyclose
 	if err != nil {
 		return nil, err
 	}

--- a/kong/client_test.go
+++ b/kong/client_test.go
@@ -2,7 +2,6 @@ package kong
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -101,9 +100,6 @@ func TestDo(T *testing.T) {
 			resp, err = client.Do(context.Background(), req, nil)
 			require.NotNil(err)
 			require.NotNil(resp)
-			body, err := io.ReadAll(resp.Body)
-			assert.NoError(err)
-			assert.Empty(body)
 			assert.Equal(405, resp.StatusCode)
 		})
 	}

--- a/kong/consumer_service_test.go
+++ b/kong/consumer_service_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestConsumersService(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -67,12 +69,14 @@ func TestConsumersService(T *testing.T) {
 }
 
 func TestConsumerWithTags(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.1.0")
-	assert := assert.New(T)
+
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(err)
+	require.NotNil(client)
 
 	consumer := &Consumer{
 		Username: String("foo"),
@@ -80,15 +84,17 @@ func TestConsumerWithTags(T *testing.T) {
 	}
 
 	createdConsumer, err := client.Consumers.Create(defaultCtx, consumer)
-	assert.NoError(err)
-	assert.NotNil(createdConsumer)
-	assert.Equal(StringSlice("tag1", "tag2"), createdConsumer.Tags)
+	require.NoError(err)
+	require.NotNil(createdConsumer)
+	require.Equal(StringSlice("tag1", "tag2"), createdConsumer.Tags)
 
 	err = client.Consumers.Delete(defaultCtx, createdConsumer.ID)
-	assert.NoError(err)
+	require.NoError(err)
 }
 
 func TestConsumerListEndpoint(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	// Enterprise tests create an admin, which affects the list endpoints in peculiar ways. although the actual
 	// consumer and credential entities are hidden from the API they still affect pagination. Tests that check
 	// pagination behavior cannot check the same values on community and Enterprise. As such, we just don't run this
@@ -165,7 +171,9 @@ func TestConsumerListEndpoint(T *testing.T) {
 }
 
 func TestConsumerListWithTags(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.1.0")
+
 	assert := assert.New(T)
 	require := require.New(T)
 

--- a/kong/hmac_auth_service_test.go
+++ b/kong/hmac_auth_service_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestHMACAuthCreate(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -54,6 +56,8 @@ func TestHMACAuthCreate(T *testing.T) {
 }
 
 func TestHMACAuthCreateWithID(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -90,6 +94,8 @@ func TestHMACAuthCreateWithID(T *testing.T) {
 }
 
 func TestHMACAuthGet(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -139,6 +145,8 @@ func TestHMACAuthGet(T *testing.T) {
 }
 
 func TestHMACAuthUpdate(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -184,6 +192,8 @@ func TestHMACAuthUpdate(T *testing.T) {
 }
 
 func TestHMACAuthDelete(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -223,6 +233,8 @@ func TestHMACAuthDelete(T *testing.T) {
 }
 
 func TestHMACAuthListMethods(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 

--- a/kong/jwt_auth_service_test.go
+++ b/kong/jwt_auth_service_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestJWTCreate(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -54,6 +56,8 @@ func TestJWTCreate(T *testing.T) {
 }
 
 func TestJWTCreateWithID(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -90,6 +94,8 @@ func TestJWTCreateWithID(T *testing.T) {
 }
 
 func TestJWTGet(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -138,6 +144,8 @@ func TestJWTGet(T *testing.T) {
 }
 
 func TestJWTUpdate(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -180,6 +188,8 @@ func TestJWTUpdate(T *testing.T) {
 }
 
 func TestJWTDelete(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -217,6 +227,8 @@ func TestJWTDelete(T *testing.T) {
 }
 
 func TestJWTListMethods(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 

--- a/kong/key_auth_service_test.go
+++ b/kong/key_auth_service_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestKeyAuthCreate(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -51,6 +53,8 @@ func TestKeyAuthCreate(T *testing.T) {
 }
 
 func TestKeyAuthCreateWithID(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -85,6 +89,8 @@ func TestKeyAuthCreateWithID(T *testing.T) {
 }
 
 func TestKeyAuthGet(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -136,6 +142,8 @@ func TestKeyAuthGet(T *testing.T) {
 }
 
 func TestKeyAuthUpdate(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -179,6 +187,8 @@ func TestKeyAuthUpdate(T *testing.T) {
 }
 
 func TestKeyAuthDelete(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -218,6 +228,8 @@ func TestKeyAuthDelete(T *testing.T) {
 }
 
 func TestKeyAuthListMethods(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -308,7 +320,9 @@ func TestKeyAuthListMethods(T *testing.T) {
 }
 
 func TestKeyAuthCreateWithTTL(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.4.0")
+
 	assert := assert.New(T)
 	require := require.New(T)
 

--- a/kong/key_service_test.go
+++ b/kong/key_service_test.go
@@ -74,7 +74,9 @@ func TestKeyService(T *testing.T) {
 }
 
 func TestKeyServiceWithSet(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=3.1.0")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -180,7 +182,9 @@ func TestKeyWithTags(T *testing.T) {
 }
 
 func TestKeyWithTagsWithSet(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=3.1.0")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -376,7 +380,9 @@ func TestKeyListWithTags(T *testing.T) {
 }
 
 func TestKeyListWithTagsWithSet(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=3.1.0")
+
 	assert := assert.New(T)
 	require := require.New(T)
 

--- a/kong/keyset_service_test.go
+++ b/kong/keyset_service_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestKeySetService(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=3.1.0")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -55,12 +57,14 @@ func TestKeySetService(T *testing.T) {
 }
 
 func TestKeySetWithTags(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=3.1.0")
-	assert := assert.New(T)
+
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(err)
+	require.NotNil(client)
 
 	keySet := &KeySet{
 		Name: String("foo"),
@@ -68,16 +72,18 @@ func TestKeySetWithTags(T *testing.T) {
 	}
 
 	createdKeySet, err := client.KeySets.Create(defaultCtx, keySet)
-	assert.NoError(err)
-	assert.NotNil(createdKeySet)
-	assert.Equal(StringSlice("tag1", "tag2"), createdKeySet.Tags)
+	require.NoError(err)
+	require.NotNil(createdKeySet)
+	require.Equal(StringSlice("tag1", "tag2"), createdKeySet.Tags)
 
 	err = client.KeySets.Delete(defaultCtx, createdKeySet.ID)
-	assert.NoError(err)
+	require.NoError(err)
 }
 
 func TestKeySetListWithTags(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=3.1.0")
+
 	assert := assert.New(T)
 	require := require.New(T)
 

--- a/kong/oauth2_auth_service_test.go
+++ b/kong/oauth2_auth_service_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestOauth2CredentialCreate(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -51,6 +53,8 @@ func TestOauth2CredentialCreate(T *testing.T) {
 }
 
 func TestOauth2CredentialCreateWithID(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -89,6 +93,8 @@ func TestOauth2CredentialCreateWithID(T *testing.T) {
 }
 
 func TestOauth2CredentialCreatePublicClientType(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -126,6 +132,8 @@ func TestOauth2CredentialCreatePublicClientType(T *testing.T) {
 }
 
 func TestOauth2CredentialGet(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -226,6 +234,8 @@ func TestOauth2CredentialUpdate(T *testing.T) {
 }
 
 func TestOauth2CredentialDelete(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -267,6 +277,8 @@ func TestOauth2CredentialDelete(T *testing.T) {
 }
 
 func TestOauth2CredentialListMethods(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -41,6 +41,8 @@ func TestPluginsServiceValidation(T *testing.T) {
 }
 
 func TestPluginsService(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -177,12 +179,14 @@ func TestPluginsService(T *testing.T) {
 }
 
 func TestPluginWithTags(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.1.0")
-	assert := assert.New(T)
+
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(err)
+	require.NotNil(client)
 
 	plugin := &Plugin{
 		Name: String("key-auth"),
@@ -190,12 +194,12 @@ func TestPluginWithTags(T *testing.T) {
 	}
 
 	createdPlugin, err := client.Plugins.Create(defaultCtx, plugin)
-	assert.NoError(err)
-	assert.NotNil(createdPlugin)
-	assert.Equal(StringSlice("tag1", "tag2"), createdPlugin.Tags)
+	require.NoError(err)
+	require.NotNil(createdPlugin)
+	require.Equal(StringSlice("tag1", "tag2"), createdPlugin.Tags)
 
 	err = client.Plugins.Delete(defaultCtx, createdPlugin.ID)
-	assert.NoError(err)
+	require.NoError(err)
 }
 
 func TestPluginWithOrdering(T *testing.T) {
@@ -275,6 +279,8 @@ func TestUnknownPlugin(T *testing.T) {
 }
 
 func TestPluginListEndpoint(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -354,6 +360,8 @@ func TestPluginListEndpoint(T *testing.T) {
 }
 
 func TestPluginListAllForEntityEndpoint(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 

--- a/kong/route_service_test.go
+++ b/kong/route_service_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestRoutesRoute(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -99,12 +101,13 @@ func TestRoutesRoute(T *testing.T) {
 }
 
 func TestRouteWithTags(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.1.0")
-	assert := assert.New(T)
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(err)
+	require.NotNil(client)
 
 	route := &Route{
 		Name:  String("key-auth"),
@@ -113,15 +116,17 @@ func TestRouteWithTags(T *testing.T) {
 	}
 
 	createdRoute, err := client.Routes.Create(defaultCtx, route)
-	assert.NoError(err)
-	assert.NotNil(createdRoute)
-	assert.Equal(StringSlice("tag1", "tag2"), createdRoute.Tags)
+	require.NoError(err)
+	require.NotNil(createdRoute)
+	require.Equal(StringSlice("tag1", "tag2"), createdRoute.Tags)
 
 	err = client.Routes.Delete(defaultCtx, createdRoute.ID)
-	assert.NoError(err)
+	require.NoError(err)
 }
 
 func TestCreateInRoute(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -160,12 +165,14 @@ func TestCreateInRoute(T *testing.T) {
 }
 
 func TestRouteListEndpoint(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(err)
+	require.NotNil(client)
 
 	service := &Service{
 		Name: String("foo"),
@@ -175,8 +182,8 @@ func TestRouteListEndpoint(T *testing.T) {
 	}
 
 	createdService, err := client.Services.Create(defaultCtx, service)
-	assert.NoError(err)
-	assert.NotNil(createdService)
+	require.NoError(err)
+	require.NotNil(createdService)
 
 	// fixtures
 	routes := []*Route{
@@ -269,12 +276,14 @@ func compareRoutes(T *testing.T, expected, actual []*Route) bool {
 }
 
 func TestRouteWithHeaders(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.3.0")
 	assert := assert.New(T)
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(err)
+	require.NotNil(client)
 
 	route := &Route{
 		Name: String("route-by-header"),
@@ -285,8 +294,8 @@ func TestRouteWithHeaders(T *testing.T) {
 	}
 
 	createdRoute, err := client.Routes.Create(defaultCtx, route)
-	assert.NoError(err)
-	assert.NotNil(createdRoute)
+	require.NoError(err)
+	require.NotNil(createdRoute)
 	assert.Equal(StringSlice("tag1", "tag2"), createdRoute.Tags)
 	assert.Equal(map[string][]string{"foo": {"bar"}}, createdRoute.Headers)
 

--- a/kong/service_service_test.go
+++ b/kong/service_service_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestServicesService(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -83,12 +85,15 @@ func TestServicesService(T *testing.T) {
 }
 
 func TestServiceWithTags(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	RunWhenKong(T, ">=1.1.0")
 	assert := assert.New(T)
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(err)
+	require.NotNil(client)
 
 	service := &Service{
 		Name: String("key-auth"),
@@ -97,8 +102,8 @@ func TestServiceWithTags(T *testing.T) {
 	}
 
 	createdService, err := client.Services.Create(defaultCtx, service)
-	assert.NoError(err)
-	assert.NotNil(createdService)
+	require.NoError(err)
+	require.NotNil(createdService)
 	assert.Equal(StringSlice("tag1", "tag2"), createdService.Tags)
 
 	err = client.Services.Delete(defaultCtx, createdService.ID)
@@ -106,6 +111,8 @@ func TestServiceWithTags(T *testing.T) {
 }
 
 func TestServiceListEndpoint(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -132,8 +139,8 @@ func TestServiceListEndpoint(T *testing.T) {
 	// create fixturs
 	for i := 0; i < len(services); i++ {
 		service, err := client.Services.Create(defaultCtx, services[i])
-		assert.NoError(err)
-		assert.NotNil(service)
+		require.NoError(err)
+		require.NotNil(service)
 		services[i] = service
 	}
 
@@ -195,20 +202,22 @@ func compareServices(T *testing.T, expected, actual []*Service) bool {
 }
 
 func TestServiceWithClientCert(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.3.0")
 	assert := assert.New(T)
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(err)
+	require.NotNil(client)
 
 	certificate := &Certificate{
 		Key:  String(key1),
 		Cert: String(cert1),
 	}
 	createdCertificate, err := client.Certificates.Create(defaultCtx, certificate)
-	assert.NoError(err)
-	assert.NotNil(createdCertificate)
+	require.NoError(err)
+	require.NotNil(createdCertificate)
 
 	service := &Service{
 		Name:              String("foo"),
@@ -218,8 +227,8 @@ func TestServiceWithClientCert(T *testing.T) {
 	}
 
 	createdService, err := client.Services.Create(defaultCtx, service)
-	assert.NoError(err)
-	assert.NotNil(createdService)
+	require.NoError(err)
+	require.NotNil(createdService)
 	assert.Equal(*createdCertificate.ID, *createdService.ClientCertificate.ID)
 
 	err = client.Services.Delete(defaultCtx, createdService.ID)

--- a/kong/sni_service_test.go
+++ b/kong/sni_service_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestSNIsCertificate(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -73,27 +75,29 @@ func TestSNIsCertificate(T *testing.T) {
 }
 
 func TestSNIWithTags(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.1.0")
 	assert := assert.New(T)
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(err)
+	require.NotNil(client)
 
 	fixtureCertificate, err := client.Certificates.Create(defaultCtx,
 		&Certificate{
 			Key:  String(key1),
 			Cert: String(cert1),
 		})
-	assert.NoError(err)
+	require.NoError(err)
 
 	createdSNI, err := client.SNIs.Create(defaultCtx, &SNI{
 		Name:        String("host1.com"),
 		Certificate: fixtureCertificate,
 		Tags:        StringSlice("tag1", "tag2"),
 	})
-	assert.NoError(err)
-	assert.NotNil(createdSNI)
+	require.NoError(err)
+	require.NotNil(createdSNI)
 	assert.Equal(StringSlice("tag1", "tag2"), createdSNI.Tags)
 
 	err = client.Certificates.Delete(defaultCtx, fixtureCertificate.ID)
@@ -101,6 +105,8 @@ func TestSNIWithTags(T *testing.T) {
 }
 
 func TestSNIListEndpoint(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 

--- a/kong/target_service_test.go
+++ b/kong/target_service_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestTargetsUpstream(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -64,6 +66,8 @@ func TestTargetsUpstream(T *testing.T) {
 }
 
 func TestTargetsUpdate(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -108,25 +112,27 @@ func TestTargetsUpdate(T *testing.T) {
 }
 
 func TestTargetWithTags(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.1.0")
 	assert := assert.New(T)
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(err)
+	require.NotNil(client)
 
 	fixtureUpstream, err := client.Upstreams.Create(defaultCtx, &Upstream{
 		Name: String("vhost.com"),
 	})
-	assert.NoError(err)
+	require.NoError(err)
 
 	createdTarget, err := client.Targets.Create(defaultCtx,
 		fixtureUpstream.ID, &Target{
 			Target: String("10.0.0.1:80"),
 			Tags:   StringSlice("tag1", "tag2"),
 		})
-	assert.NoError(err)
-	assert.NotNil(createdTarget)
+	require.NoError(err)
+	require.NotNil(createdTarget)
 	assert.Equal(StringSlice("tag1", "tag2"), createdTarget.Tags)
 
 	err = client.Upstreams.Delete(defaultCtx, fixtureUpstream.ID)
@@ -134,6 +140,8 @@ func TestTargetWithTags(T *testing.T) {
 }
 
 func TestTargetListEndpoint(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -229,6 +237,8 @@ func compareTargets(expected, actual []*Target) bool {
 }
 
 func TestTargetMarkHealthy(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	// TODO https://github.com/Kong/go-kong/issues/213 this does not yet work on 3.x
 	RunWhenKong(T, "<3.0.0")
 	assert := assert.New(T)
@@ -275,6 +285,8 @@ func TestTargetMarkHealthy(T *testing.T) {
 }
 
 func TestTargetMarkUnhealthy(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	// TODO https://github.com/Kong/go-kong/issues/213 this does not yet work on 3.x
 	RunWhenKong(T, "<3.0.0")
 	assert := assert.New(T)

--- a/kong/test_utils.go
+++ b/kong/test_utils.go
@@ -16,6 +16,8 @@ type RequiredFeatures struct {
 // This helper function can be used in tests to write version specific
 // tests for Kong.
 func RunWhenKong(t *testing.T, versionRange string) {
+	t.Helper()
+
 	client, err := NewTestClient(nil, nil)
 	if err != nil {
 		t.Error(err)
@@ -34,7 +36,7 @@ func RunWhenKong(t *testing.T, versionRange string) {
 		t.Error(err)
 	}
 	if !r(currentVersion) {
-		t.Skip()
+		t.Skipf("kong version %s not in range %s", version, versionRange)
 	}
 }
 
@@ -45,6 +47,8 @@ func RunWhenKong(t *testing.T, versionRange string) {
 // RBAC and RBAC is not enabled on Kong the test
 // will be skipped
 func RunWhenEnterprise(t *testing.T, versionRange string, required RequiredFeatures) {
+	t.Helper()
+
 	client, err := NewTestClient(nil, nil)
 	if err != nil {
 		t.Error(err)
@@ -60,19 +64,16 @@ func RunWhenEnterprise(t *testing.T, versionRange string, required RequiredFeatu
 	}
 
 	if !currentVersion.IsKongGatewayEnterprise() {
-		t.Log("non-Enterprise test Kong instance, skipping")
-		t.Skip()
+		t.Skip("non-Enterprise test Kong instance, skipping")
 	}
 	configuration := info["configuration"].(map[string]interface{})
 
 	if required.RBAC && configuration["rbac"].(string) != "on" {
-		t.Log("RBAC not enabled on test Kong instance, skipping")
-		t.Skip()
+		t.Skip("RBAC not enabled on test Kong instance, skipping")
 	}
 
 	if required.Portal && !configuration["portal"].(bool) {
-		t.Log("Portal not enabled on test Kong instance, skipping")
-		t.Skip()
+		t.Skip("Portal not enabled on test Kong instance, skipping")
 	}
 
 	r, err := NewRange(versionRange)
@@ -80,12 +81,14 @@ func RunWhenEnterprise(t *testing.T, versionRange string, required RequiredFeatu
 		t.Error(err)
 	}
 	if !r(currentVersion) {
-		t.Skip()
+		t.Skipf("kong version %s not in range %s", version, versionRange)
 	}
 }
 
 // SkipWhenEnterprise skips a test if the Kong version is an Enterprise version
 func SkipWhenEnterprise(t *testing.T) {
+	t.Helper()
+
 	client, err := NewTestClient(nil, nil)
 	if err != nil {
 		t.Error(err)
@@ -101,8 +104,7 @@ func SkipWhenEnterprise(t *testing.T) {
 	}
 
 	if currentVersion.IsKongGatewayEnterprise() {
-		t.Log("non-Enterprise test Kong instance, skipping")
-		t.Skip()
+		t.Skip("non-Enterprise test Kong instance, skipping")
 	}
 }
 
@@ -123,6 +125,8 @@ func NewTestClient(baseURL *string, client *http.Client) (*Client, error) {
 }
 
 func RunWhenDBMode(t *testing.T, dbmode string) {
+	t.Helper()
+
 	client, err := NewTestClient(nil, nil)
 	if err != nil {
 		t.Error(err)
@@ -134,29 +138,25 @@ func RunWhenDBMode(t *testing.T, dbmode string) {
 
 	config, ok := info["configuration"]
 	if !ok {
-		t.Logf("failed to find 'configuration' config key in kong configuration")
-		t.Skip()
+		t.Skip("failed to find 'configuration' config key in kong configuration")
 	}
 
 	configuration, ok := config.(map[string]any)
 	if !ok {
-		t.Logf("'configuration' key is not a map but %T", config)
-		t.Skip()
+		t.Skipf("'configuration' key is not a map but %T", config)
 	}
 
 	dbConfig, ok := configuration["database"]
 	if !ok {
-		t.Logf("failed to find 'database' config key in kong confiration")
-		t.Skip()
+		t.Skip("failed to find 'database' config key in kong confiration")
 	}
 
 	dbMode, ok := dbConfig.(string)
 	if !ok {
-		t.Logf("'database' config key is not a string but %T", dbConfig)
-		t.Skip()
+		t.Skipf("'database' config key is not a string but %T", dbConfig)
 	}
 
 	if dbMode != dbmode {
-		t.Skip()
+		t.Skipf("detected Kong running in dbmode:%q but requested dbmode:%q", dbMode, dbmode)
 	}
 }

--- a/kong/upstream_node_health_service_test.go
+++ b/kong/upstream_node_health_service_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestUpstreamNodeHealthService(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 

--- a/kong/upstream_service_test.go
+++ b/kong/upstream_service_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestUpstreamsService(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -54,12 +56,14 @@ func TestUpstreamsService(T *testing.T) {
 }
 
 func TestUpstreamWithTags(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.1.0")
 	assert := assert.New(T)
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(err)
+	require.NotNil(client)
 
 	upstream := &Upstream{
 		Name: String("key-auth"),
@@ -67,8 +71,8 @@ func TestUpstreamWithTags(T *testing.T) {
 	}
 
 	createdUpstream, err := client.Upstreams.Create(defaultCtx, upstream)
-	assert.NoError(err)
-	assert.NotNil(createdUpstream)
+	require.NoError(err)
+	require.NotNil(createdUpstream)
 	assert.Equal(StringSlice("tag1", "tag2"), createdUpstream.Tags)
 
 	err = client.Upstreams.Delete(defaultCtx, createdUpstream.ID)
@@ -77,6 +81,8 @@ func TestUpstreamWithTags(T *testing.T) {
 
 // regression test for #6
 func TestUpstreamWithActiveUnHealthyInterval(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -128,6 +134,8 @@ func TestUpstreamWithPassiveUnHealthyInterval(T *testing.T) {
 }
 
 func TestUpstreamWithPassiveHealthy(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -158,12 +166,14 @@ func TestUpstreamWithPassiveHealthy(T *testing.T) {
 }
 
 func TestUpstreamWithAlgorithm(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.3.0")
 	assert := assert.New(T)
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(err)
+	require.NotNil(client)
 
 	upstream := &Upstream{
 		Name:      String("upstream1"),
@@ -171,8 +181,8 @@ func TestUpstreamWithAlgorithm(T *testing.T) {
 	}
 
 	createdUpstream, err := client.Upstreams.Create(defaultCtx, upstream)
-	assert.NoError(err)
-	assert.NotNil(createdUpstream)
+	require.NoError(err)
+	require.NotNil(createdUpstream)
 	assert.Equal("least-connections", *createdUpstream.Algorithm)
 
 	err = client.Upstreams.Delete(defaultCtx, createdUpstream.ID)
@@ -180,6 +190,8 @@ func TestUpstreamWithAlgorithm(T *testing.T) {
 }
 
 func TestUpstreamListEndpoint(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -272,12 +284,14 @@ func compareUpstreams(T *testing.T, expected, actual []*Upstream) bool {
 }
 
 func TestUpstreamsWithHostHeader(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.4.0")
 	assert := assert.New(T)
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(err)
+	require.NotNil(client)
 
 	upstream := &Upstream{
 		Name:       String("upstream-with-host-header"),
@@ -285,8 +299,8 @@ func TestUpstreamsWithHostHeader(T *testing.T) {
 	}
 
 	createdUpstream, err := client.Upstreams.Create(defaultCtx, upstream)
-	assert.NoError(err)
-	assert.NotNil(createdUpstream)
+	require.NoError(err)
+	require.NotNil(createdUpstream)
 	assert.Equal("example.com", *createdUpstream.HostHeader)
 
 	err = client.Upstreams.Delete(defaultCtx, createdUpstream.ID)


### PR DESCRIPTION
This also bumps default kong image to 3.1.1 and makes some minor refactor in test skipping conditionals (marking `t.Helper()` to prevent logging helper line numbers but to print corresponding test line numbers)