### PR TITLE
feat: add FillID() method for Consumer Group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,9 @@
 
 > Release date: TBD
 
-- Added support for scoping plugins to consumer-groups.
+- Added method `FillID()` method for Consumer Group.
+  [#357](https://github.com/Kong/go-kong/pull/357)
+- Added support for scoping plugins to Consumer Groups.
   [#352](https://github.com/Kong/go-kong/pull/352)
 
 ## [v0.45.0]

--- a/kong/consumer_group.go
+++ b/kong/consumer_group.go
@@ -44,12 +44,12 @@ type ConsumerGroupPlugin struct {
 }
 
 // FriendlyName returns the endpoint key name or ID.
-func (s *ConsumerGroup) FriendlyName() string {
-	if s.Name != nil {
-		return *s.Name
+func (cg *ConsumerGroup) FriendlyName() string {
+	if cg.Name != nil {
+		return *cg.Name
 	}
-	if s.ID != nil {
-		return *s.ID
+	if cg.ID != nil {
+		return *cg.ID
 	}
 	return ""
 }

--- a/kong/ids_test.go
+++ b/kong/ids_test.go
@@ -104,6 +104,35 @@ func TestFillEntityID(t *testing.T) {
 				require.Equal(t, expectedID, *consumer.ID, "ID should be deterministic")
 			},
 		},
+		// Consumer Group
+		{
+			name:      "consumer group nil pointer",
+			entity:    (*kong.ConsumerGroup)(nil),
+			expectErr: true,
+		},
+		{
+			name:      "consumer group with nil name",
+			entity:    &kong.ConsumerGroup{},
+			expectErr: true,
+		},
+		{
+			name:      "consumer group with empty name",
+			entity:    &kong.ConsumerGroup{Name: kong.String("")},
+			expectErr: true,
+		},
+		{
+			name: "consumer group with name",
+			entity: &kong.ConsumerGroup{
+				Name: kong.String("some.consumer.group"),
+			},
+			assertEntity: func(t *testing.T, e kong.IDFillable) {
+				cg := e.(*kong.ConsumerGroup)
+				require.NotNil(t, cg.ID)
+
+				const expectedID = "e5643801-37c6-5d04-9d3f-c1c84c747e90"
+				require.Equal(t, expectedID, *cg.ID, "ID should be deterministic")
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Adds FillID methods for Consumer Group entities to allow setting deterministic IDs for entities based on their unique properties.

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/4358 (prerequisite)