### PR TITLE
fix: allow explicit nulls in config

### DIFF
--- a/kong/utils.go
+++ b/kong/utils.go
@@ -247,6 +247,10 @@ func fillConfigRecord(schema gjson.Result, config Configuration) Configuration {
 				if v != nil {
 					return true
 				}
+				ftype := value.Get(fname + ".type").String()
+				if ftype != "record" && ftype != "array" {
+					return true
+				}
 			}
 		}
 		ftype := value.Get(fname + ".type")


### PR DESCRIPTION
Allow explicit `null`s in configurations to fix #320 . 