### PR TITLE
chore: add depguard config for linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,6 @@ linters:
   - asciicheck
   - bodyclose
   - contextcheck
-  - depguard
   - dogsled
   - durationcheck
   - errcheck
@@ -69,3 +68,10 @@ linters-settings:
       - gopkg.in/yaml.v3:
           recommendations:
           - sigs.k8s.io/yaml
+      - github.com/pkg/errors:
+          recommendations:
+          - fmt
+          - errors
+      - golang.org/x/net/context:
+          recommendations:
+          - context


### PR DESCRIPTION
See https://github.com/Kong/go-kong/actions/runs/5171929210/jobs/9315785132?pr=333 for example problem.

golangci-lint version 1.53 upgraded the depguard linter from v1 to v2. AFAICT v1's behavior with no configuration to allow all packages, whereas v2 apparently denies everything but the standard library and local files (unclear--I'm not sure where the defaults actually live and the depguard change logs do not mention this, but it appears to be the case from my testing). https://github.com/golangci/golangci-lint/pull/3795#issuecomment-1576920783 agrees but doesn't indicate the cause of the default change.

The presence of a denylist will instead deny _only_ those packages and allow all others. The tests I can find in golangci-lint appear to all use a denylist and may be missing the default behavior, and it's possible nobody noticed the issue because it was masked by some other issue where depguard was preventing the linter from running at all :|

I don't entirely agree that this is a "reasonable" default and have half a mind to just remove it, but seeing as we need to make changes to the golangci-lint config either way, we may as well list some basic packages we should never include instead.

Edit: subsequently, I found that elsewhere we did remove it, and that we're also using gomodguard in some cases, which seems to provide nigh-identical functionality. Since we don't use the depguard globbing and gomodguard appears to maybe some additional features re suggestions, using that instead.