### PR TITLE
fix(*): avoid setting nil for missing fields

### DIFF
--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -573,7 +573,6 @@ func TestFillPluginDefaults(T *testing.T) {
 				Name:  String("basic-auth"),
 				RunOn: String("test"),
 				Config: Configuration{
-					"anonymous":        nil,
 					"hide_credentials": false,
 					// NOTE: realm has been introduced in 3.6 basic auth schema
 					// https://docs.konghq.com/hub/kong-inc/basic-auth/changelog/#kong-gateway-36x
@@ -594,7 +593,6 @@ func TestFillPluginDefaults(T *testing.T) {
 				Name:  String("basic-auth"),
 				RunOn: String("test"),
 				Config: Configuration{
-					"anonymous":        nil,
 					"hide_credentials": false,
 				},
 				Protocols: []*string{String("grpc"), String("grpcs"), String("http"), String("https")},
@@ -619,7 +617,6 @@ func TestFillPluginDefaults(T *testing.T) {
 					ID: String("3bb9a73c-a467-11ec-b909-0242ac120002"),
 				},
 				Config: Configuration{
-					"anonymous":        nil,
 					"hide_credentials": true,
 					// NOTE: realm has been introduced in 3.6 basic auth schema
 					// https://docs.konghq.com/hub/kong-inc/basic-auth/changelog/#kong-gateway-36x
@@ -647,7 +644,6 @@ func TestFillPluginDefaults(T *testing.T) {
 					ID: String("3bb9a73c-a467-11ec-b909-0242ac120002"),
 				},
 				Config: Configuration{
-					"anonymous":        nil,
 					"hide_credentials": true,
 				},
 				Protocols: []*string{String("grpc"), String("grpcs"), String("http"), String("https")},
@@ -678,7 +674,6 @@ func TestFillPluginDefaults(T *testing.T) {
 			expected: &Plugin{
 				Name: String("request-transformer"),
 				Config: Configuration{
-					"http_method": nil,
 					"add": map[string]interface{}{
 						"body":        []interface{}{},
 						"headers":     "x-new-header:value",
@@ -703,7 +698,6 @@ func TestFillPluginDefaults(T *testing.T) {
 						"body":        []interface{}{},
 						"headers":     []interface{}{},
 						"querystring": []interface{}{},
-						"uri":         nil,
 					},
 				},
 				Protocols: []*string{String("grpc"), String("grpcs")},

--- a/kong/utils.go
+++ b/kong/utils.go
@@ -393,8 +393,8 @@ func fillConfigRecord(schema gjson.Result, config Configuration) Configuration {
 		if value.Exists() {
 			res[fname] = value.Value()
 		} else {
-			// if no default exists, set an explicit nil
-			res[fname] = nil
+			// if no default exists, remove the field
+			delete(res, fname)
 		}
 		return true
 	})

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -1801,7 +1801,6 @@ func Test_fillConfigRecord(t *testing.T) {
 				"enabled": true,
 				"mappings": []any{
 					Configuration{
-						"name":        nil,
 						"nationality": "Ethiopian",
 					},
 				},
@@ -1823,7 +1822,6 @@ func Test_fillConfigRecord(t *testing.T) {
 				"enabled": true,
 				"mappings": []any{
 					Configuration{
-						"name":        nil,
 						"nationality": "Ethiopian",
 					},
 				},
@@ -1954,17 +1952,14 @@ func Test_fillConfigRecord_shorthand_fields(t *testing.T) {
 				"enabled": true,
 				"mappings": []any{
 					Configuration{
-						"name":        nil,
 						"nationality": "Ethiopian",
 					},
 				},
 				"empty_record": map[string]any{},
 				"redis": map[string]interface{}{
-					"host": nil,
 					"port": float64(6379),
 				},
 				"redis_port": float64(6379),
-				"redis_host": nil,
 			},
 		},
 		{
@@ -1976,7 +1971,6 @@ func Test_fillConfigRecord_shorthand_fields(t *testing.T) {
 			},
 			expected: Configuration{
 				"enabled":      true,
-				"mappings":     nil,
 				"empty_record": map[string]any{},
 				"redis": map[string]interface{}{
 					"host": "localhost",
@@ -2075,10 +2069,8 @@ func Test_FillPluginsDefaults(t *testing.T) {
 					"prefix": "kong",
 					"metrics": []interface{}{
 						Configuration{
-							"name":                "response_size",
-							"stat_type":           "histogram",
-							"consumer_identifier": nil,
-							"sample_rate":         nil,
+							"name":      "response_size",
+							"stat_type": "histogram",
 						},
 					},
 				},
@@ -2165,10 +2157,9 @@ func Test_FillPluginsDefaults_RequestTransformer(t *testing.T) {
 						"headers":     []any{},
 						"querystring": []any{},
 					},
-					"http_method": nil,
-					"enabled":     true,
-					"id":          "0beef60e-e7e3-40f8-ac47-f6a10b931cee",
-					"name":        "request-transformer",
+					"enabled": true,
+					"id":      "0beef60e-e7e3-40f8-ac47-f6a10b931cee",
+					"name":    "request-transformer",
 					"protocols": []any{
 						"grpc",
 						"grpcs",
@@ -2196,13 +2187,12 @@ func Test_FillPluginsDefaults_RequestTransformer(t *testing.T) {
 						"headers":     []interface{}{},
 						"querystring": []interface{}{},
 					},
-					"remove":      map[string]any{"body": []any{}, "headers": []any{}, "querystring": []any{}},
-					"rename":      map[string]any{"body": []any{}, "headers": []any{}, "querystring": []any{}},
-					"replace":     map[string]any{"body": []any{}, "headers": []any{}, "querystring": []any{}, "uri": nil},
-					"http_method": nil,
-					"enabled":     true,
-					"id":          "0beef60e-e7e3-40f8-ac47-f6a10b931cee",
-					"name":        "request-transformer",
+					"remove":  map[string]any{"body": []any{}, "headers": []any{}, "querystring": []any{}},
+					"rename":  map[string]any{"body": []any{}, "headers": []any{}, "querystring": []any{}},
+					"replace": map[string]any{"body": []any{}, "headers": []any{}, "querystring": []any{}},
+					"enabled": true,
+					"id":      "0beef60e-e7e3-40f8-ac47-f6a10b931cee",
+					"name":    "request-transformer",
 					"protocols": []any{
 						"grpc",
 						"grpcs",
@@ -2371,54 +2361,29 @@ func Test_FillPluginsDefaults_Acme(t *testing.T) {
 			},
 			expected: &Plugin{
 				Config: Configuration{
-					"account_email":           nil,
-					"account_key":             nil,
 					"allow_any_domain":        bool(false),
 					"api_uri":                 string("https://acme-v02.api.letsencrypt.org/directory"),
 					"cert_type":               string("rsa"),
-					"domains":                 nil,
-					"eab_hmac_key":            nil,
-					"eab_kid":                 nil,
 					"enable_ipv4_common_name": bool(true),
 					"fail_backoff_minutes":    float64(5),
-					"preferred_chain":         nil,
 					"renew_threshold_days":    float64(14),
 					"rsa_key_size":            float64(4096),
 					"storage":                 string("shm"),
 					"storage_config": map[string]any{
 						"consul": map[string]any{
-							"host":    nil,
-							"https":   bool(false),
-							"kv_path": nil,
-							"port":    nil,
-							"timeout": nil,
-							"token":   nil,
+							"https": bool(false),
 						},
 						"kong": map[string]any{},
 						"redis": map[string]any{
-							"auth":            nil,
-							"database":        nil,
-							"host":            nil,
-							"namespace":       string(""),
-							"port":            nil,
-							"ssl":             bool(false),
-							"ssl_server_name": nil,
-							"ssl_verify":      bool(false),
+							"namespace":  string(""),
+							"ssl":        bool(false),
+							"ssl_verify": bool(false),
 						},
 						"shm": map[string]any{"shm_name": string("kong")},
 						"vault": map[string]any{
-							"auth_method":     string("token"),
-							"auth_path":       nil,
-							"auth_role":       nil,
-							"host":            nil,
-							"https":           bool(false),
-							"jwt_path":        nil,
-							"kv_path":         nil,
-							"port":            nil,
-							"timeout":         nil,
-							"tls_server_name": nil,
-							"tls_verify":      bool(true),
-							"token":           nil,
+							"auth_method": string("token"),
+							"https":       bool(false),
+							"tls_verify":  bool(true),
 						},
 					},
 					"tos_accepted": bool(false),
@@ -2466,7 +2431,6 @@ func Test_FillPluginsDefaults_DefaultRecord(t *testing.T) {
 					"endpoint": "http://test.test:4317",
 					"propagation": map[string]interface{}{
 						"default_format": string("w3c"), // from record defaults
-						"extract":        nil,           // from field defaults
 					},
 					"queue": map[string]interface{}{
 						"max_batch_size":       float64(200), // from record defaults
@@ -2493,7 +2457,6 @@ func Test_FillPluginsDefaults_DefaultRecord(t *testing.T) {
 					"endpoint": "http://test.test:4317",
 					"propagation": map[string]interface{}{
 						"default_format": string("b3"),
-						"extract":        nil, // from field defaults
 					},
 					"queue": map[string]interface{}{
 						"max_batch_size":       float64(123),


### PR DESCRIPTION
when filling defaults, the existing logic sets `nil` on missing fields, but in Kong Gateway explicit `nil`s result in the corresponding fields to be unset, causing problems such as: [KAG-5157](https://konghq.atlassian.net/browse/KAG-5157)

This change **removes** any unset fields that don't have a default from the configuration instead of explicitly setting them to `nil`.

`@reviewers`: could this be a breaking change? I tested it in decK and it seems to work but I'm worried about other projects using this lib. An alternative would be creating another utils function with the new behavior (which I think would require updating at least `deck`, `go-database-reconciler` and probably [kubernetes-ingress-controller](https://github.com/Kong/kubernetes-ingress-controller/blob/09257b8425b3d3654028fa5bbedb7d3f6677079f/internal/dataplane/deckgen/generate.go)), but if we're fairly confident the func is only used while interacting with decK then it *might* be considered safe enough.

[Searching occurrences](https://github.com/search?q=org%3AKong+FillPluginsDefaults&type=code).

For more details see: [KAG-5210](https://konghq.atlassian.net/browse/KAG-5210)

[KAG-5157]: https://konghq.atlassian.net/browse/KAG-5157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAG-5210]: https://konghq.atlassian.net/browse/KAG-5210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ