### PR TITLE
chore(build): get rid of obsolete Go build tags

### DIFF
--- a/kong/admin_service_test.go
+++ b/kong/admin_service_test.go
@@ -1,5 +1,4 @@
 //go:build enterprise
-// +build enterprise
 
 package kong
 

--- a/kong/mtls_auth_service_test.go
+++ b/kong/mtls_auth_service_test.go
@@ -1,5 +1,4 @@
 //go:build enterprise
-// +build enterprise
 
 package kong
 

--- a/kong/workspace_service_test.go
+++ b/kong/workspace_service_test.go
@@ -1,5 +1,4 @@
 //go:build enterprise
-// +build enterprise
 
 package kong
 

--- a/third_party/golangci-lint.go
+++ b/third_party/golangci-lint.go
@@ -1,5 +1,4 @@
 //go:build third_party
-// +build third_party
 
 package third_party
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,4 +1,4 @@
-// +build tools
+//go:build tools
 
 package tools
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Since Go 1.18 the new directive `//go:build` is now preferred and the toolchain will actively remove old directives; as mentioned in Go 1.18 release notes:

> In Go 1.18, go fix now removes the now-obsolete // +build lines in modules declaring go 1.18 or later in their go.mod files.

KIC  specifies in `go.mod` Go version `1.20`.
 
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

It's part of the https://github.com/Kong/team-k8s/issues/286

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

Files generated by `controller-gen`:

- `kong/zz_generated.deepcopy.go`

still include obsolete build tag. Issue has been created https://github.com/kubernetes-sigs/controller-tools/issues/826
