### PR TITLE
fix: handle empty array as nil when filling record defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,8 @@
 
 > Release date: TBD
 
-Nothing yet.
+- Fix: handle empty array as nil when filling record defaults
+  [#345](https://github.com/Kong/go-kong/pull/345)
 
 ## [v0.43.0]
 

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -1715,8 +1715,8 @@ func Test_fillConfigRecord(t *testing.T) {
 			name:   "fills defaults for all missing fields",
 			schema: gjson.Parse(fillConfigRecordTestSchema),
 			config: Configuration{
-				"mappings": []interface{}{
-					map[string]interface{}{
+				"mappings": []any{
+					map[string]any{
 						"nationality": "Ethiopian",
 					},
 				},
@@ -1736,12 +1736,12 @@ func Test_fillConfigRecord(t *testing.T) {
 			name:   "handle empty array as nil for a record field",
 			schema: gjson.Parse(fillConfigRecordTestSchema),
 			config: Configuration{
-				"mappings": []interface{}{
-					map[string]interface{}{
+				"mappings": []any{
+					map[string]any{
 						"nationality": "Ethiopian",
 					},
 				},
-				"empty_record": []interface{}{},
+				"empty_record": map[string]any{},
 			},
 			expected: Configuration{
 				"enabled": true,

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -1656,16 +1656,7 @@ func TestFillConsumerGroupPluginDefaults(T *testing.T) {
 	}
 }
 
-func Test_fillConfigRecord(t *testing.T) {
-	tests := []struct {
-		name     string
-		schema   gjson.Result
-		config   Configuration
-		expected Configuration
-	}{
-		{
-			name: "fills defaults for all missing fields",
-			schema: gjson.Parse(`{
+var fillConfigRecordTestSchema = `{
 				"fields": {
 					"config":
 						{
@@ -1690,11 +1681,30 @@ func Test_fillConfigRecord(t *testing.T) {
 											]
 										}
 									}
-								}
+								},
+								{
+									"empty_record": {
+										"type": "record",
+										"required": true,
+										"fields":[]
+									},
+								},
 							]
 						}
 					}
-				}`),
+				}
+`
+
+func Test_fillConfigRecord(t *testing.T) {
+	tests := []struct {
+		name     string
+		schema   gjson.Result
+		config   Configuration
+		expected Configuration
+	}{
+		{
+			name:   "fills defaults for all missing fields",
+			schema: gjson.Parse(fillConfigRecordTestSchema),
 			config: Configuration{
 				"mappings": []interface{}{
 					map[string]interface{}{
@@ -1710,6 +1720,29 @@ func Test_fillConfigRecord(t *testing.T) {
 						"nationality": "Ethiopian",
 					},
 				},
+				"empty_record": map[string]any{},
+			},
+		},
+		{
+			name:   "handle empty array as nil for a record field",
+			schema: gjson.Parse(fillConfigRecordTestSchema),
+			config: Configuration{
+				"mappings": []interface{}{
+					map[string]interface{}{
+						"nationality": "Ethiopian",
+					},
+				},
+				"empty_record": []interface{}{},
+			},
+			expected: Configuration{
+				"enabled": true,
+				"mappings": []any{
+					Configuration{
+						"name":        nil,
+						"nationality": "Ethiopian",
+					},
+				},
+				"empty_record": map[string]any{},
 			},
 		},
 	}

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -1656,43 +1656,52 @@ func TestFillConsumerGroupPluginDefaults(T *testing.T) {
 	}
 }
 
-var fillConfigRecordTestSchema = `{
-				"fields": {
-					"config":
-						{
+const fillConfigRecordTestSchema = `{
+	"fields": {
+		"config": {
+			"type": "record",
+			"fields": [
+				{
+					"enabled": {
+						"type": "boolean",
+						"default": true,
+						"required": true
+					}
+				},
+				{
+					"mappings": {
+						"required": false,
+						"type": "array",
+						"elements": {
 							"type": "record",
-							"fields":[
+							"fields": [
 								{
-									"enabled":{
-										"type":"boolean",
-										"default":true,
-										"required":true
+									"name": {
+										"type": "string",
+										"required": false
 									}
 								},
 								{
-									"mappings":{
-										"required":false,
-										"type":"array",
-										"elements":{
-											"type":"record",
-											"fields":[
-												{"name":{"type":"string","required":false}},
-												{"nationality":{"type":"string","required":false}}
-											]
-										}
+									"nationality": {
+										"type": "string",
+										"required": false
 									}
-								},
-								{
-									"empty_record": {
-										"type": "record",
-										"required": true,
-										"fields":[]
-									},
-								},
+								}
 							]
 						}
 					}
+				},
+				{
+					"empty_record": {
+						"type": "record",
+						"required": true,
+						"fields": []
+					}
 				}
+			]
+		}
+	}
+}
 `
 
 func Test_fillConfigRecord(t *testing.T) {


### PR DESCRIPTION
To avoid panic errors, in case of a wrong `[]` being set in the config for a record field, let's treat it as a nil and create the proper object map.

Can be reproduced with a deck sync:

```
_format_version: "3.0"
plugins:
- config:
    storage_config:
      redis: []
  enabled: true
  name: acme