### PR TITLE
docs: update compatibility section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go get github.com/kong/go-kong/kong
 
 ## Compatibility
 
-`go-kong` is compatible with Kong 1.x and 2.x.
+`go-kong` is compatible with Kong 2.x and 3.x.
 Semantic versioning is followed for versioning `go-kong`.
 
 ## Generators


### PR DESCRIPTION
This commit is updating the Compatibily section within the README file, making sure it matches the current status.

The `1.x` reference is dropped, since we don't even test go-kong against 1.x releases anymore, and a `3.x` reference is added.