### PR TITLE
fix(utils): support record-level default schema values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v0.53.0](#v0530)
 - [v0.52.0](#v0520)
 - [v0.51.0](#v0510)
 - [v0.50.0](#v0500)
@@ -63,6 +64,13 @@
 - [0.3.0](#030)
 - [0.2.0](#020)
 - [0.1.0](#010)
+
+## [v0.53.0]
+
+> Release date: 
+
+- Support record-level default schema values.
+  [#431](https://github.com/Kong/go-kong/pull/431)
 
 ## [v0.52.0]
 
@@ -861,6 +869,8 @@ authentication credentials in Kong.
   releases of Kong since every release of Kong is introducing breaking changes
   to the Admin API.
 
+[v0.53.0]: https://github.com/Kong/go-kong/compare/v0.52.0...v0.53.0
+[v0.52.0]: https://github.com/Kong/go-kong/compare/v0.51.0...v0.52.0
 [v0.51.0]: https://github.com/Kong/go-kong/compare/v0.50.0...v0.51.0
 [v0.50.0]: https://github.com/Kong/go-kong/compare/v0.49.0...v0.50.0
 [v0.49.0]: https://github.com/Kong/go-kong/compare/v0.48.0...v0.49.0

--- a/kong/utils.go
+++ b/kong/utils.go
@@ -211,6 +211,7 @@ func getConfigSchema(schema gjson.Result) (gjson.Result, error) {
 func fillConfigRecord(schema gjson.Result, config Configuration) Configuration {
 	res := config.DeepCopy()
 	value := schema.Get("fields")
+	defaultRecordValue := schema.Get("default")
 
 	value.ForEach(func(_, value gjson.Result) bool {
 		// get the key name
@@ -308,7 +309,15 @@ func fillConfigRecord(schema gjson.Result, config Configuration) Configuration {
 				}
 			}
 		}
-		value = value.Get(fname + ".default")
+
+		// Check if the record has a default value for the specified field.
+		// If so, use it. If not, fall back to the default value of the field itself.
+		if defaultRecordValue.Exists() && defaultRecordValue.Get(fname).Exists() {
+			value = defaultRecordValue.Get(fname)
+		} else {
+			value = value.Get(fname + ".default")
+		}
+
 		if value.Exists() {
 			res[fname] = value.Value()
 		} else {


### PR DESCRIPTION
Before this change, during the process of filling default configuration values, if a record existed in the schema with a structure similar to the following:
```
{
  "default": {
   "some_field": "record_level_default"
 },
 "fields": [
  {
   "some_field": {
    "type": "string",
    "default": "field_level_default"
   }
  }
 ]
}
```
the value `record_level_default` would be ignored and the field set to the `field_level_default` value. Similarly, in case of no field-level default, the field would be set to `null`.

This commit modifies the utils/fillConfigRecord logic to assign fields with record-level default values when available.

Example of default configuration values that were previously ignored: https://github.com/Kong/kong/blob/8fe14097a17cf904676672fc8cdaabe5e02e4a2d/kong/plugins/opentelemetry/schema.lua#L49 https://github.com/Kong/kong/blob/8fe14097a17cf904676672fc8cdaabe5e02e4a2d/kong/plugins/opentelemetry/schema.lua#L90

fixes: KAG-4149