### PR TITLE
chore(tests) split out plugin map test

### DIFF
--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -550,11 +550,10 @@ func TestFillPluginDefaults(T *testing.T) {
 	// not all Enterprise versions.
 	SkipWhenEnterprise(T)
 	RunWhenKong(T, ">=2.3.0")
-	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(T, err)
+	require.NotNil(T, client)
 
 	tests := []struct {
 		name     string
@@ -664,11 +663,9 @@ func TestFillPluginDefaults(T *testing.T) {
 		T.Run(tc.name, func(t *testing.T) {
 			p := tc.plugin
 			fullSchema, err := client.Plugins.GetFullSchema(defaultCtx, p.Name)
-			assert.NoError(err)
-			assert.NotNil(fullSchema)
-			if err := FillPluginsDefaults(p, fullSchema); err != nil {
-				t.Errorf(err.Error())
-			}
+			require.NoError(t, err)
+			require.NotNil(t, fullSchema)
+			require.NoError(t, FillPluginsDefaults(p, fullSchema))
 
 			if diff := cmp.Diff(p, tc.expected); diff != "" {
 				t.Errorf(diff)
@@ -730,9 +727,7 @@ func TestFillPluginDefaultsArbitraryMap(T *testing.T) {
 			fullSchema, err := client.Plugins.GetFullSchema(defaultCtx, p.Name)
 			require.NoError(t, err)
 			require.NotNil(t, fullSchema)
-			if err := FillPluginsDefaults(p, fullSchema); err != nil {
-				t.Errorf(err.Error())
-			}
+			require.NoError(t, FillPluginsDefaults(p, fullSchema))
 
 			// the log plugins are the only plugins that use the typedefs.lua_code type in their schema
 			// https://github.com/Kong/kong/commit/9df893f6aff98cd51f27f1c27fa30fdcf13fcf48 changes a number of other


### PR DESCRIPTION
Separate the plugin arbitrary map default test from the main default test. The new test only checks the arbitrary map field.

Changes to the test plugin in upstream Kong break the blanket diff used in the main test, and would require a version split without testing only the relevant field.

The issue appeared in https://github.com/Kong/go-kong/actions/runs/4718806033/jobs/8369120871?pr=315

```
 === RUN   TestFillPluginDefaults/nested_config_with_arbitrary_map_field
    plugin_service_test.go:706:   &kong.Plugin{
          	... // 5 identical fields
          	Service:  nil,
          	Consumer: nil,
          	Config: kong.Configuration{
          		"content_type":         string("application/json"),
          		"custom_fields_by_lua": map[string]any{"foo": string("bar")},
        - 		"flush_timeout":        nil,
        + 		"flush_timeout":        float64(2),
          		"headers":              nil,
          		"http_endpoint":        nil,
          		"keepalive":            float64(60000),
          		"method":               string("POST"),
        - 		"queue": map[string]any{
        - 			"initial_retry_delay":  float64(0.01),
        - 			"max_batch_size":       float64(1),
        - 			"max_bytes":            nil,
        - 			"max_coalescing_delay": float64(1),
        - 			"max_entries":          float64(10000),
        - 			"max_retry_delay":      float64(60),
        - 			"max_retry_time":       float64(60),
        - 			"name":                 nil,
        - 		},
        - 		"queue_size":  nil,
        + 		"queue_size":  float64(1),
        - 		"retry_count": nil,
        + 		"retry_count": float64(10),
          		"timeout":     float64(10000),
          	},
          	Enabled: &false,
          	RunOn:   nil,
          	... // 3 identical fields
          }
--- FAIL: TestFillPluginDefaults (0.04s)
```

These fields were added upstream for 3.3: https://github.com/Kong/kong/commit/9df893f6aff98cd51f27f1c27fa30fdcf13fcf48