### PR TITLE
extract details from response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@
 - [0.2.0](#020)
 - [0.1.0](#010)
 
+## Unreleased
+
+- Added extract of `details` field in response when CRUD API fails to extract
+  details from Konnect APIs.
+  [#399](https://github.com/Kong/go-kong/pull/399)
+
 ## [v0.50.0]
 
 > Release date: 2024/01/09

--- a/kong/response.go
+++ b/kong/response.go
@@ -37,6 +37,18 @@ func messageFromBody(b []byte) string {
 	return s.Message
 }
 
+// detailsFromBodyDetailsField extract details from body if the response body contains a "details" field.
+// Used for extracting details from response from Konnect APIs when error happens.
+func detailsFromBodyDetailsField(b []byte) any {
+	s := struct {
+		Details any `json:"details"`
+	}{}
+	if err := json.Unmarshal(b, &s); err != nil {
+		return nil
+	}
+	return s.Details
+}
+
 func hasError(res *http.Response) error {
 	if res.StatusCode >= 200 && res.StatusCode <= 399 {
 		return nil
@@ -48,14 +60,18 @@ func hasError(res *http.Response) error {
 	}
 
 	apiErr := NewAPIError(res.StatusCode, messageFromBody(body))
-	if details, ok := extractErrDetails(res); ok {
+	if details, ok := extractErrDetails(res, body); ok {
 		apiErr.SetDetails(details)
 	}
 
 	return apiErr
 }
 
-func extractErrDetails(res *http.Response) (any, bool) {
+func extractErrDetails(res *http.Response, body []byte) (any, bool) {
+	// Firstly extract `details` field from response.
+	if detailsFromRespBody := detailsFromBodyDetailsField(body); detailsFromRespBody != nil {
+		return detailsFromRespBody, true
+	}
 	switch res.StatusCode {
 	case http.StatusTooManyRequests:
 		return extractErrTooManyRequestsDetails(res)

--- a/kong/response.go
+++ b/kong/response.go
@@ -68,13 +68,14 @@ func hasError(res *http.Response) error {
 }
 
 func extractErrDetails(res *http.Response, body []byte) (any, bool) {
-	// Firstly extract `details` field from response.
-	if detailsFromRespBody := detailsFromBodyDetailsField(body); detailsFromRespBody != nil {
-		return detailsFromRespBody, true
-	}
+	// firstly deal with certain status code.
 	switch res.StatusCode {
 	case http.StatusTooManyRequests:
 		return extractErrTooManyRequestsDetails(res)
+	}
+	// Then extract details from "details" field in the response body.
+	if detailsFromRespBody := detailsFromBodyDetailsField(body); detailsFromRespBody != nil {
+		return detailsFromRespBody, true
 	}
 
 	return nil, false

--- a/kong/response_test.go
+++ b/kong/response_test.go
@@ -68,6 +68,23 @@ func TestHasError(T *testing.T) {
 			},
 		},
 		{
+			name: "code 400 and has array of objects in 'details' in response",
+			response: http.Response{
+				StatusCode: 400,
+				Body:       io.NopCloser(strings.NewReader(`{"message":"validation failed","details":[{"type":"ERROR_TYPE_FIELD","field":"config.key"}]}`)),
+			},
+			want: &APIError{
+				httpCode: 400,
+				message:  "validation failed",
+				details: []any{
+					map[string]any{
+						"type":  "ERROR_TYPE_FIELD",
+						"field": "config.key",
+					},
+				},
+			},
+		},
+		{
 			name: "code 429 with retry-after header",
 			response: http.Response{
 				StatusCode: http.StatusTooManyRequests,

--- a/kong/response_test.go
+++ b/kong/response_test.go
@@ -71,7 +71,9 @@ func TestHasError(T *testing.T) {
 			name: "code 400 and has array of objects in 'details' in response",
 			response: http.Response{
 				StatusCode: 400,
-				Body:       io.NopCloser(strings.NewReader(`{"message":"validation failed","details":[{"type":"ERROR_TYPE_FIELD","field":"config.key"}]}`)),
+				Body: io.NopCloser(strings.NewReader(
+					`{"message":"validation failed","details":[{"type":"ERROR_TYPE_FIELD","field":"config.key"}]}`,
+				)),
 			},
 			want: &APIError{
 				httpCode: 400,


### PR DESCRIPTION
Extract `details` field from response if error happens in calling admin API on Konnect to do CRUD of entities. fixes #398.