### PR TITLE
chore(gha): preemptively add 1p creds

### DIFF
--- a/.github/workflows/integration-test-enterprise-nightly.yaml
+++ b/.github/workflows/integration-test-enterprise-nightly.yaml
@@ -55,6 +55,7 @@ jobs:
         id: license_step
         with:
           password: ${{ secrets.PULP_PASSWORD }}
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Setup go

--- a/.github/workflows/integration-test-enterprise.yaml
+++ b/.github/workflows/integration-test-enterprise.yaml
@@ -88,6 +88,7 @@ jobs:
         id: license_step
         with:
           password: ${{ secrets.PULP_PASSWORD }}
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Setup go


### PR DESCRIPTION
This change is required to accommodate the forthcoming work in https://github.com/Kong/kong-license/pull/25

That work will change kong-license such that the license is sourced directly from 1Password, rather than it being sourced from Pulp using credentials from 1Password (as is the case today). Meaning that workflows needing to run Kong/kong-license's will require 1P credentials instead of the Pulp password.

This work is a necessary step in the deprecation of Pulp aka [KAG-2247](https://konghq.atlassian.net/browse/KAG-2247) / [KAG-3254](https://konghq.atlassian.net/browse/KAG-3254).

Leaving the Pulp password for now so that https://github.com/Kong/kong-license/pull/25 can be merged *after* this PR.

[KAG-2247]: https://konghq.atlassian.net/browse/KAG-2247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAG-3254]: https://konghq.atlassian.net/browse/KAG-3254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ