### PR TITLE
chore(deps) replace yaml lib

### DIFF
--- a/kong/client_test.go
+++ b/kong/client_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 func TestNewTestClient(t *testing.T) {


### PR DESCRIPTION
Replace a banned module with the preferred version.

For some reason this banned module was in use but showed up as indirect. Somehow https://github.com/Kong/go-kong/pull/359 made it not indirect.

```
run golangci-lint
  Running [/home/runner/golangci-lint-1.53.3-linux-amd64/golangci-lint run --out-format=github-actions] in [] ...
  Error: import of package `gopkg.in/yaml.v2` is blocked because the module is in the blocked modules list. `sigs.k8s.io/yaml` is a recommended module. (gomodguard)
  
  Error: issues found
  Ran golangci-lint in 17695ms
```