### PR TITLE
fix: omit response body from config push error and release 0.38.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v0.38.1](#v0381)
 - [v0.38.0](#v0380)
 - [v0.37.0](#v0370)
 - [v0.36.0](#v0360)
@@ -46,6 +47,15 @@
 - [0.3.0](#030)
 - [0.2.0](#020)
 - [0.1.0](#010)
+
+## [v0.38.0]
+
+> Release date: 2023/02/22
+
+- Omit response body from error when config push fails. The body can be quite
+  large and will result in massive logs downstream if included in the error.
+  The body is returned along with the error and downstream clients and log it
+  separately if they so desire.
 
 ## [v0.38.0]
 
@@ -692,6 +702,7 @@ authentication credentials in Kong.
   releases of Kong since every release of Kong is introducing breaking changes
   to the Admin API.
 
+[v0.38.1]: https://github.com/Kong/go-kong/compare/v0.38.0...v0.38.1
 [v0.38.0]: https://github.com/Kong/go-kong/compare/v0.37.0...v0.38.0
 [v0.37.0]: https://github.com/Kong/go-kong/compare/v0.36.0...v0.37.0
 [v0.36.0]: https://github.com/Kong/go-kong/compare/v0.35.0...v0.36.0

--- a/kong/client.go
+++ b/kong/client.go
@@ -421,7 +421,7 @@ func (c *Client) ReloadDeclarativeRawConfig(
 		return nil, fmt.Errorf("could not read /config %d status response body: %w", resp.StatusCode, err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		return b, fmt.Errorf("failed posting new config to /config: got status code %d and body %s", resp.StatusCode, b)
+		return b, fmt.Errorf("failed posting new config to /config: got status code %d", resp.StatusCode)
 	}
 
 	return b, nil


### PR DESCRIPTION
Omit the response body from config push error strings. ReloadDeclarativeRawConfig already returns the body separately, so formatting it into the error is unnecessary.

Currently, formatting the body into the error string results in KIC logs like:

```
ERRO[0039] could not update kong admin                   error="performing update for http://172.22.0.102:8001 failed: failed posting new config to /config: got status code 400 and body {\"code\":14,\"fields\":{\"services\":[{\"path\":\"value must be null\",\"@entity\":[\"failed conditional validation given value of field 'protocol'\"]}]},\"name\":\"invalid declarative configuration\",\"flattened_errors\":[{\"entity_name\":\"50a88f89-b578-4c77-a3fe-5371884f306c.httpbin.httpbin..80\",\"entity_tags\":[\"k8s-name:httpbin\",\"k8s-namespace:50a88f89-b578-4c77-a3fe-5371884f306c\",\"k8s-kind:Ingress\",\"k8s-uid:3dcd75e9-c076-46a0-8cd3-3cc62f081920\",\"k8s-group:networking.k8s.io\",\"k8s-version:v1\"],\"entity_type\":\"route\",\"errors\":[{\"type\":\"field\",\"field\":\"methods\",\"message\":\"cannot set 'methods' when 'protocols' is 'grpc' or 'grpcs'\"}],\"entity\":{\"methods\":[\"GET\"],\"path_handling\":\"v0\",\"protocols\":[\"grpcs\"],\"name\":\"50a88f89-b578-4c77-a3fe-5371884f306c.httpbin.httpbin..80\",\"tags\":[\"k8s-name:httpbin\",\"k8s-namespace:50a88f89-b578-4c77-a3fe-5371884f306c\",\"k8s-kind:Ingress\",\"k8s-uid:3dcd75e9-c076-46a0-8cd3-3cc62f081920\",\"k8s-group:networking.k8s.io\",\"k8s-version:v1\"],\"preserve_host\":true,\"request_buffering\":true,\"response_buffering\":true,\"regex_priority\":0,\"https_redirect_status_code\":426,\"paths\":[\"/bar/\",\"~/bar$\"]}},{\"entity_name\":\"50a88f89-b578-4c77-a3fe-5371884f306c.httpbin.httpbin.80\",\"entity_tags\":[\"k8s-name:httpbin\",\"k8s-namespace:50a88f89-b578-4c77-a3fe-5371884f306c\",\"k8s-kind:Service\",\"k8s-uid:bb93d6fb-13bf-4424-9916-d9b04762f4f2\",\"k8s-version:v1\"],\"entity_type\":\"service\",\"errors\":[{\"type\":\"field\",\"field\":\"path\",\"message\":\"value must be null\"},{\"type\":\"entity\",\"message\":\"failed conditional validation given value of field 'protocol'\"}],\"entity\":{\"path\":\"/aitmatov\",\"port\":80,\"host\":\"httpbin.50a88f89-b578-4c77-a3fe-5371884f306c.80.svc\",\"write_timeout\":60000,\"name\":\"50a88f89-b578-4c77-a3fe-5371884f306c.httpbin.httpbin.80\",\"connect_timeout\":60000,\"read_timeout\":60000,\"retries\":5,\"tags\":[\"k8s-name:httpbin\",\"k8s-namespace:50a88f89-b578-4c77-a3fe-5371884f306c\",\"k8s-kind:Service\",\"k8s-uid:bb93d6fb-13bf-4424-9916-d9b04762f4f2\",\"k8s-version:v1\"],\"protocol\":\"tcp\"}}],\"message\":\"declarative config is invalid: {services={{[\\\"@entity\\\"]={\\\"failed conditional validation given value of field 'protocol'\\\"},path=\\\"value must be null\\\"}}}\"}" subsystem=dataplane-synchronizer
```

Massive escaped JSON blobs in their entirety are not good for logs, and we parse the blob into more useful bits after. I expect it's unlikely end users would need to review the entire body string, but if so, that's a case where you should disable TLS and tcpdump to see it.