### PR TITLE
fix: fill config defaults for array of records

### DIFF
--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -1015,8 +1015,37 @@ func Test_fillConfigRecord(T *testing.T) {
 		expected Configuration
 	}{
 		{
-			name:   "fills defaults for all missing fields",
-			schema: gjson.Parse("{\"fields\":{\"config\":{\"type\":\"record\",\"fields\":[{\"enabled\":{\"type\":\"boolean\",\"default\":true,\"required\":true}},{\"mappings\":{\"required\":false,\"type\":\"array\",\"elements\":{\"type\":\"record\",\"fields\":[{\"name\":{\"type\":\"string\",\"required\":false}},{\"nationality\":{\"type\":\"string\",\"required\":false}}]}}}]}}}"),
+			name: "fills defaults for all missing fields",
+			schema: gjson.Parse(`{
+				"fields": {
+					"config":
+						{
+							"type": "record",
+							"fields":[
+								{
+									"enabled":{
+										"type":"boolean",
+										"default":true,
+										"required":true
+									}
+								},
+								{
+									"mappings":{
+										"required":false,
+										"type":"array",
+										"elements":{
+											"type":"record",
+											"fields":[
+												{"name":{"type":"string","required":false}},
+												{"nationality":{"type":"string","required":false}}
+											]
+										}
+									}
+								}
+							]
+						}
+					}
+				}`),
 			config: Configuration{
 				"mappings": []interface{}{
 					map[string]interface{}{


### PR DESCRIPTION
Add handling for type "record" nested under type "array". 

Currently there is no handling for subconfig of type array, therefore defaults/nil values are not set when there are missing fields in array of records

This fixes the issue by recursively calling the same function for all the records in the array.
Added test for the same

Fixes: #301 