### PR TITLE
chore: add missing releases' compare links in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -853,6 +853,9 @@ authentication credentials in Kong.
   releases of Kong since every release of Kong is introducing breaking changes
   to the Admin API.
 
+[v0.51.0]: https://github.com/Kong/go-kong/compare/v0.50.0...v0.51.0
+[v0.50.0]: https://github.com/Kong/go-kong/compare/v0.49.0...v0.50.0
+[v0.49.0]: https://github.com/Kong/go-kong/compare/v0.48.0...v0.49.0
 [v0.48.0]: https://github.com/Kong/go-kong/compare/v0.47.0...v0.48.0
 [v0.47.0]: https://github.com/Kong/go-kong/compare/v0.46.0...v0.47.0
 [v0.46.0]: https://github.com/Kong/go-kong/compare/v0.45.0...v0.46.0


### PR DESCRIPTION
We forgot to add these links for the past 3 releases.