### PR TITLE
fix: update Route's priority type to uint64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v0.48.0](#v0480)
 - [v0.47.0](#v0470)
 - [v0.46.0](#v0460)
 - [v0.45.0](#v0450)
@@ -59,9 +60,13 @@
 - [0.2.0](#020)
 - [0.1.0](#010)
 
-## Unreleased
+## [v0.48.0]
 
-- Fix a bug preventing users to set fields to emtpy arrays when
+> Release date: 2023/10/30
+
+- `Route`'s `priority` field type is changed from `int` to `uint64`.
+  [#378](https://github.com/Kong/go-kong/pull/378)
+- Fix a bug preventing users to set fields to empty arrays when
   a default for those fields exist.
   [#374](https://github.com/Kong/go-kong/pull/374)
 

--- a/kong/route.go
+++ b/kong/route.go
@@ -14,7 +14,7 @@ type Route struct {
 	Paths         []*string           `json:"paths,omitempty" yaml:"paths,omitempty"`
 	PathHandling  *string             `json:"path_handling,omitempty" yaml:"path_handling,omitempty"`
 	PreserveHost  *bool               `json:"preserve_host,omitempty" yaml:"preserve_host,omitempty"`
-	Priority      *int                `json:"priority,omitempty" yaml:"priority,omitempty"`
+	Priority      *uint64             `json:"priority,omitempty" yaml:"priority,omitempty"`
 	Protocols     []*string           `json:"protocols,omitempty" yaml:"protocols,omitempty"`
 	RegexPriority *int                `json:"regex_priority,omitempty" yaml:"regex_priority,omitempty"`
 	Service       *Service            `json:"service,omitempty" yaml:"service,omitempty"`

--- a/kong/test_utils.go
+++ b/kong/test_utils.go
@@ -159,6 +159,18 @@ func SkipWhenKongRouterFlavor(t *testing.T, flavor ...RouterFlavor) {
 	}
 }
 
+func RunWhenKongRouterFlavor(t *testing.T, flavor RouterFlavor) {
+	t.Helper()
+
+	routerFlavor, err := getKongConfigValue(t, "router_flavor")
+	if err != nil {
+		t.Skip(err.Error())
+	}
+	if RouterFlavor(routerFlavor) != flavor {
+		t.Skipf("router flavor:%q, expecting %q, skipping", routerFlavor, flavor)
+	}
+}
+
 func getKongConfigValue(t *testing.T, key string) (string, error) {
 	t.Helper()
 	client, err := NewTestClient(nil, nil)

--- a/kong/utils.go
+++ b/kong/utils.go
@@ -32,6 +32,11 @@ func Int(i int) *int {
 	return &i
 }
 
+// Uint64 returns a pointer to i.
+func Uint64(i uint64) *uint64 {
+	return &i
+}
+
 // Float64 returns a pointer to f.
 func Float64(f float64) *float64 {
 	return &f

--- a/kong/zz_generated.deepcopy.go
+++ b/kong/zz_generated.deepcopy.go
@@ -1976,7 +1976,7 @@ func (in *Route) DeepCopyInto(out *Route) {
 	}
 	if in.Priority != nil {
 		in, out := &in.Priority, &out.Priority
-		*out = new(int)
+		*out = new(uint64)
 		**out = **in
 	}
 	if in.Protocols != nil {


### PR DESCRIPTION
Route's priority in expression routes should be of type `uint64` instead of int.

---

There's a related (linked in the comment) issue for Gateway which returns integers in scientific notation: https://konghq.atlassian.net/browse/FTI-5515. When that's solved the commented test case should be uncommented.

---

Also update the changelog to release 0.48.0.