### PR TITLE
feat: add /status/ready function

### DIFF
--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -32,6 +32,7 @@ function deploy_kong_postgres()
     -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
     -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
     -e "KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl" \
+    -e "KONG_STATUS_LISTEN=0.0.0.0:8100" \
     -e "KONG_ADMIN_GUI_AUTH=basic-auth" \
     -e "KONG_ADMIN_GUI_SESSION_CONF={}" \
     -e "KONG_ENFORCE_RBAC=on" \
@@ -44,6 +45,7 @@ function deploy_kong_postgres()
     -p 8443:8443 \
     -p 127.0.0.1:8001:8001 \
     -p 127.0.0.1:8444:8444 \
+    -p 127.0.0.1:8100:8100 \
     --label "$DOCKER_LABEL" \
     $KONG_IMAGE
   waitContainer "Kong" 8001 0.2
@@ -59,6 +61,7 @@ function deploy_kong_dbless()
     -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
     -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
     -e "KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl" \
+    -e "KONG_STATUS_LISTEN=0.0.0.0:8100" \
     -e "KONG_ADMIN_GUI_AUTH=basic-auth" \
     -e "KONG_ENFORCE_RBAC=on" \
     -e "KONG_PORTAL=on" \
@@ -70,6 +73,7 @@ function deploy_kong_dbless()
     -p 8443:8443 \
     -p 127.0.0.1:8001:8001 \
     -p 127.0.0.1:8444:8444 \
+    -p 127.0.0.1:8100:8100 \
     --label "$DOCKER_LABEL" \
     $KONG_IMAGE
   waitContainer "Kong" 8001 0.2

--- a/.ci/setup_kong_ee.sh
+++ b/.ci/setup_kong_ee.sh
@@ -40,6 +40,7 @@ function deploy_kong_ee()
     -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
     -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
     -e "KONG_ADMIN_LISTEN=0.0.0.0:8001" \
+    -e "KONG_STATUS_LISTEN=0.0.0.0:8100" \
     -e "KONG_PORTAL_GUI_URI=127.0.0.1:8003" \
     -e "KONG_ADMIN_GUI_URL=http://127.0.0.1:8002" \
     -e "KONG_LICENSE_DATA=$KONG_LICENSE_DATA" \
@@ -59,6 +60,7 @@ function deploy_kong_ee()
     -p 8445:8445 \
     -p 8003:8003 \
     -p 8004:8004 \
+    -p 127.0.0.1:8100:8100 \
     --label "$DOCKER_LABEL" \
     $KONG_IMAGE
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ replace github.com/imdario/mergo v0.3.12 => github.com/Kong/mergo v0.3.13
 retract v0.39.1
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Kong/mergo v0.3.13 h1:J+RyBootTG0GSmmzPBF4GqhHDLBKuSZeuaIyAHtOF9Y=
 github.com/Kong/mergo v0.3.13/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/kong/client.go
+++ b/kong/client.go
@@ -20,11 +20,11 @@ import (
 )
 
 const (
-	// ref: https://docs.konghq.com/gateway/latest/production/networking/default-ports/
-	// defaultBaseURL is the endpoint for admin API
+	// defaultBaseURL is the endpoint for admin API.
+	// ref: https://docs.konghq.com/gateway/latest/production/networking/default-ports/	
 	defaultBaseURL = "http://localhost:8001"
 	// defaultStatusURL is the endpoint for status API
-	// By default, the Status API listens on 127.0.0.1
+	// By default, the Status API listens on localhost.
 	// If you need to request it from elsewhere,
 	// please modify the `KONG_STATUS_LISTEN` environment variable of Gateway.
 	defaultStatusURL = "http://localhost:8007"

--- a/kong/client_test.go
+++ b/kong/client_test.go
@@ -63,13 +63,16 @@ func TestKongReady(t *testing.T) {
 	}
 
 	assert := assert.New(t)
+	require := require.New(t)
 
-	client, err := NewTestClientWithOpts(RequestOptions{
-		BaseURL:   String("http://localhost:8001"),
-		StatusURL: String("http://localhost:8100"),
-	}, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	client, err := NewTestClientWithOpts(
+		RequestOptions{
+			BaseURL:   String("http://localhost:8001"),
+			StatusURL: String("http://localhost:8100"),
+		}, nil,
+	)
+	require.NoError(err)
+	require.NotNil(client)
 
 	sm, err := client.Ready(defaultCtx)
 	if err != nil {

--- a/kong/test_utils.go
+++ b/kong/test_utils.go
@@ -112,6 +112,16 @@ func SkipWhenEnterprise(t *testing.T) {
 	}
 }
 
+func NewTestClientWithOpts(opts RequestOptions, client *http.Client) (*Client, error) {
+	return NewClientWithOpts(
+		RequestOptions{
+			BaseURL:   opts.BaseURL,
+			StatusURL: opts.StatusURL,
+		},
+		client,
+	)
+}
+
 func NewTestClient(baseURL *string, client *http.Client) (*Client, error) {
 	if value, exists := os.LookupEnv("KONG_ADMIN_TOKEN"); exists && value != "" {
 		c := &http.Client{}


### PR DESCRIPTION
ref: https://github.com/Kong/kubernetes-ingress-controller/issues/5068

> This endpoint should be used to health-check Kong nodes. This can be health checks from orchestration frameworks like k8s or by load-balancers fronting Kong nodes that proxy traffic. This endpoint returns 200 only after the Kong node has configured itself and is ready to start proxying traffic.

https://docs.konghq.com/gateway/api/status/latest/#/default/get_status_ready