### PR TITLE
feat: add Details to APIError and propagate Details for 429

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,12 +58,12 @@
 > Release date: TBD
 
 - Added `Details` and `SetDetails` methods to `APIError` struct to enable
-  propagating status-specific details in there.  
+  propagating status-specific details in there.
   Introduced `ErrTooManyRequestsDetails` struct that's going to be available
-  as an `APIError`'s `Details` when Admin API returns status code 429 along 
-  with a `Retry-After` header. That should be useful for handling rate limiting 
+  as an `APIError`'s `Details` when Admin API returns status code 429 along
+  with a `Retry-After` header. That should be useful for handling rate limiting
   on an application level.
-
+  [#323](https://github.com/Kong/go-kong/pull/323)
 
 ## [v0.41.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,18 @@
 - [0.2.0](#020)
 - [0.1.0](#010)
 
+## Unreleased
+
+> Release date: TBD
+
+- Added `Details` and `SetDetails` methods to `APIError` struct to enable
+  propagating status-specific details in there.  
+  Introduced `ErrTooManyRequestsDetails` struct that's going to be available
+  as an `APIError`'s `Details` when Admin API returns status code 429 along 
+  with a `Retry-After` header. That should be useful for handling rate limiting 
+  on an application level.
+
+
 ## [v0.41.0]
 
 > Release date: 2023/04/25

--- a/kong/client.go
+++ b/kong/client.go
@@ -258,7 +258,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request,
 
 	response := newResponse(resp)
 
-	///check for API errors
+	// check for API errors
 	if err = hasError(resp); err != nil {
 		return response, err
 	}


### PR DESCRIPTION
Adds `Details` and `SetDetails` methods to `APIError` struct to allow propagating status code specific information, e.g. content of the `Retry-After` header for 429 which is also added in this PR.

It's needed in order to gracefully handle rate limiting on Kong Ingress Controller side.