### PR TITLE
add details in APIError.Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,8 +65,10 @@
 ## Unreleased
 
 - Added extract of `details` field in response when CRUD API fails to extract
-  details from Konnect APIs.
+  details from Konnect APIs, and include `details` field in return value of
+  `Error()` method in `APIError`.
   [#399](https://github.com/Kong/go-kong/pull/399)
+  [#400](https://github.com/Kong/go-kong/pull/400)
 
 ## [v0.50.0]
 

--- a/kong/error.go
+++ b/kong/error.go
@@ -31,7 +31,10 @@ func NewAPIErrorWithRaw(code int, msg string, raw []byte) *APIError {
 }
 
 func (e *APIError) Error() string {
-	return fmt.Sprintf("HTTP status %d (message: %q)", e.httpCode, e.message)
+	if e.details == nil {
+		return fmt.Sprintf("HTTP status %d (message: %q)", e.httpCode, e.message)
+	}
+	return fmt.Sprintf("HTTP status %d (message: %q; details: %v)", e.httpCode, e.message, e.details)
 }
 
 // Code returns the HTTP status code for the error.


### PR DESCRIPTION
Because `sync.Solve` wraps the error returned from CRUD actions by `fmt.Errorf()`, the `details` which are not included in `APIError.Error()` method is lost in wrapping errors. So https://github.com/Kong/kubernetes-ingress-controller/issues/5274 requires `details` to be included in `Error()` method. 