### PR TITLE
feat: add ConfigSource field into ConsumerGroupPlugin

### DIFF
--- a/kong/consumer_group.go
+++ b/kong/consumer_group.go
@@ -41,6 +41,7 @@ type ConsumerGroupPlugin struct {
 	CreatedAt     *int64         `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 	Config        Configuration  `json:"config,omitempty" yaml:"config,omitempty"`
 	ConsumerGroup *ConsumerGroup `json:"consumer_group,omitempty" yaml:"consumer_group,omitempty"`
+	ConfigSource  *string        `json:"_config,omitempty" yaml:"_config,omitempty"`
 }
 
 // FriendlyName returns the endpoint key name or ID.

--- a/kong/zz_generated.deepcopy.go
+++ b/kong/zz_generated.deepcopy.go
@@ -580,6 +580,11 @@ func (in *ConsumerGroupPlugin) DeepCopyInto(out *ConsumerGroupPlugin) {
 		*out = new(ConsumerGroup)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ConfigSource != nil {
+		in, out := &in.ConfigSource, &out.ConfigSource
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
This commit is adding a new `ConfigSource` field into the `ConsumerGroupPlugin` struct. This is not a field that should be used for online operation, but it's needed by the the `go-database-reconciler` to allow decK to work with plugins config deduplication with Consumer Groups as well.

Ref: https://docs.konghq.com/deck/latest/guides/deduplicate-plugin-configuration/