### PR TITLE
feat: add global query params to kong client

### DIFF
--- a/kong/client.go
+++ b/kong/client.go
@@ -34,8 +34,10 @@ var defaultCtx = context.Background()
 // Client talks to the Admin API or control plane of a
 // Kong cluster
 type Client struct {
-	client                  *http.Client
-	baseRootURL             string
+	client      *http.Client
+	baseRootURL string
+	// QueryParams are query string parameters that are set on all requests.
+	QueryParams             url.Values
 	workspace               string       // Do not access directly. Use Workspace()/SetWorkspace().
 	workspaceLock           sync.RWMutex // Synchronizes access to workspace.
 	common                  service
@@ -116,6 +118,7 @@ func NewClient(baseURL *string, client *http.Client) (*Client, error) {
 		}
 	}
 	kong := new(Client)
+	kong.QueryParams = make(url.Values, 0)
 	kong.client = client
 	var rootURL string
 	if baseURL != nil {

--- a/kong/request.go
+++ b/kong/request.go
@@ -48,12 +48,23 @@ func (c *Client) NewRequestRaw(method, baseURL string, endpoint string, qs inter
 	}
 
 	// add query string if any
-	if qs != nil {
-		values, err := query.Values(qs)
-		if err != nil {
-			return nil, err
+	if qs != nil || len(c.QueryParams) > 0 {
+		if qs == nil {
+			req.URL.RawQuery = c.QueryParams.Encode()
+		} else {
+			values, err := query.Values(qs)
+			if err != nil {
+				return nil, err
+			}
+
+			// apply global query params
+			for param, paramValues := range c.QueryParams {
+				for _, paramValue := range paramValues {
+					values.Add(param, paramValue)
+				}
+			}
+			req.URL.RawQuery = values.Encode()
 		}
-		req.URL.RawQuery = values.Encode()
 	}
 	return req, nil
 }

--- a/kong/request_test.go
+++ b/kong/request_test.go
@@ -89,4 +89,33 @@ func TestNewRequestBody(t *testing.T) {
 			string(b),
 		)
 	})
+
+	t.Run("query params are set in URL", func(t *testing.T) {
+		cl, err := NewClient(nil, nil)
+		require.NoError(t, err)
+		cl.QueryParams.Add("cluster.id", "clusterId")
+		cl.QueryParams.Add("params", "test1")
+		cl.QueryParams.Add("params", "test2")
+
+		req, err := cl.NewRequest("GET", "/", nil, nil)
+		require.NoError(t, err)
+		require.Contains(t, req.URL.String(), "cluster.id=clusterId&params=test1&params=test2")
+	})
+
+	t.Run("query params and qs are set in URL", func(t *testing.T) {
+		type Opt struct {
+			Params   string `url:"params"`
+			NewParam string `url:"newParam"`
+		}
+		cl, err := NewClient(nil, nil)
+		require.NoError(t, err)
+		cl.QueryParams.Add("cluster.id", "clusterId")
+		cl.QueryParams.Add("params", "test1")
+		cl.QueryParams.Add("params", "test2")
+
+		req, err := cl.NewRequest("GET", "/", Opt{"test3", "newParam"}, nil)
+		require.NoError(t, err)
+		require.Contains(t, req.URL.String(),
+			"cluster.id=clusterId&newParam=newParam&params=test3&params=test1&params=test2")
+	})
 }


### PR DESCRIPTION
This is mostly a konnect requirement for our development workflow, but there are cases that we need to set global query params to use deck+go-kong.