### PR TITLE
chore: validate type assertion to prevent panic

### DIFF
--- a/kong/test_utils.go
+++ b/kong/test_utils.go
@@ -69,7 +69,7 @@ func RunWhenEnterprise(t *testing.T, versionRange string, required RequiredFeatu
 	}
 	configuration, ok := info["configuration"].(map[string]interface{})
 	if !ok {
-		t.Errorf("Failed to cast 'configuration' to map[string]interface{}.")
+		t.Errorf("failed to cast 'configuration' to map[string]interface{}.")
 	}
 
 	if required.RBAC && configuration["rbac"].(string) != "on" {

--- a/kong/test_utils.go
+++ b/kong/test_utils.go
@@ -69,7 +69,7 @@ func RunWhenEnterprise(t *testing.T, versionRange string, required RequiredFeatu
 	}
 	configuration, ok := info["configuration"].(map[string]interface{})
 	if !ok {
-		t.Errorf("failed to cast 'configuration' to map[string]interface{}.")
+		t.Errorf("failed to cast 'configuration' to map[string]interface{}")
 	}
 
 	if required.RBAC && configuration["rbac"].(string) != "on" {

--- a/kong/test_utils.go
+++ b/kong/test_utils.go
@@ -67,7 +67,10 @@ func RunWhenEnterprise(t *testing.T, versionRange string, required RequiredFeatu
 	if !currentVersion.IsKongGatewayEnterprise() {
 		t.Skip("non-Enterprise test Kong instance, skipping")
 	}
-	configuration := info["configuration"].(map[string]interface{})
+	configuration, ok := info["configuration"].(map[string]interface{})
+	if !ok {
+		t.Errorf("Failed to cast 'configuration' to map[string]interface{}.")
+	}
 
 	if required.RBAC && configuration["rbac"].(string) != "on" {
 		t.Skip("RBAC not enabled on test Kong instance, skipping")


### PR DESCRIPTION
I observed panics couple of times in tests. Validating type assertion before proceeding further should prevent this panic. 