### PR TITLE
feat: drop resp body from ReloadDeclarativeRawConfig signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Table of Contents
 
+- [v0.57.0](#v0570)
+- [v0.56.0](#v0560)
 - [v0.55.0](#v0550)
 - [v0.54.0](#v0540)
 - [v0.53.0](#v0530)
@@ -66,6 +68,15 @@
 - [0.3.0](#030)
 - [0.2.0](#020)
 - [0.1.0](#010)
+
+## [v0.57.0]
+
+> Release date: 2024/06/25
+
+- **Breaking change** `ReloadDeclarativeRawConfig` now doesn't return a response body
+  as its first return value - the body can be obtained from `APIError` returned when
+  the response is not successful.
+  [#453](https://github.com/Kong/go-kong/pull/453)
 
 ## [v0.56.0]
 
@@ -894,6 +905,8 @@ authentication credentials in Kong.
   releases of Kong since every release of Kong is introducing breaking changes
   to the Admin API.
 
+[v0.57.0]: https://github.com/Kong/go-kong/compare/v0.56.0...v0.57.0
+[v0.56.0]: https://github.com/Kong/go-kong/compare/v0.55.0...v0.56.0
 [v0.55.0]: https://github.com/Kong/go-kong/compare/v0.54.0...v0.55.0
 [v0.54.0]: https://github.com/Kong/go-kong/compare/v0.53.0...v0.54.0
 [v0.53.0]: https://github.com/Kong/go-kong/compare/v0.52.0...v0.53.0


### PR DESCRIPTION
Simplify `ReloadDeclarativeRawConfig` signature so it complies with Go standards.