### PR TITLE
chore: retract v0.39.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ retract (
 	// Contains https://github.com/Kong/go-kong/pull/302 which introduced
 	// a bug with filling the config defaults:
 	// https://github.com/Kong/go-kong/issues/307
-	v0.30.1
+	v0.39.1
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,13 @@ go 1.19
 
 replace github.com/imdario/mergo v0.3.12 => github.com/Kong/mergo v0.3.13
 
+retract (
+	// Contains https://github.com/Kong/go-kong/pull/302 which introduced
+	// a bug with filling the config defaults:
+	// https://github.com/Kong/go-kong/issues/307
+	v0.30.1
+)
+
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-querystring v1.1.0


### PR DESCRIPTION
Retract v0.30.1 to prevent anyone depending on it.

ref: https://go.dev/ref/mod#go-mod-file-retract