### PR TITLE
feat: config helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@
 
 ## Unreleased
 
+> Release date: TBD
+
+- Added `Client.Config` handler, that can be used to obtain Kong's config.
+  [#354](https://github.com/Kong/go-kong/pull/354)
+
 ## [v0.44.0]
 
 > Release date: 2023/06/22

--- a/kong/client_test.go
+++ b/kong/client_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 func TestNewTestClient(t *testing.T) {
@@ -30,6 +31,22 @@ func TestKongStatus(T *testing.T) {
 	status, err := client.Status(defaultCtx)
 	assert.NoError(err)
 	assert.NotNil(status)
+}
+
+func TestKongConfig(t *testing.T) {
+	RunWhenDBMode(t, "off")
+	client, err := NewTestClient(nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	config, err := client.Config(defaultCtx)
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	var configStruct map[string]any
+	require.NoError(t, yaml.Unmarshal(config, &configStruct))
+	require.Contains(t, configStruct, "_format_version")
+	require.Contains(t, configStruct, "_transform")
 }
 
 func TestRoot(T *testing.T) {


### PR DESCRIPTION
### What this PR does

This PR introduces a new helper to retrieve Kong's current config. The return value is an interface, and needs to be correctly parsed by the caller.

Fixes #353 

### Notes for your reviewer

This endpoint is only available when Kong is configured to not use a database, therefore it is tested only with Kong dbless.