### PR TITLE
fix: fill config values and defaults in shorthand fields

### DIFF
--- a/kong/utils.go
+++ b/kong/utils.go
@@ -416,7 +416,7 @@ func fillConfigRecord(schema gjson.Result, config Configuration) Configuration {
 		if v, ok := config[fname]; ok {
 			if v != nil {
 				// This config's value should be retained.
-				// Also, the resul config 'res' may have a different value for some nested fields than this.
+				// Also, the result config 'res' may have a different value for some nested fields than this.
 				// As per current conventions, shorthand fields take priority when different values are present
 				// in equivalent shorthand configs and normal nested configs.
 				// Backfilling nested configs to reduce inconsistencies.
@@ -434,7 +434,7 @@ func fillConfigRecord(schema gjson.Result, config Configuration) Configuration {
 			return true
 		}
 
-		var configPathForBackwardTranslation []string
+		configPathForBackwardTranslation := make([]string, 0, len(backwardTranslation.Array()))
 		for _, value := range backwardTranslation.Array() {
 			configPathForBackwardTranslation = append(configPathForBackwardTranslation, value.Str)
 		}


### PR DESCRIPTION
As of now, deprecated fields are renamed to shorthand_fields in all schemas, as per the conventions. Till now, we do not fill any values for these fields while attempting to fill config records for plugins. This creates a visualisation problem in decK. Everytime, a deck diff or deck sync command is issued, it shows that the deprecated field values are changed and need to be updated, thus running an unnecessary update process each time and also confusing end users.

Check https://github.com/Kong/deck/issues/1251 for details.

This fix attempts to fill defaults for the shorthand_fields, retaining their values, if passed. Also, since shorthand_fields take priority over normal/nested fields in the gateway, if any changes are detected in shorthand_fields, it is backfilled to nested fields as well.