### PR TITLE
chore: bump kong versions in integration tests strategy matrix

### DIFF
--- a/.github/workflows/integration-test-enterprise.yaml
+++ b/.github/workflows/integration-test-enterprise.yaml
@@ -44,10 +44,10 @@ jobs:
         - '2.5.1.2'
         - '2.6.1.0'
         - '2.7.2.0'
-        - '2.8.2.4'
+        - '2.8.4.0'
         - '3.0.2.0'
         - '3.1.1.3'
-        - '3.2.2.0'
+        - '3.2.2.1'
     env:
       KONG_IMAGE_TAG: ${{ matrix.kong_version }}
       KONG_ANONYMOUS_REPORTS: "off"

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -30,7 +30,7 @@ jobs:
         - '2.8.3'
         - '3.0.2'
         - '3.1.1'
-        # - '3.2.2' # Not yet available
+        - '3.2.2' # Not yet available
         dbmode:
           - 'dbless'
           - 'postgres'


### PR DESCRIPTION
Include 3.2.2 open source image and bump EE images with those that were released recently.