### PR TITLE
chore(ci): add GHA timeouts

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   analyze:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: Analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   golangci:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/integration-test-enterprise-nightly.yaml
+++ b/.github/workflows/integration-test-enterprise-nightly.yaml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   secret-available:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     outputs:
       ok: ${{ steps.exists.outputs.ok }}
     runs-on: ubuntu-latest
@@ -31,6 +32,7 @@ jobs:
         fi
 
   test-enterprise:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     strategy:
       matrix:
         router_flavor:

--- a/.github/workflows/integration-test-enterprise.yaml
+++ b/.github/workflows/integration-test-enterprise.yaml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   secret-available:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     outputs:
       ok: ${{ steps.exists.outputs.ok }}
     runs-on: ubuntu-latest
@@ -31,6 +32,7 @@ jobs:
         fi
 
   test-enterprise:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     continue-on-error: true
     needs:
     - secret-available
@@ -111,6 +113,7 @@ jobs:
           fail_ci_if_error: true
 
   test-enterprise-passed:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     needs: test-enterprise
     if: always()

--- a/.github/workflows/integration-test-nightly.yaml
+++ b/.github/workflows/integration-test-nightly.yaml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   test:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     strategy:
       matrix:
         dbmode:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   test:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     strategy:
       matrix:
         # Skip explicitly to avoid spawning many unnecessary jobs,
@@ -89,6 +90,7 @@ jobs:
           fail_ci_if_error: true
 
   test-passed:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     needs: test
     if: always()


### PR DESCRIPTION
Add timeouts to CI jobs 

See:
- https://github.com/Kong/go-kong/pull/410
- https://github.com/Kong/go-kong/pull/411
- https://github.com/Kong/go-kong/pull/412
- https://github.com/Kong/go-kong/pull/413
- https://github.com/Kong/go-kong/pull/414
- https://github.com/Kong/go-kong/pull/415
