### PR TITLE
tests: use GetFullSchema instead of deprecated GetSchema

### DIFF
--- a/kong/plugin_service.go
+++ b/kong/plugin_service.go
@@ -76,7 +76,7 @@ func (s *PluginService) GetFullSchema(ctx context.Context,
 
 // GetSchema retrieves the config schema of a plugin
 //
-// Deprecated: Use GetPluginSchema instead
+// Deprecated: Use GetFullSchema instead
 func (s *PluginService) GetSchema(ctx context.Context,
 	pluginName *string,
 ) (Schema, error) {

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -344,7 +344,7 @@ func TestPluginListEndpoint(T *testing.T) {
 
 	// create fixturs
 	for i := 0; i < len(plugins); i++ {
-		schema, err := client.Plugins.GetSchema(defaultCtx, plugins[i].Name)
+		schema, err := client.Plugins.GetFullSchema(defaultCtx, plugins[i].Name)
 		assert.NoError(err)
 		assert.NotNil(schema)
 		plugin, err := client.Plugins.Create(defaultCtx, plugins[i])
@@ -476,7 +476,7 @@ func TestPluginListAllForEntityEndpoint(T *testing.T) {
 
 	// create fixturs
 	for i := 0; i < len(plugins); i++ {
-		schema, err := client.Plugins.GetSchema(defaultCtx, plugins[i].Name)
+		schema, err := client.Plugins.GetFullSchema(defaultCtx, plugins[i].Name)
 		assert.NoError(err)
 		assert.NotNil(schema)
 		plugin, err := client.Plugins.Create(defaultCtx, plugins[i])


### PR DESCRIPTION
Should fix #324.

The `GET /plugins/schema/<pluginName>` endpoint that `GetSchema` was using has been recently removed https://github.com/Kong/kong/pull/10846.