### PR TITLE
fix: fill defaults for non-required field of type "record"

### DIFF
--- a/kong/utils.go
+++ b/kong/utils.go
@@ -250,7 +250,9 @@ func fillConfigRecord(schema gjson.Result, config Configuration) Configuration {
 			}
 		}
 		ftype := value.Get(fname + ".type")
-		if ftype.String() == "record" {
+		frequired := value.Get(fname + ".required")
+		// Recursively fill defaults only if the field is either required or a subconfig is provided
+		if ftype.String() == "record" && (config[fname] != nil || (frequired.Exists() && frequired.Bool())) {
 			subConfig := config[fname]
 			if subConfig == nil {
 				subConfig = make(map[string]interface{})

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -1511,6 +1511,7 @@ func Test_FillPluginsDefaults_RequestTransformer(t *testing.T) {
 }
 
 func Test_FillPluginsDefaults_Acme(t *testing.T) {
+	RunWhenKong(t, ">=2.6.0")
 	client, err := NewTestClient(nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, client)
@@ -1592,7 +1593,7 @@ func Test_FillPluginsDefaults_Acme(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, fullSchema)
 			assert.NoError(t, FillPluginsDefaults(plugin, fullSchema))
-			opts := cmpopts.IgnoreFields(*plugin, "Enabled", "Protocols", "storage_config", "allow_any_domain", "enable_ipv4_common_name", "preferred_chain", "rsa_key_size")
+			opts := cmpopts.IgnoreFields(*plugin, "Enabled", "Protocols")
 			if diff := cmp.Diff(plugin, tc.expected, opts); diff != "" {
 				t.Errorf(diff)
 			}

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -1592,7 +1592,7 @@ func Test_FillPluginsDefaults_Acme(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, fullSchema)
 			assert.NoError(t, FillPluginsDefaults(plugin, fullSchema))
-			opts := cmpopts.IgnoreFields(*plugin, "Enabled", "Protocols")
+			opts := cmpopts.IgnoreFields(*plugin, "Enabled", "Protocols", "storage_config", "allow_any_domain", "enable_ipv4_common_name", "preferred_chain", "rsa_key_size")
 			if diff := cmp.Diff(plugin, tc.expected, opts); diff != "" {
 				t.Errorf(diff)
 			}

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -1511,7 +1511,7 @@ func Test_FillPluginsDefaults_RequestTransformer(t *testing.T) {
 }
 
 func Test_FillPluginsDefaults_Acme(t *testing.T) {
-	RunWhenKong(t, ">=2.6.0")
+	RunWhenKong(t, "==3.3.0")
 	client, err := NewTestClient(nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, client)


### PR DESCRIPTION
Fixes #334 

Adds a check for required while recusrively filling defaults for subconfig of type record.
Current behaviour of KIC is out of sync from Kong Lua implementation.

There are some field "required" checks in Lua code: [here](https://github.com/Kong/kong/blob/2a3e9193c37a8df3eb3edae6728fa84b4bfed820/kong/db/schema/init.lua#L1020) and [here](https://github.com/Kong/kong/blob/2a3e9193c37a8df3eb3edae6728fa84b4bfed820/kong/db/schema/init.lua#L1538)
These checks are missing form go code
