### PR TITLE
test: update priority in route to `2^46 - 1`

### DIFF
--- a/kong/route.go
+++ b/kong/route.go
@@ -42,6 +42,14 @@ type Route struct {
 	ResponseBuffering *bool `json:"response_buffering,omitempty" yaml:"response_buffering,omitempty"`
 }
 
+const (
+	// maxRoutePriorityBits is the maximum number of bits that can be used in `priority` field of route.
+	maxRoutePriorityBits = 46
+	// MaxRoutePriority is the maximum value can be used in `priority` field of routes when Kong gateway runs expression router.
+	// Kong gateway 3.7 has limited it to 2^46-1 .
+	MaxRoutePriority = (1 << maxRoutePriorityBits) - 1
+)
+
 // CIDRPort represents a set of CIDR and a port.
 // +k8s:deepcopy-gen=true
 type CIDRPort struct {

--- a/kong/route_service_test.go
+++ b/kong/route_service_test.go
@@ -418,7 +418,7 @@ func TestRoutesValidationExpressions(T *testing.T) {
 			name: "valid expression with priority",
 			route: &Route{
 				Expression: String(`lower(http.path) ^= "/prefix/"`),
-				Priority:   Uint64((1 << 46) - 1),
+				Priority:   Uint64(MaxRoutePriority),
 			},
 			valid: true,
 		},

--- a/kong/route_service_test.go
+++ b/kong/route_service_test.go
@@ -418,7 +418,7 @@ func TestRoutesValidationExpressions(T *testing.T) {
 			name: "valid expression with priority",
 			route: &Route{
 				Expression: String(`lower(http.path) ^= "/prefix/"`),
-				Priority:   Uint64(3382097767104500),
+				Priority:   Uint64((1 << 46) - 1),
 			},
 			valid: true,
 		},


### PR DESCRIPTION
Since Kong gateway will limit the `priority` in routes to be less than `2^46` (in `[0,2^46-1]`) , the `priority`of route used in tests should be updated to be in the interval.