### PR TITLE
chore(*) fix lints

### DIFF
--- a/kong/custom/entity_crud_test.go
+++ b/kong/custom/entity_crud_test.go
@@ -95,7 +95,7 @@ func TestEntityCRUDDefinition(t *testing.T) {
 func TestEntityCRUDUnmarshal(t *testing.T) {
 	assert := assert.New(t)
 
-	t.Run("unmarshal JSON into EntityCRUDDefinition", func(t *testing.T) {
+	t.Run("unmarshal JSON into EntityCRUDDefinition", func(_ *testing.T) {
 		bytes := []byte(`{
 			"name": "name",
 			"crud": "crud-path",
@@ -109,7 +109,7 @@ func TestEntityCRUDUnmarshal(t *testing.T) {
 		assert.Equal("primary-key", def.PrimaryKey)
 	})
 
-	t.Run("unmarshal YAML into EntityCRUDDefinition", func(t *testing.T) {
+	t.Run("unmarshal YAML into EntityCRUDDefinition", func(_ *testing.T) {
 		var def EntityCRUDDefinition
 		bytes := []byte(`
 name: "name"

--- a/kong/route_service_test.go
+++ b/kong/route_service_test.go
@@ -423,7 +423,7 @@ func TestRoutesValidationExpressions(T *testing.T) {
 			valid: true,
 		},
 	} {
-		T.Run(tC.name, func(t *testing.T) {
+		T.Run(tC.name, func(_ *testing.T) {
 			ok, msg, err := client.Routes.Validate(defaultCtx, tC.route)
 			require.NoError(err)
 			require.Equal(tC.valid, ok)
@@ -492,7 +492,7 @@ func TestRoutesValidationTraditionalCompatible(T *testing.T) {
 			msgStartWith: "schema violation (paths.2: invalid regex:",
 		},
 	} {
-		T.Run(tC.name, func(t *testing.T) {
+		T.Run(tC.name, func(_ *testing.T) {
 			ok, msg, err := client.Routes.Validate(defaultCtx, tC.route)
 			require.NoError(err)
 			require.Equal(tC.valid, ok)

--- a/kong/utils.go
+++ b/kong/utils.go
@@ -206,7 +206,7 @@ func fillConfigRecord(schema gjson.Result, config Configuration) Configuration {
 	res := config.DeepCopy()
 	value := schema.Get("fields")
 
-	value.ForEach(func(key, value gjson.Result) bool {
+	value.ForEach(func(_, value gjson.Result) bool {
 		// get the key name
 		ms := value.Map()
 		fname := ""
@@ -427,7 +427,7 @@ func flattenJSONSchema(value gjson.Result) Schema {
 func flattenLuaSchema(value gjson.Result) Schema {
 	results := Schema{}
 
-	value.ForEach(func(key, value gjson.Result) bool {
+	value.ForEach(func(_, value gjson.Result) bool {
 		// get the key name
 		ms := value.Map()
 		fname := ""

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -1566,7 +1566,7 @@ func TestFillTargetDefaultsFromJSONSchema(t *testing.T) {
 }
 
 func TestHTTPClientWithHeaders(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(200)
 	}))
 	defer srv.Close()

--- a/kong/workspace_service.go
+++ b/kong/workspace_service.go
@@ -29,12 +29,12 @@ type AbstractWorkspaceService interface {
 	// of the entity that was added to the workspace.
 	//
 	// Deprecated: Kong 2.x removed this endpoint.
-	AddEntities(ctx context.Context, workspaceNameOrID *string, entityIds *string) (*[]map[string]interface{}, error)
+	AddEntities(ctx context.Context, workspaceNameOrID *string, entityIDs *string) (*[]map[string]interface{}, error)
 	// DeleteEntities deletes entity ids given as a a comma delimited string
 	// to a given workspace in Kong.
 	//
 	// Deprecated: Kong 2.x removed this endpoint.
-	DeleteEntities(ctx context.Context, workspaceNameOrID *string, entityIds *string) error
+	DeleteEntities(ctx context.Context, workspaceNameOrID *string, entityIDs *string) error
 	// ListEntities fetches a list of all workspace entities in Kong.
 	//
 	// Deprecated: Kong 2.x removed this endpoint.
@@ -210,17 +210,17 @@ func (s *WorkspaceService) ListAll(ctx context.Context) ([]*Workspace, error) {
 //
 // Deprecated: Kong 2.x removed this endpoint.
 func (s *WorkspaceService) AddEntities(ctx context.Context,
-	workspaceNameOrID *string, entityIds *string,
+	workspaceNameOrID *string, entityIDs *string,
 ) (*[]map[string]interface{}, error) {
-	if entityIds == nil {
-		return nil, fmt.Errorf("entityIds cannot be nil")
+	if entityIDs == nil {
+		return nil, fmt.Errorf("entityIDs cannot be nil")
 	}
 
 	endpoint := fmt.Sprintf("/workspaces/%v/entities", *workspaceNameOrID)
 	var entities struct {
 		Entities *string `json:"entities,omitempty"`
 	}
-	entities.Entities = entityIds
+	entities.Entities = entityIDs
 
 	req, err := s.client.NewRequest("POST", endpoint, nil, entities)
 	if err != nil {
@@ -241,17 +241,17 @@ func (s *WorkspaceService) AddEntities(ctx context.Context,
 //
 // Deprecated: Kong 2.x removed this endpoint.
 func (s *WorkspaceService) DeleteEntities(ctx context.Context,
-	workspaceNameOrID *string, entityIds *string,
+	workspaceNameOrID *string, entityIDs *string,
 ) error {
-	if entityIds == nil {
-		return fmt.Errorf("entityIds cannot be nil")
+	if entityIDs == nil {
+		return fmt.Errorf("entityIDs cannot be nil")
 	}
 
 	endpoint := fmt.Sprintf("/workspaces/%v/entities", *workspaceNameOrID)
 	var entities struct {
 		Entities *string `json:"entities,omitempty"`
 	}
-	entities.Entities = entityIds
+	entities.Entities = entityIDs
 
 	req, err := s.client.NewRequest("DELETE", endpoint, nil, entities)
 	if err != nil {


### PR DESCRIPTION
Blocking dependabot upgrades after a linter upgrade, e.g. https://github.com/Kong/go-kong/actions/runs/8045072066/job/21980638584?pr=420

Discard a bunch of unused parameters and rename a poorly-capitalized argument.

Could probably discard most of the args entirely, but :shrug: they're mostly test objects in test functions, which are kinda standard-ish, so I kept the placeholder around.