### PR TITLE
fix: ensure defaults are properly filled for a set

### DIFF
--- a/kong/utils.go
+++ b/kong/utils.go
@@ -264,7 +264,8 @@ func fillConfigRecord(schema gjson.Result, config Configuration) Configuration {
 		// If this array is non-nil and non-empty (in Config), go through all the records in this array and add defaults
 		// If the array has only primitives like string/number/boolean then the value is already set
 		// If the array is empty or nil, then no defaults need to be set for its elements
-		if ftype.String() == "array" {
+		// The same logic should be applied if field is of type set of records (in Schema)
+		if ftype.String() == "array" || ftype.String() == "set" {
 			if value.Get(fname).Get("elements.type").String() == "record" {
 				if config[fname] != nil {
 					// Check sub config is of type array and it is non-empty


### PR DESCRIPTION
A recent bugfix caused a regression when filling defaults of a set type field (https://github.com/Kong/go-kong/pull/309). This can be reproduced when using deck with a valid set field with values.  The `bootstrap_servers` is defaulted to `nil`.

```
_format_version: "3.0"

plugins:
- name: kafka-log
  enabled: false
  config:
    topic: konnect.auditlogs.gateway-access-logs
    bootstrap_servers:
    - host: broker-1.endpoint
      port: 9096
    - host: broker-1.endpoint
      port: 9096
    - host: broker-1.endpoint
      port: 9096
    authentication:
      strategy: sasl
      mechanism: SCRAM-SHA-512
      user: sasl_user
      password: xxxxxxxx
    security:
      ssl: false
    cluster_name: konnect-msk
``