### PR TITLE
chore(ci): skip caching in golangci/golangci-lint-action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,5 +22,8 @@ jobs:
           go-version-file: go.mod
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v3.4.0
+        with:
+          # actions/setup-go@v4 introduced automatic cache handling so skip cache here
+          skip-cache: true
       - name: Verify Codegen
         run: make verify-codegen


### PR DESCRIPTION
After `actions/setup-go@v4` introduces automatic go caching we can do away with golangci-lint action's cache.

Exemplar failures: https://github.com/Kong/go-kong/actions/runs/4436756271/jobs/7785584917#step:4:23