### PR TITLE
feat: return APIError from ReloadDeclarativeRawConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,14 @@
 - [0.2.0](#020)
 - [0.1.0](#010)
 
+## [v0.56.0]
+
+> Release date: 2024/06/25
+
+- `ReloadDeclarativeRawConfig` now returns `APIError` when it retrieves a valid 
+  HTTP response, allowing inspection of the response status code.
+  [#452](https://github.com/Kong/go-kong/pull/452)
+
 ## [v0.55.0]
 
 > Release date: 2024/05/14

--- a/kong/client.go
+++ b/kong/client.go
@@ -510,7 +510,7 @@ func (c *Client) ReloadDeclarativeRawConfig(
 		return nil, fmt.Errorf("could not read /config %d status response body: %w", resp.StatusCode, err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		return b, fmt.Errorf("failed posting new config to /config: got status code %d", resp.StatusCode)
+		return b, NewAPIErrorWithRaw(resp.StatusCode, "failed posting new config to /config", b)
 	}
 
 	return b, nil


### PR DESCRIPTION
Makes `ReloadDeclarativeRawConfig` return an `APIError` when the status code is <200 or >=400.
KIC needs to inspect the HTTP response status code when invoking `ReloadDeclarativeRawConfig` to decide whether it's a recoverable issue (4xx) or not (5xx).

Required for https://github.com/Kong/kubernetes-ingress-controller/pull/6237.