### PR TITLE
ci: fix setup kong scripts

### DIFF
--- a/.ci/_common.sh
+++ b/.ci/_common.sh
@@ -22,6 +22,7 @@ function create_network()
   fi
 }
 
+# Usage: waitKongAPI <waitPeriodSeconds>
 function waitKongAPI() {
   for try in {1..100}; do
     echo "waiting for Kong Admin API.."

--- a/.ci/_common.sh
+++ b/.ci/_common.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Usage: waitContainer "PostgreSQL" 5432 0.2
+function waitContainer()
+{
+  local container=${1}
+  local port=${2}
+  local sleep_time=${3}
+
+  for try in {1..100}; do
+    echo "waiting for ${container}.."
+    nc localhost ${port} && break;
+    sleep ${sleep_time}
+  done
+}
+
+function create_network()
+{
+  # create docker network if it doesn't exist
+  if [[ -z $(docker network ls --filter name=${NETWORK_NAME} -q) ]]; then
+    docker network create ${NETWORK_NAME}
+  fi
+}
+
+function waitKongAPI() {
+  for try in {1..100}; do
+    echo "waiting for Kong Admin API.."
+    curl -f -LI $KONG_ADMIN_API -H kong-admin-token:$KONG_ADMIN_TOKEN && break;
+    sleep $1
+  done
+}
+
+function deploy_pg()
+{
+  # Start a PostgreSQL container
+  docker run --rm -d --name $PG_CONTAINER_NAME \
+    --network=$NETWORK_NAME \
+    -p 5432:5432 \
+    -e "POSTGRES_USER=$DATABASE_USER" \
+    -e "POSTGRES_DB=$DATABASE_NAME" \
+    -e "POSTGRES_PASSWORD=$KONG_DB_PASSWORD" \
+    postgres:9.6
+
+  waitContainer "PostgreSQL" 5432 0.2
+}
+
+function perform_migrations()
+{
+  for try in {1..10}; do
+    # Prepare the Kong database
+    docker run --rm --network=$NETWORK_NAME \
+      -e "KONG_DATABASE=postgres" \
+      -e "KONG_PG_HOST=$KONG_PG_HOST" \
+      -e "KONG_PG_PASSWORD=$KONG_DB_PASSWORD" \
+      -e "KONG_PASSWORD=$KONG_DB_PASSWORD" \
+      -e "KONG_LICENSE_DATA=$KONG_LICENSE_DATA" \
+      $KONG_IMAGE kong migrations bootstrap && break
+  done
+}

--- a/.ci/_common.sh
+++ b/.ci/_common.sh
@@ -23,7 +23,8 @@ function create_network()
 }
 
 # Usage: waitKongAPI <waitPeriodSeconds>
-function waitKongAPI() {
+function waitKongAPI()
+{
   for try in {1..100}; do
     echo "waiting for Kong Admin API.."
     curl -f -LI $KONG_ADMIN_API -H kong-admin-token:$KONG_ADMIN_TOKEN && break;

--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+source $(dirname "$0")/_common.sh
+
 KONG_IMAGE=${KONG_IMAGE_REPO:-kong}:${KONG_IMAGE_TAG:-3.1.1}
 NETWORK_NAME=kong-test
 
@@ -12,38 +14,6 @@ KONG_DB_PASSWORD=kong
 KONG_PG_HOST=pg
 
 GATEWAY_CONTAINER_NAME=kong
-
-waitContainer() {
-  for try in {1..100}; do
-    echo "waiting for $1.."
-    nc -w 1 localhost $2 && break;
-    sleep $3
-  done
-}
-
-function deploy_pg()
-{
-  # Start a PostgreSQL container
-  docker run --rm -d --name $PG_CONTAINER_NAME \
-    --network=$NETWORK_NAME \
-    -p 5432:5432 \
-    -e "POSTGRES_USER=$DATABASE_USER" \
-    -e "POSTGRES_DB=$DATABASE_NAME" \
-    -e "POSTGRES_PASSWORD=$KONG_DB_PASSWORD" \
-    postgres:9.6
-
-  waitContainer "PostgreSQL" 5432 0.2
-
-  for try in {1..10}; do
-    # Prepare the Kong database
-    docker run --rm --network=$NETWORK_NAME \
-      -e "KONG_DATABASE=postgres" \
-      -e "KONG_PG_HOST=$KONG_PG_HOST" \
-      -e "KONG_PG_PASSWORD=$KONG_DB_PASSWORD" \
-      -e "KONG_PASSWORD=$KONG_DB_PASSWORD" \
-      $KONG_IMAGE kong migrations bootstrap && break
-  done
-}
 
 function deploy_kong_postgres()
 {
@@ -91,11 +61,6 @@ function deploy_kong_dbless()
   waitContainer "Kong" 8001 0.2
 }
 
-function create_network()
-{
-  docker network inspect $NETWORK_NAME 2>/dev/null >/dev/null || docker network create $NETWORK_NAME
-}
-
 while [[ $# -gt 0 ]]; do
   case $1 in
     --dbless)
@@ -120,6 +85,7 @@ if [[ "${DBMODE}" == "off" ]]; then
 elif [[ "${DBMODE}" == "postgres" ]]; then
   create_network
   deploy_pg
+  perform_migrations
   deploy_kong_postgres
 else
   echo "ERROR: no dbmode specified. Run this script with --dbless or --postgres"

--- a/.ci/setup_kong_ee.sh
+++ b/.ci/setup_kong_ee.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-KONG_IMAGE=${KONG_IMAGE_REPO:-kong/kong-gateway}:${KONG_IMAGE_TAG:-3.0.0.0}
+source $(dirname "$0")/_common.sh
+
+KONG_IMAGE=${KONG_IMAGE_REPO:-kong/kong-gateway}:${KONG_IMAGE_TAG:-3.1.1.0}
 NETWORK_NAME=kong-test
 
 PG_CONTAINER_NAME=pg
@@ -15,78 +17,47 @@ GATEWAY_CONTAINER_NAME=kong
 
 KONG_ADMIN_API=http://localhost:8001
 
-# create docker network
-docker network create $NETWORK_NAME
+create_network
 
-waitContainer() {
-  for try in {1..100}; do
-    echo "waiting for $1.."
-    nc localhost $2 && break;
-    sleep $3
-  done
-}
-
-waitKongAPI() {
-  for try in {1..100}; do
-    echo "waiting for Kong Admin API.."
-    curl -f -LI $KONG_ADMIN_API -H kong-admin-token:$KONG_ADMIN_TOKEN && break;
-    sleep $1
-  done
-}
-
-if [[ -v TEST_KONG_PULL_USERNAME ]]; then
+if [[ ! -z "${TEST_KONG_PULL_USERNAME}" ]]; then
   echo "${TEST_KONG_PULL_PASSWORD}" | docker login --username "${TEST_KONG_PULL_USERNAME}" --password-stdin
 fi
 
+function deploy_kong_ee()
+{
+  # Start Kong Gateway EE
+  docker run -d --name $GATEWAY_CONTAINER_NAME \
+    --network=$NETWORK_NAME \
+    -e "KONG_DATABASE=postgres" \
+    -e "KONG_PG_HOST=$KONG_PG_HOST" \
+    -e "KONG_PG_USER=$DATABASE_USER" \
+    -e "KONG_PG_PASSWORD=$KONG_DB_PASSWORD" \
+    -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
+    -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
+    -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
+    -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
+    -e "KONG_ADMIN_LISTEN=0.0.0.0:8001" \
+    -e "KONG_PORTAL_GUI_URI=127.0.0.1:8003" \
+    -e "KONG_ADMIN_GUI_URL=http://127.0.0.1:8002" \
+    -e "KONG_LICENSE_DATA=$KONG_LICENSE_DATA" \
+    -e "KONG_ADMIN_GUI_AUTH=basic-auth" \
+    -e "KONG_ENFORCE_RBAC=on" \
+    -e "KONG_PORTAL=on" \
+    -e "KONG_ADMIN_GUI_SESSION_CONF={}" \
+    -p 8000:8000 \
+    -p 8443:8443 \
+    -p 8001:8001 \
+    -p 8444:8444 \
+    -p 8002:8002 \
+    -p 8445:8445 \
+    -p 8003:8003 \
+    -p 8004:8004 \
+    $KONG_IMAGE
+}
 
-# Start a PostgreSQL container
-docker run --rm -d --name $PG_CONTAINER_NAME \
-  --network=$NETWORK_NAME \
-  -p 5432:5432 \
-  -e "POSTGRES_USER=$DATABASE_USER" \
-  -e "POSTGRES_DB=$DATABASE_NAME" \
-  -e "POSTGRES_PASSWORD=$KONG_DB_PASSWORD" \
-  postgres:9.6
-
-waitContainer "PostgreSQL" 5432 0.2
-
-# Prepare the Kong database
-docker run --rm --network=$NETWORK_NAME \
-  -e "KONG_DATABASE=postgres" \
-  -e "KONG_PG_HOST=$KONG_PG_HOST" \
-  -e "KONG_PG_PASSWORD=$KONG_DB_PASSWORD" \
-  -e "KONG_PASSWORD=$KONG_DB_PASSWORD" \
-  -e "KONG_LICENSE_DATA=$KONG_LICENSE_DATA" \
-  $KONG_IMAGE kong migrations bootstrap
-
-# Start Kong Gateway EE
-docker run -d --name $GATEWAY_CONTAINER_NAME \
-  --network=$NETWORK_NAME \
-  -e "KONG_DATABASE=postgres" \
-  -e "KONG_PG_HOST=$KONG_PG_HOST" \
-  -e "KONG_PG_USER=$DATABASE_USER" \
-  -e "KONG_PG_PASSWORD=$KONG_DB_PASSWORD" \
-  -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
-  -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
-  -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
-  -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
-  -e "KONG_ADMIN_LISTEN=0.0.0.0:8001" \
-  -e "KONG_PORTAL_GUI_URI=127.0.0.1:8003" \
-  -e "KONG_ADMIN_GUI_URL=http://127.0.0.1:8002" \
-  -e "KONG_LICENSE_DATA=$KONG_LICENSE_DATA" \
-  -e "KONG_ADMIN_GUI_AUTH=basic-auth" \
-  -e "KONG_ENFORCE_RBAC=on" \
-  -e "KONG_PORTAL=on" \
-  -e "KONG_ADMIN_GUI_SESSION_CONF={}" \
-  -p 8000:8000 \
-  -p 8443:8443 \
-  -p 8001:8001 \
-  -p 8444:8444 \
-  -p 8002:8002 \
-  -p 8445:8445 \
-  -p 8003:8003 \
-  -p 8004:8004 \
-  $KONG_IMAGE
+deploy_pg
+perform_migrations
+deploy_kong_ee
 
 waitContainer "Kong" 8001 0.2
 waitKongAPI 0.5


### PR DESCRIPTION
Currently setup script are very fragile and susceptible to the state of the environment.

For instance when docker network used for tests already exists then user is greeted with 

```
Error response from daemon: network with name kong-test already exists
```

When that is sorted `./.ci/setup_kong_ee.sh` prints out:

```
d49438e56decc80a8ec362b515731cd551ee1536571eef7fb55e59f6f3ade158
./.ci/setup_kong_ee.sh: line 37: conditional binary operator expected
```

This PR aims to fix that and to extract some small utility functions to `./ci/_common.sh` which is then sourced in `setup_kong_ee.sh` and `setup_kong.sh`