### PR TITLE
feat: add method Validate for RouteService

### DIFF
--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -34,6 +34,7 @@ function deploy_kong_postgres()
     -e "KONG_ADMIN_GUI_AUTH=basic-auth" \
     -e "KONG_ENFORCE_RBAC=on" \
     -e "KONG_PORTAL=on" \
+    -e "KONG_ROUTER_FLAVOR=${KONG_ROUTER_FLAVOR}" \
     -p 8000:8000 \
     -p 8443:8443 \
     -p 127.0.0.1:8001:8001 \

--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -7,6 +7,8 @@ source $(dirname "$0")/_common.sh
 KONG_IMAGE=${KONG_IMAGE_REPO:-kong}:${KONG_IMAGE_TAG:-3.3}
 NETWORK_NAME=kong-test
 
+KONG_ROUTER_FLAVOR=${KONG_ROUTER_FLAVOR:-'traditional_compatible'}
+
 PG_CONTAINER_NAME=pg
 DATABASE_USER=kong
 DATABASE_NAME=kong
@@ -53,6 +55,7 @@ function deploy_kong_dbless()
     -e "KONG_ADMIN_GUI_AUTH=basic-auth" \
     -e "KONG_ENFORCE_RBAC=on" \
     -e "KONG_PORTAL=on" \
+    -e "KONG_ROUTER_FLAVOR=${KONG_ROUTER_FLAVOR}" \
     -p 8000:8000 \
     -p 8443:8443 \
     -p 127.0.0.1:8001:8001 \

--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -4,7 +4,7 @@ set -e
 
 source $(dirname "$0")/_common.sh
 
-KONG_IMAGE=${KONG_IMAGE_REPO:-kong}:${KONG_IMAGE_TAG:-3.3}
+KONG_IMAGE=${KONG_IMAGE_REPO:-kong}:${KONG_IMAGE_TAG:-3.4}
 NETWORK_NAME=kong-test
 
 KONG_ROUTER_FLAVOR=${KONG_ROUTER_FLAVOR:-'traditional_compatible'}

--- a/.ci/setup_kong_ee.sh
+++ b/.ci/setup_kong_ee.sh
@@ -7,6 +7,8 @@ source $(dirname "$0")/_common.sh
 KONG_IMAGE=${KONG_IMAGE_REPO:-kong/kong-gateway}:${KONG_IMAGE_TAG:-3.3}
 NETWORK_NAME=kong-test
 
+KONG_ROUTER_FLAVOR=${KONG_ROUTER_FLAVOR:-'traditional_compatible'}
+
 PG_CONTAINER_NAME=pg
 DATABASE_USER=kong
 DATABASE_NAME=kong
@@ -44,6 +46,7 @@ function deploy_kong_ee()
     -e "KONG_ENFORCE_RBAC=on" \
     -e "KONG_PORTAL=on" \
     -e "KONG_ADMIN_GUI_SESSION_CONF={}" \
+    -e "KONG_ROUTER_FLAVOR=${KONG_ROUTER_FLAVOR}" \
     -p 8000:8000 \
     -p 8443:8443 \
     -p 8001:8001 \

--- a/.ci/setup_kong_ee.sh
+++ b/.ci/setup_kong_ee.sh
@@ -4,7 +4,7 @@ set -e
 
 source $(dirname "$0")/_common.sh
 
-KONG_IMAGE=${KONG_IMAGE_REPO:-kong/kong-gateway}:${KONG_IMAGE_TAG:-3.3}
+KONG_IMAGE=${KONG_IMAGE_REPO:-kong/kong-gateway}:${KONG_IMAGE_TAG:-3.4}
 NETWORK_NAME=kong-test
 
 KONG_ROUTER_FLAVOR=${KONG_ROUTER_FLAVOR:-'traditional_compatible'}

--- a/.github/workflows/integration-test-enterprise-nightly.yaml
+++ b/.github/workflows/integration-test-enterprise-nightly.yaml
@@ -31,11 +31,17 @@ jobs:
         fi
 
   test-enterprise:
+    strategy:
+      matrix:
+        router_flavor:
+          - 'traditional_compatible'
+          - 'expressions'
     continue-on-error: true
     needs:
     - secret-available
     if: needs.secret-available.outputs.ok
     env:
+      KONG_ROUTER_FLAVOR: ${{ matrix.router_flavor }}
       KONG_ADMIN_TOKEN: kong
       KONG_IMAGE_REPO: "kong/kong-gateway-internal"
       KONG_IMAGE_TAG: "master-alpine"

--- a/.github/workflows/integration-test-enterprise.yaml
+++ b/.github/workflows/integration-test-enterprise.yaml
@@ -37,6 +37,9 @@ jobs:
     if: needs.secret-available.outputs.ok
     strategy:
       matrix:
+        router_flavor:
+          - 'traditional_compatible'
+          - 'expressions'
         kong_version:
         - '2.2'
         - '2.3'
@@ -50,6 +53,7 @@ jobs:
         - '3.2'
         - '3.3'
     env:
+      KONG_ROUTER_FLAVOR: ${{ matrix.router_flavor }}
       KONG_IMAGE_TAG: ${{ matrix.kong_version }}
       KONG_ANONYMOUS_REPORTS: "off"
       KONG_ADMIN_TOKEN: kong

--- a/.github/workflows/integration-test-enterprise.yaml
+++ b/.github/workflows/integration-test-enterprise.yaml
@@ -37,6 +37,24 @@ jobs:
     if: needs.secret-available.outputs.ok
     strategy:
       matrix:
+        # Skip explicitly to avoid spawning many unecessary jobs,
+        # since expressions router is supported for Kong >= 3.0.
+        # Option router_flavor is ignored for Kong < 3.0.
+        exclude:
+          - kong_version: '2.2'
+            router_flavor: 'expressions'
+          - kong_version: '2.3'
+            router_flavor: 'expressions'
+          - kong_version: '2.4'
+            router_flavor: 'expressions'
+          - kong_version: '2.5'
+            router_flavor: 'expressions'
+          - kong_version: '2.6'
+            router_flavor: 'expressions'
+          - kong_version: '2.7'
+            router_flavor: 'expressions'
+          - kong_version: '2.8'
+            router_flavor: 'expressions'
         router_flavor:
           - 'traditional_compatible'
           - 'expressions'
@@ -52,6 +70,7 @@ jobs:
         - '3.1'
         - '3.2'
         - '3.3'
+        - '3.4'
     env:
       KONG_ROUTER_FLAVOR: ${{ matrix.router_flavor }}
       KONG_IMAGE_TAG: ${{ matrix.kong_version }}

--- a/.github/workflows/integration-test-enterprise.yaml
+++ b/.github/workflows/integration-test-enterprise.yaml
@@ -37,7 +37,7 @@ jobs:
     if: needs.secret-available.outputs.ok
     strategy:
       matrix:
-        # Skip explicitly to avoid spawning many unecessary jobs,
+        # Skip explicitly to avoid spawning many unnecessary jobs,
         # since expressions router is supported for Kong >= 3.0.
         # Option router_flavor is ignored for Kong < 3.0.
         exclude:

--- a/.github/workflows/integration-test-nightly.yaml
+++ b/.github/workflows/integration-test-nightly.yaml
@@ -22,7 +22,11 @@ jobs:
         dbmode:
           - 'dbless'
           - 'postgres'
+        router_flavor:
+          - 'traditional_compatible'
+          - 'expressions'
     env:
+      KONG_ROUTER_FLAVOR: ${{ matrix.router_flavor }}
       KONG_IMAGE_REPO: "kong/kong"
       KONG_IMAGE_TAG: "master-alpine"
       KONG_ANONYMOUS_REPORTS: "off"
@@ -45,4 +49,3 @@ jobs:
           name: codecov-nightly
           flags: nightly,integration,community
           fail_ci_if_error: true
-

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -35,7 +35,11 @@ jobs:
         dbmode:
           - 'dbless'
           - 'postgres'
+        router_flavor:
+          - 'traditional_compatible'
+          - 'expressions'
     env:
+      KONG_ROUTER_FLAVOR: ${{ matrix.router_flavor }}
       KONG_IMAGE_TAG: ${{ matrix.kong_version }}
       KONG_ANONYMOUS_REPORTS: "off"
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -19,7 +19,7 @@ jobs:
   test:
     strategy:
       matrix:
-        # Skip explicitly to avoid spawning many unecessary jobs,
+        # Skip explicitly to avoid spawning many unnecessary jobs,
         # since expressions router is supported for Kong >= 3.0.
         # Option router_flavor is ignored for Kong < 3.0.
         exclude:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -19,25 +19,48 @@ jobs:
   test:
     strategy:
       matrix:
-        kong_version:
-        - '2.1'
-        - '2.2'
-        - '2.3'
-        - '2.4'
-        - '2.5'
-        - '2.6'
-        - '2.7'
-        - '2.8'
-        - '3.0'
-        - '3.1'
-        - '3.2'
-        - '3.3'
+        # Skip explicitly to avoid spawning many unecessary jobs,
+        # since expressions router is supported for Kong >= 3.0.
+        # Option router_flavor is ignored for Kong < 3.0.
+        exclude:
+          - kong_version: '2.1'
+            router_flavor: 'expressions'
+          - kong_version: '2.2'
+            router_flavor: 'expressions'
+          - kong_version: '2.2'
+            router_flavor: 'expressions'
+          - kong_version: '2.3'
+            router_flavor: 'expressions'
+          - kong_version: '2.4'
+            router_flavor: 'expressions'
+          - kong_version: '2.5'
+            router_flavor: 'expressions'
+          - kong_version: '2.6'
+            router_flavor: 'expressions'
+          - kong_version: '2.7'
+            router_flavor: 'expressions'
+          - kong_version: '2.8'
+            router_flavor: 'expressions'
         dbmode:
           - 'dbless'
           - 'postgres'
         router_flavor:
           - 'traditional_compatible'
           - 'expressions'
+        kong_version:
+          - '2.1'
+          - '2.2'
+          - '2.3'
+          - '2.4'
+          - '2.5'
+          - '2.6'
+          - '2.7'
+          - '2.8'
+          - '3.0'
+          - '3.1'
+          - '3.2'
+          - '3.3'
+          - '3.4'
     env:
       KONG_ROUTER_FLAVOR: ${{ matrix.router_flavor }}
       KONG_IMAGE_TAG: ${{ matrix.kong_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
 
 ## [v0.47.0]
 
-> Release date: 2023/08/25
+> Release date: 2023/08/28
 
 - Added method `Validate` to `RouteService`
   [#368](https://github.com/Kong/go-kong/pull/368)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v0.47.0](#v0470)
 - [v0.46.0](#v0460)
 - [v0.45.0](#v0450)
 - [v0.44.0](#v0440)
@@ -59,6 +60,13 @@
 - [0.1.0](#010)
 
 ## Unreleased
+
+## [v0.47.0]
+
+> Release date: 2023/08/25
+
+- Added method `Validate` to `RouteService`
+  [#368](https://github.com/Kong/go-kong/pull/368)
 
 ## [v0.46.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
 
 ## [v0.47.0]
 
-> Release date: 2023/08/28
+> Release date: 2023/08/29
 
 - Added method `Validate` to `RouteService`
   [#368](https://github.com/Kong/go-kong/pull/368)

--- a/kong/client_test.go
+++ b/kong/client_test.go
@@ -227,7 +227,7 @@ func TestBaseRootURL(t *testing.T) {
 
 func TestReloadDeclarativeRawConfig(t *testing.T) {
 	RunWhenDBMode(t, "off")
-
+	SkipWhenKongRouterFlavor(t, Expressions)
 	tests := []struct {
 		name    string
 		config  Configuration

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -42,6 +42,7 @@ func TestPluginsServiceValidation(T *testing.T) {
 
 func TestPluginsService(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
+	SkipWhenKongRouterFlavor(T, Expressions)
 
 	assert := assert.New(T)
 	require := require.New(T)
@@ -403,6 +404,7 @@ func TestPluginListEndpoint(T *testing.T) {
 
 func TestPluginListAllForEntityEndpoint(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
+	SkipWhenKongRouterFlavor(T, Expressions)
 
 	assert := assert.New(T)
 	require := require.New(T)
@@ -474,7 +476,7 @@ func TestPluginListAllForEntityEndpoint(T *testing.T) {
 		},
 	}
 
-	// create fixturs
+	// create fixtures
 	for i := 0; i < len(plugins); i++ {
 		schema, err := client.Plugins.GetFullSchema(defaultCtx, plugins[i].Name)
 		assert.NoError(err)

--- a/kong/route_service_test.go
+++ b/kong/route_service_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestRoutesRoute(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
+	SkipWhenKongRouterFlavor(T, Expressions)
 
 	assert := assert.New(T)
 	require := require.New(T)
@@ -104,6 +105,8 @@ func TestRoutesRoute(T *testing.T) {
 func TestRouteWithTags(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.1.0")
+	SkipWhenKongRouterFlavor(T, Expressions)
+
 	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -127,6 +130,7 @@ func TestRouteWithTags(T *testing.T) {
 
 func TestCreateInRoute(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
+	SkipWhenKongRouterFlavor(T, Expressions)
 
 	assert := assert.New(T)
 	require := require.New(T)
@@ -167,6 +171,7 @@ func TestCreateInRoute(T *testing.T) {
 
 func TestRouteListEndpoint(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
+	SkipWhenKongRouterFlavor(T, Expressions)
 
 	assert := assert.New(T)
 	require := require.New(T)
@@ -279,6 +284,8 @@ func compareRoutes(T *testing.T, expected, actual []*Route) bool {
 func TestRouteWithHeaders(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
 	RunWhenKong(T, ">=1.3.0")
+	SkipWhenKongRouterFlavor(T, Expressions)
+
 	assert := assert.New(T)
 	require := require.New(T)
 
@@ -307,6 +314,7 @@ func TestRouteWithHeaders(T *testing.T) {
 func TestRoutesValidation(T *testing.T) {
 	RunWhenKong(T, ">=3.0.0")
 	SkipWhenKongRouterFlavor(T, Traditional, TraditionalCompatible)
+
 	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/service_service_test.go
+++ b/kong/service_service_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestServicesService(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
+	SkipWhenKongRouterFlavor(T, Expressions)
 
 	assert := assert.New(T)
 	require := require.New(T)

--- a/kong/test_utils.go
+++ b/kong/test_utils.go
@@ -154,7 +154,7 @@ func SkipWhenKongRouterFlavor(t *testing.T, flavor ...RouterFlavor) {
 	}
 	for _, f := range flavor {
 		if RouterFlavor(routerFlavor) == f {
-			t.Skipf("detected Kong running with router flavor:%q but requested router flavor:%q", routerFlavor, f)
+			t.Skipf("router flavor:%q skipping", f)
 		}
 	}
 }

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -861,6 +861,7 @@ func Test_requestWithHeaders(t *testing.T) {
 }
 
 func TestFillRoutesDefaults(T *testing.T) {
+	SkipWhenKongRouterFlavor(T, Expressions)
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/vault_service_test.go
+++ b/kong/vault_service_test.go
@@ -75,7 +75,9 @@ func TestVaultsService(t *testing.T) {
 	require.Equal(id, *createdVault.ID)
 	require.Equal("aws", *createdVault.Name)
 	require.Equal("aws vault for secrets", *createdVault.Description)
-	require.Equal(Configuration{"region": "us-east-2"}, createdVault.Config)
+	region, ok := createdVault.Config["region"]
+	require.Equal(true, ok)
+	require.Equal("us-east-2", region)
 
 	err = client.Vaults.Delete(defaultCtx, createdVault.ID)
 	require.NoError(err)

--- a/kong/vault_service_test.go
+++ b/kong/vault_service_test.go
@@ -76,7 +76,7 @@ func TestVaultsService(t *testing.T) {
 	require.Equal("aws", *createdVault.Name)
 	require.Equal("aws vault for secrets", *createdVault.Description)
 	region, ok := createdVault.Config["region"]
-	require.Equal(true, ok)
+	require.True(ok)
 	require.Equal("us-east-2", region)
 
 	err = client.Vaults.Delete(defaultCtx, createdVault.ID)


### PR DESCRIPTION
**What this PR does / why we need it:**

Gateway offers API for validating routes - `/schemas/routes/validate`. This PR extends `RouteService` with the method `Validate` (that calls aforementioned endpoint) and prepares the release of the new version `v0.47.0`.

**Which issue this PR fixes:**

Prerequisite to implement https://github.com/Kong/kubernetes-ingress-controller/issues/4557.

**Special notes for your reviewer:**

Hence this method will be used to validate expressions routes, extend tests with this configuration, and introduce a helper to skip tests when it is not applicable (also a small refactor to avoid unnecessary duplication). Extend the tests matrix with such a configuration, tests run quickly, but on the other hand, need a lot of runners - using `exclude` in workflow helps a lot. The number of checks increased from 45 to 66 (added Kong 3.4 to the matrix too).

Change in `kong/vault_service_test.go` is needed, because more values are in this map (for Kong 3.4) and others are rather random/irrelevant nad the region is presented for older versions, thus it doesn't break anything. 

**To consider:** creating an issue for covering with tests routes when expressions router is enabled.

