### PR TITLE
fix: update empty slices in kong entities

### DIFF
--- a/kong/plugin.go
+++ b/kong/plugin.go
@@ -16,8 +16,8 @@ type Plugin struct {
 	Enabled       *bool           `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 	RunOn         *string         `json:"run_on,omitempty" yaml:"run_on,omitempty"`
 	Ordering      *PluginOrdering `json:"ordering,omitempty" yaml:"ordering,omitempty"`
-	Protocols     []*string       `json:"protocols,omitempty" yaml:"protocols,omitempty"`
-	Tags          []*string       `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Protocols     []*string       `json:"protocols" yaml:"protocols"`
+	Tags          []*string       `json:"tags" yaml:"tags"`
 }
 
 // PluginOrdering contains before or after instructions for plugin execution order

--- a/kong/route.go
+++ b/kong/route.go
@@ -6,24 +6,24 @@ package kong
 type Route struct {
 	CreatedAt     *int                `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 	Expression    *string             `json:"expression,omitempty" yaml:"expression,omitempty"`
-	Hosts         []*string           `json:"hosts,omitempty" yaml:"hosts,omitempty"`
+	Hosts         []*string           `json:"hosts" yaml:"hosts"`
 	Headers       map[string][]string `json:"headers,omitempty" yaml:"headers,omitempty"`
 	ID            *string             `json:"id,omitempty" yaml:"id,omitempty"`
 	Name          *string             `json:"name,omitempty" yaml:"name,omitempty"`
-	Methods       []*string           `json:"methods,omitempty" yaml:"methods,omitempty"`
-	Paths         []*string           `json:"paths,omitempty" yaml:"paths,omitempty"`
+	Methods       []*string           `json:"methods" yaml:"methods"`
+	Paths         []*string           `json:"paths" yaml:"paths"`
 	PathHandling  *string             `json:"path_handling,omitempty" yaml:"path_handling,omitempty"`
 	PreserveHost  *bool               `json:"preserve_host,omitempty" yaml:"preserve_host,omitempty"`
 	Priority      *uint64             `json:"priority,omitempty" yaml:"priority,omitempty"`
-	Protocols     []*string           `json:"protocols,omitempty" yaml:"protocols,omitempty"`
+	Protocols     []*string           `json:"protocols" yaml:"protocols"`
 	RegexPriority *int                `json:"regex_priority,omitempty" yaml:"regex_priority,omitempty"`
 	Service       *Service            `json:"service,omitempty" yaml:"service,omitempty"`
 	StripPath     *bool               `json:"strip_path,omitempty" yaml:"strip_path,omitempty"`
 	UpdatedAt     *int                `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
-	SNIs          []*string           `json:"snis,omitempty" yaml:"snis,omitempty"`
-	Sources       []*CIDRPort         `json:"sources,omitempty" yaml:"sources,omitempty"`
-	Destinations  []*CIDRPort         `json:"destinations,omitempty" yaml:"destinations,omitempty"`
-	Tags          []*string           `json:"tags,omitempty" yaml:"tags,omitempty"`
+	SNIs          []*string           `json:"snis" yaml:"snis"`
+	Sources       []*CIDRPort         `json:"sources" yaml:"sources"`
+	Destinations  []*CIDRPort         `json:"destinations" yaml:"destinations"`
+	Tags          []*string           `json:"tags" yaml:"tags"`
 
 	HTTPSRedirectStatusCode *int `json:"https_redirect_status_code,omitempty" yaml:"https_redirect_status_code,omitempty"`
 

--- a/kong/service.go
+++ b/kong/service.go
@@ -19,10 +19,10 @@ type Service struct {
 	UpdatedAt         *int         `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
 	URL               *string      `json:"url,omitempty" yaml:"url,omitempty"`
 	WriteTimeout      *int         `json:"write_timeout,omitempty" yaml:"write_timeout,omitempty"`
-	Tags              []*string    `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Tags              []*string    `json:"tags" yaml:"tags"`
 	TLSVerify         *bool        `json:"tls_verify,omitempty" yaml:"tls_verify,omitempty"`
 	TLSVerifyDepth    *int         `json:"tls_verify_depth,omitempty" yaml:"tls_verify_depth,omitempty"`
-	CACertificates    []*string    `json:"ca_certificates,omitempty" yaml:"ca_certificates,omitempty"`
+	CACertificates    []*string    `json:"ca_certificates" yaml:"ca_certificates"`
 }
 
 // FriendlyName returns the endpoint key name or ID.


### PR DESCRIPTION
### Summary

Bugfix: Could not update service, route or plugin with empty slices because it was removed through the `omitempty` JSON struct tag.

Note: This bug is only fixed for services, routes or plugins. With other entities this problem may still occur.