### PR TITLE
fix(ci): don't run enterprise nightly tests for outside contributors

### DIFF
--- a/.github/workflows/integration-test-enterprise-nightly.yaml
+++ b/.github/workflows/integration-test-enterprise-nightly.yaml
@@ -10,8 +10,25 @@ on:
     - '*'
 
 jobs:
+  secret-available:
+    outputs:
+      ok: ${{ steps.exists.outputs.ok }}
+    runs-on: ubuntu-latest
+    env:
+      PULP_PASSWORD: ${{ secrets.PULP_PASSWORD }}
+    steps:
+    - name: check for secret availability
+      id: exists
+      run: |
+        if [ ! -z "$PULP_PASSWORD" ]; then
+          echo "ok=true" >> $GITHUB_OUTPUT
+        fi
+
   test-enterprise:
     continue-on-error: true
+    needs:
+    - secret-available
+    if: needs.secret-available.outputs.ok
     env:
       KONG_ADMIN_TOKEN: kong
       KONG_IMAGE_REPO: "kong/kong-gateway-internal"
@@ -22,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # This will set KONG_LINCENSE_DATA environment variable.
-      - uses: Kong/kong-license@9fb64ad7be1ed2b121a70990783d7c0869e531d5
+      - uses: Kong/kong-license@master
         id: license_step
         with:
           password: ${{ secrets.PULP_PASSWORD }}
@@ -49,4 +66,3 @@ jobs:
           name: codecov-enterprise-nightly
           flags: enterprise-nightly,integration,enterprise
           fail_ci_if_error: true
-

--- a/.github/workflows/integration-test-enterprise.yaml
+++ b/.github/workflows/integration-test-enterprise.yaml
@@ -28,7 +28,7 @@ jobs:
     continue-on-error: true
     needs:
     - secret-available
-    if: needs.secret-available.outputs.ok == 'true'
+    if: needs.secret-available.outputs.ok
     strategy:
       matrix:
         kong_version:
@@ -53,7 +53,7 @@ jobs:
       # to override:
       # Warning: Skip output 'license' since it may contain secret.
       # on Github Actions when setting a job output.
-      - uses: Kong/kong-license@9fb64ad7be1ed2b121a70990783d7c0869e531d5
+      - uses: Kong/kong-license@master
         id: license_step
         with:
           password: ${{ secrets.PULP_PASSWORD }}


### PR DESCRIPTION
To prevent bypassing branch protection rules, don't run enterprise nightly tests just as we do regular enterprise tests already.