### PR TITLE
chore(ci): update Kong versions in CI

### DIFF
--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -4,7 +4,7 @@ set -e
 
 source $(dirname "$0")/_common.sh
 
-KONG_IMAGE=${KONG_IMAGE_REPO:-kong}:${KONG_IMAGE_TAG:-3.4}
+KONG_IMAGE=${KONG_IMAGE_REPO:-kong}:${KONG_IMAGE_TAG:-3.6}
 NETWORK_NAME=kong-test
 
 KONG_ROUTER_FLAVOR=${KONG_ROUTER_FLAVOR:-'traditional_compatible'}

--- a/.github/workflows/integration-test-enterprise.yaml
+++ b/.github/workflows/integration-test-enterprise.yaml
@@ -71,6 +71,8 @@ jobs:
         - '3.2'
         - '3.3'
         - '3.4'
+        - '3.5'
+        - '3.6'
     env:
       KONG_ROUTER_FLAVOR: ${{ matrix.router_flavor }}
       KONG_IMAGE_TAG: ${{ matrix.kong_version }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -61,6 +61,8 @@ jobs:
           - '3.2'
           - '3.3'
           - '3.4'
+          - '3.5'
+          - '3.6'
     env:
       KONG_ROUTER_FLAVOR: ${{ matrix.router_flavor }}
       KONG_IMAGE_TAG: ${{ matrix.kong_version }}

--- a/kong/client_test.go
+++ b/kong/client_test.go
@@ -106,7 +106,7 @@ func TestDo(T *testing.T) {
 			require.NotNil(client)
 
 			req, err := client.NewRequest("GET", "/does-not-exist", nil, nil)
-			assert.NoError(err)
+			require.NoError(err)
 			require.NotNil(req)
 			resp, err := client.Do(context.Background(), req, nil)
 			assert.True(IsNotFoundErr(err), "got %v", err)
@@ -114,7 +114,7 @@ func TestDo(T *testing.T) {
 			assert.Equal(404, resp.StatusCode)
 
 			req, err = client.NewRequest("POST", "/", nil, nil)
-			assert.NoError(err)
+			require.NoError(err)
 			require.NotNil(req)
 			resp, err = client.Do(context.Background(), req, nil)
 			require.NotNil(err)

--- a/kong/developer_role_service_test.go
+++ b/kong/developer_role_service_test.go
@@ -5,41 +5,47 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDeveloperRoleService(T *testing.T) {
 	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{Portal: true})
-	RunWhenEnterprise(T, "<3.7.0", RequiredFeatures{Portal: true})
+	// NOTE: Developer Portal is not available in Kong < 3.5.0. Requires special config/license to enable.
+	RunWhenEnterprise(T, "<3.5.0", RequiredFeatures{Portal: true})
 	assert := assert.New(T)
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(err)
+	require.NotNil(client)
 
 	testWs, err := NewTestWorkspace(client, "default")
-	assert.NoError(err)
-	assert.NoError(testWs.UpdateConfig(map[string]interface{}{"portal": true}))
+	require.NoError(err)
+	T.Cleanup(func() {
+		assert.NoError(testWs.Reset())
+	})
 
+	require.NoError(testWs.UpdateConfig(map[string]interface{}{"portal": true}))
 	role := &DeveloperRole{
 		Name: String("roleA"),
 	}
 
 	createdRole, err := client.DeveloperRoles.Create(defaultCtx, role)
-	assert.NoError(err)
+	require.NoError(err)
 	assert.NotNil(createdRole)
 
 	role, err = client.DeveloperRoles.Get(defaultCtx, createdRole.ID)
-	assert.NoError(err)
-	assert.NotNil(role)
+	require.NoError(err)
+	require.NotNil(role)
 
 	role.Comment = String("new comment")
 	role, err = client.DeveloperRoles.Update(defaultCtx, role)
-	assert.NoError(err)
+	require.NoError(err)
 	assert.NotNil(role)
 	assert.Equal("roleA", *role.Name)
 
 	err = client.DeveloperRoles.Delete(defaultCtx, createdRole.ID)
-	assert.NoError(err)
+	require.NoError(err)
 
 	// ID can be specified
 	id := uuid.NewString()
@@ -49,28 +55,32 @@ func TestDeveloperRoleService(T *testing.T) {
 	}
 
 	createdRole, err = client.DeveloperRoles.Create(defaultCtx, role)
-	assert.NoError(err)
+	require.NoError(err)
 	assert.NotNil(createdRole)
 	assert.Equal(id, *createdRole.ID)
 
 	err = client.DeveloperRoles.Delete(defaultCtx, createdRole.ID)
-	assert.NoError(err)
-
-	assert.NoError(testWs.Reset())
+	require.NoError(err)
 }
 
 func TestDeveloperRoleServiceList(T *testing.T) {
 	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{Portal: true})
-	RunWhenEnterprise(T, "<3.7.0", RequiredFeatures{Portal: true})
+	// NOTE: Developer Portal is not available in Kong < 3.5.0. Requires special config/license to enable.
+	RunWhenEnterprise(T, "<3.5.0", RequiredFeatures{Portal: true})
 	assert := assert.New(T)
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
+	require.NoError(err)
 	assert.NotNil(client)
 
 	testWs, err := NewTestWorkspace(client, "default")
-	assert.NoError(err)
-	assert.NoError(testWs.UpdateConfig(map[string]interface{}{"portal": true}))
+	require.NoError(err)
+	T.Cleanup(func() {
+		assert.NoError(testWs.Reset())
+	})
+
+	require.NoError(testWs.UpdateConfig(map[string]interface{}{"portal": true}))
 
 	roleA := &DeveloperRole{
 		Name: String("roleA"),
@@ -80,36 +90,41 @@ func TestDeveloperRoleServiceList(T *testing.T) {
 	}
 
 	createdRoleA, err := client.DeveloperRoles.Create(defaultCtx, roleA)
-	assert.NoError(err)
+	require.NoError(err)
+	T.Cleanup(func() {
+		assert.NoError(client.DeveloperRoles.Delete(defaultCtx, createdRoleA.ID))
+	})
+
 	createdRoleB, err := client.DeveloperRoles.Create(defaultCtx, roleB)
-	assert.NoError(err)
+	require.NoError(err)
+	T.Cleanup(func() {
+		assert.NoError(client.DeveloperRoles.Delete(defaultCtx, createdRoleB.ID))
+	})
 
 	roles, next, err := client.DeveloperRoles.List(defaultCtx, nil)
-	assert.NoError(err)
+	require.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(roles)
-	assert.Equal(2, len(roles))
-
-	err = client.DeveloperRoles.Delete(defaultCtx, createdRoleA.ID)
-	assert.NoError(err)
-	err = client.DeveloperRoles.Delete(defaultCtx, createdRoleB.ID)
-	assert.NoError(err)
-
-	assert.NoError(testWs.Reset())
+	assert.Len(roles, 2)
 }
 
 func TestDeveloperRoleListEndpoint(T *testing.T) {
 	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{Portal: true})
-	RunWhenEnterprise(T, "<3.7.0", RequiredFeatures{Portal: true})
+	// NOTE: Developer Portal is not available in Kong < 3.5.0. Requires special config/license to enable.
+	RunWhenEnterprise(T, "<3.5.0", RequiredFeatures{Portal: true})
 	assert := assert.New(T)
+	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
+	require.NoError(err)
 	assert.NotNil(client)
 
 	testWs, err := NewTestWorkspace(client, "default")
-	assert.NoError(err)
-	assert.NoError(testWs.UpdateConfig(map[string]interface{}{"portal": true}))
+	require.NoError(err)
+	T.Cleanup(func() {
+		assert.NoError(testWs.Reset())
+	})
+	require.NoError(testWs.UpdateConfig(map[string]interface{}{"portal": true}))
 
 	// fixtures
 	roles := []*DeveloperRole{
@@ -127,13 +142,17 @@ func TestDeveloperRoleListEndpoint(T *testing.T) {
 	// create fixturs
 	for i := 0; i < len(roles); i++ {
 		role, err := client.DeveloperRoles.Create(defaultCtx, roles[i])
-		assert.NoError(err)
+		require.NoError(err)
 		assert.NotNil(role)
+		T.Cleanup(func() {
+			id := *role.ID
+			assert.NoError(client.DeveloperRoles.Delete(defaultCtx, &id))
+		})
 		roles[i] = role
 	}
 
 	rolesFromKong, next, err := client.DeveloperRoles.List(defaultCtx, nil)
-	assert.NoError(err)
+	require.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(rolesFromKong)
 	assert.Equal(3, len(rolesFromKong))
@@ -146,7 +165,7 @@ func TestDeveloperRoleListEndpoint(T *testing.T) {
 
 	// first page
 	page1, next, err := client.DeveloperRoles.List(defaultCtx, &ListOpt{Size: 1})
-	assert.NoError(err)
+	require.NoError(err)
 	assert.NotNil(next)
 	assert.NotNil(page1)
 	assert.Equal(1, len(page1))
@@ -155,7 +174,7 @@ func TestDeveloperRoleListEndpoint(T *testing.T) {
 	// last page
 	next.Size = 2
 	page2, next, err := client.DeveloperRoles.List(defaultCtx, next)
-	assert.NoError(err)
+	require.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(page2)
 	assert.Equal(2, len(page2))
@@ -164,15 +183,9 @@ func TestDeveloperRoleListEndpoint(T *testing.T) {
 	assert.True(compareDeveloperRoles(roles, rolesFromKong))
 
 	roles, err = client.DeveloperRoles.ListAll(defaultCtx)
-	assert.NoError(err)
+	require.NoError(err)
 	assert.NotNil(roles)
 	assert.Equal(3, len(roles))
-
-	for i := 0; i < len(roles); i++ {
-		assert.NoError(client.DeveloperRoles.Delete(defaultCtx, roles[i].ID))
-	}
-
-	assert.NoError(testWs.Reset())
 }
 
 func compareDeveloperRoles(expected, actual []*DeveloperRole) bool {

--- a/kong/developer_service_test.go
+++ b/kong/developer_service_test.go
@@ -9,7 +9,8 @@ import (
 
 func TestDevelopersService(T *testing.T) {
 	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{Portal: true})
-	RunWhenEnterprise(T, "<3.7.0", RequiredFeatures{Portal: true})
+	// NOTE: Developer Portal is not available in Kong < 3.5.0. Requires special config/license to enable.
+	RunWhenEnterprise(T, "<3.5.0", RequiredFeatures{Portal: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -80,7 +81,8 @@ func TestDevelopersService(T *testing.T) {
 
 func TestDeveloperListEndpoint(T *testing.T) {
 	RunWhenEnterprise(T, ">=0.33.0", RequiredFeatures{Portal: true})
-	RunWhenEnterprise(T, "<3.7.0", RequiredFeatures{Portal: true})
+	// NOTE: Developer Portal is not available in Kong < 3.5.0. Requires special config/license to enable.
+	RunWhenEnterprise(T, "<3.5.0", RequiredFeatures{Portal: true})
 	assert := assert.New(T)
 
 	client, err := NewTestClient(nil, nil)

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -564,7 +564,7 @@ func TestFillPluginDefaults(T *testing.T) {
 	}{
 		{
 			name:    "no config no protocols",
-			version: ">=3.7.0",
+			version: ">=3.6.0",
 			plugin: &Plugin{
 				Name:  String("basic-auth"),
 				RunOn: String("test"),
@@ -575,7 +575,9 @@ func TestFillPluginDefaults(T *testing.T) {
 				Config: Configuration{
 					"anonymous":        nil,
 					"hide_credentials": false,
-					"realm":            "service",
+					// NOTE: realm has been introduced in 3.6 basic auth schema
+					// https://docs.konghq.com/hub/kong-inc/basic-auth/changelog/#kong-gateway-36x
+					"realm": "service",
 				},
 				Protocols: []*string{String("grpc"), String("grpcs"), String("http"), String("https")},
 				Enabled:   Bool(true),
@@ -583,7 +585,7 @@ func TestFillPluginDefaults(T *testing.T) {
 		},
 		{
 			name:    "no config no protocols",
-			version: "<3.7.0",
+			version: "<3.6.0",
 			plugin: &Plugin{
 				Name:  String("basic-auth"),
 				RunOn: String("test"),
@@ -601,7 +603,7 @@ func TestFillPluginDefaults(T *testing.T) {
 		},
 		{
 			name:    "partial config no protocols",
-			version: ">=3.7.0",
+			version: ">=3.6.0",
 			plugin: &Plugin{
 				Name: String("basic-auth"),
 				Consumer: &Consumer{
@@ -619,7 +621,9 @@ func TestFillPluginDefaults(T *testing.T) {
 				Config: Configuration{
 					"anonymous":        nil,
 					"hide_credentials": true,
-					"realm":            "service",
+					// NOTE: realm has been introduced in 3.6 basic auth schema
+					// https://docs.konghq.com/hub/kong-inc/basic-auth/changelog/#kong-gateway-36x
+					"realm": "service",
 				},
 				Protocols: []*string{String("grpc"), String("grpcs"), String("http"), String("https")},
 				Enabled:   Bool(true),
@@ -627,7 +631,7 @@ func TestFillPluginDefaults(T *testing.T) {
 		},
 		{
 			name:    "partial config no protocols",
-			version: "<3.7.0",
+			version: "<3.6.0",
 			plugin: &Plugin{
 				Name: String("basic-auth"),
 				Consumer: &Consumer{


### PR DESCRIPTION
Update CI with most recent versions of Kong.

This also changes the 

- Kong version requirements in https://github.com/Kong/go-kong/blob/da7d97002cc92a764a80f13d5bcfe134a2924bac/kong/developer_role_service_test.go and https://github.com/Kong/go-kong/blob/da7d97002cc92a764a80f13d5bcfe134a2924bac/kong/developer_service_test.go from <3.7 to <3.5 as developer portal has been removed in that version.

- Kong version requirements in https://github.com/Kong/go-kong/blob/67f71c409919db806a414dcb9b2e56872084b4ca/kong/plugin_service_test.go#L549-L737 in several subtests. The reason for this change is that `realm` plugin config field for `basic-auth` has been introduced in 3.6 and not in 3.7. Re: https://docs.konghq.com/hub/kong-inc/basic-auth/changelog/#kong-gateway-36x