### PR TITLE
fix: use replaced_with to check for deprecated fields

### DIFF
--- a/kong/utils.go
+++ b/kong/utils.go
@@ -452,24 +452,24 @@ func fillConfigRecord(schema gjson.Result, config Configuration, opts FillRecord
 		// the defaults for deprecated fields from the already formed default config
 		backwardTranslation := value.Get(fname + ".translate_backwards")
 
-		var replacePath gjson.Result
-		replacedWith := value.Get(fname + ".deprecation.replaced_with")
-		if replacedWith.IsArray() {
-			for _, item := range replacedWith.Array() {
-				if pathArray := item.Get("path"); pathArray.Exists() && pathArray.IsArray() {
-					replacePath = pathArray
-					break
+		if !backwardTranslation.Exists() {
+			// Checking for replaced_with path if it exists in the deprecation block
+			var replacePath gjson.Result
+			replacedWith := value.Get(fname + ".deprecation.replaced_with")
+			if replacedWith.IsArray() {
+				for _, item := range replacedWith.Array() {
+					if pathArray := item.Get("path"); pathArray.Exists() && pathArray.IsArray() {
+						replacePath = pathArray
+					}
 				}
 			}
-		}
 
-		if !backwardTranslation.Exists() && !replacePath.Exists() {
-			// This block attempts to fill defaults for deprecated fields.
-			// Thus, not erroring out here, as it is not vital.
-			return true
-		}
+			if !replacePath.Exists() {
+				// This block attempts to fill defaults for deprecated fields.
+				// Thus, not erroring out here, as it is not vital.
+				return true
+			}
 
-		if !backwardTranslation.Exists() {
 			backwardTranslation = replacePath
 		}
 

--- a/kong/utils.go
+++ b/kong/utils.go
@@ -452,10 +452,25 @@ func fillConfigRecord(schema gjson.Result, config Configuration, opts FillRecord
 		// the defaults for deprecated fields from the already formed default config
 		backwardTranslation := value.Get(fname + ".translate_backwards")
 
-		if !backwardTranslation.Exists() {
+		var replacePath gjson.Result
+		replacedWith := value.Get(fname + ".deprecation.replaced_with")
+		if replacedWith.IsArray() {
+			for _, item := range replacedWith.Array() {
+				if pathArray := item.Get("path"); pathArray.Exists() && pathArray.IsArray() {
+					replacePath = pathArray
+					break
+				}
+			}
+		}
+
+		if !backwardTranslation.Exists() && !replacePath.Exists() {
 			// This block attempts to fill defaults for deprecated fields.
 			// Thus, not erroring out here, as it is not vital.
 			return true
+		}
+
+		if !backwardTranslation.Exists() {
+			backwardTranslation = replacePath
 		}
 
 		configPathForBackwardTranslation := make([]string, 0, len(backwardTranslation.Array()))


### PR DESCRIPTION
In schemas, shorthand_fields that are deprecated
will use "replaced_with" going forward to convey the new fields that would be used in place of the old ones. Earlier, "translate_backwards" was used for the same.

This change ensures that both of the above mentioned fields can be used to find the new path that leads to the new values for comparison purposes. This will help tools like deck to show diff between syncs.

Fixes [deck #1440](https://github.com/Kong/deck/issues/1404)
Corresponding PR: https://github.com/Kong/kong/pull/13768