### PR TITLE
fix(utils): add ClearUnmatchingDeprecations function to align configs

### DIFF
--- a/kong/utils.go
+++ b/kong/utils.go
@@ -913,7 +913,7 @@ func traverseConfigMap(currentConfigMap map[string]interface{}, path []string) (
 	}
 }
 
-// This function handles the relationship between deprecated and new plugin configuration values.
+// clearUnmatchingDeprecationsForGivenPath handles the relationship between deprecated and new plugin configuration values.
 // We consider the following scenarios:
 //
 // - **Scenario 1**: Both old and new values are present.

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -2825,11 +2825,13 @@ func Test_FillPluginsDefaults_NonEmptyDefaultArrayField(t *testing.T) {
 
 func Test_ClearUnmatchingDeprecationsSimple(t *testing.T) {
 	RunWhenKong(t, ">=3.8.0")
-	assert := assert.New(t)
-
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	fullSchema, err := client.Schemas.Get(defaultCtx, "plugins/rate-limiting")
+	require.NoError(t, err)
+	require.NotNil(t, fullSchema)
 
 	tests := []struct {
 		name              string
@@ -2908,9 +2910,6 @@ func Test_ClearUnmatchingDeprecationsSimple(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fullSchema, err := client.Schemas.Get(defaultCtx, "plugins/rate-limiting")
-			assert.NoError(err)
-			assert.NotNil(fullSchema)
 			require.NoError(t, ClearUnmatchingDeprecations(tc.newPlugin, tc.oldPlugin, fullSchema))
 			if diff := cmp.Diff(tc.oldPlugin.Config, tc.expectedOldPlugin); diff != "" {
 				t.Errorf("unexpected diff:\n%s", diff)
@@ -2921,11 +2920,13 @@ func Test_ClearUnmatchingDeprecationsSimple(t *testing.T) {
 
 func Test_ClearUnmatchingDeprecationsAdvanced(t *testing.T) {
 	RunWhenEnterprise(t, ">=3.8.0", RequiredFeatures{})
-	assert := assert.New(t)
-
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	fullSchema, err := client.Schemas.Get(defaultCtx, "plugins/rate-limiting-advanced")
+	require.NoError(t, err)
+	require.NotNil(t, fullSchema)
 
 	tests := []struct {
 		name              string
@@ -3139,9 +3140,6 @@ func Test_ClearUnmatchingDeprecationsAdvanced(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fullSchema, err := client.Schemas.Get(defaultCtx, "plugins/rate-limiting-advanced")
-			assert.NoError(err)
-			assert.NotNil(fullSchema)
 			require.NoError(t, ClearUnmatchingDeprecations(tc.newPlugin, tc.oldPlugin, fullSchema))
 			if diff := cmp.Diff(tc.oldPlugin.Config, tc.expectedOldPlugin); diff != "" {
 				t.Errorf("unexpected diff:\n%s", diff)
@@ -3179,11 +3177,13 @@ func Test_ClearUnmatchingDeprecationsWhenSchemaIsWrong(t *testing.T) {
 
 func Test_ClearUnmatchingDeprecationsWhenNotUpdateEvent(t *testing.T) {
 	RunWhenEnterprise(t, ">=3.8.0", RequiredFeatures{})
-	assert := assert.New(t)
-
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	fullSchema, err := client.Schemas.Get(defaultCtx, "plugins/rate-limiting-advanced")
+	require.NoError(t, err)
+	require.NotNil(t, fullSchema)
 
 	tests := []struct {
 		name                     string
@@ -3266,9 +3266,6 @@ func Test_ClearUnmatchingDeprecationsWhenNotUpdateEvent(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fullSchema, err := client.Schemas.Get(defaultCtx, "plugins/rate-limiting-advanced")
-			assert.NoError(err)
-			assert.NotNil(fullSchema)
 			require.NoError(t, ClearUnmatchingDeprecations(tc.newPlugin, tc.oldPlugin, fullSchema))
 			if tc.expectedNewPluginCleared != nil {
 				if diff := cmp.Diff(tc.newPlugin.Config, tc.expectedNewPluginCleared); diff != "" {
@@ -3287,11 +3284,13 @@ func Test_ClearUnmatchingDeprecationsWhenNotUpdateEvent(t *testing.T) {
 
 func Test_ClearUnmatchingDeprecationsWhenNewConfigIsSetAsNil(t *testing.T) {
 	RunWhenEnterprise(t, ">=3.8.0", RequiredFeatures{})
-	assert := assert.New(t)
-
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	fullSchema, err := client.Schemas.Get(defaultCtx, "plugins/rate-limiting-advanced")
+	require.NoError(t, err)
+	require.NotNil(t, fullSchema)
 
 	tests := []struct {
 		name                     string
@@ -3410,9 +3409,6 @@ func Test_ClearUnmatchingDeprecationsWhenNewConfigIsSetAsNil(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fullSchema, err := client.Schemas.Get(defaultCtx, "plugins/rate-limiting-advanced")
-			assert.NoError(err)
-			assert.NotNil(fullSchema)
 			require.NoError(t, ClearUnmatchingDeprecations(tc.newPlugin, tc.oldPlugin, fullSchema))
 			if diff := cmp.Diff(tc.newPlugin.Config, tc.expectedNewPluginCleared); diff != "" {
 				t.Errorf("unexpected diff:\n%s", diff)
@@ -3427,11 +3423,13 @@ func Test_ClearUnmatchingDeprecationsWhenNewConfigIsSetAsNil(t *testing.T) {
 
 func Test_ClearUnmatchingDeprecationsWhenNewConfigHasDefaults(t *testing.T) {
 	RunWhenEnterprise(t, ">=3.8.0", RequiredFeatures{})
-	assert := assert.New(t)
-
 	client, err := NewTestClient(nil, nil)
-	assert.NoError(err)
-	assert.NotNil(client)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	fullSchema, err := client.Schemas.Get(defaultCtx, "plugins/rate-limiting-advanced")
+	require.NoError(t, err)
+	require.NotNil(t, fullSchema)
 
 	tests := []struct {
 		name                     string
@@ -3550,9 +3548,6 @@ func Test_ClearUnmatchingDeprecationsWhenNewConfigHasDefaults(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fullSchema, err := client.Schemas.Get(defaultCtx, "plugins/rate-limiting-advanced")
-			assert.NoError(err)
-			assert.NotNil(fullSchema)
 			require.NoError(t, ClearUnmatchingDeprecations(tc.newPlugin, tc.oldPlugin, fullSchema))
 			if diff := cmp.Diff(tc.newPlugin.Config, tc.expectedNewPluginCleared); diff != "" {
 				t.Errorf("unexpected diff:\n%s", diff)


### PR DESCRIPTION
# Summary

When a new plugin configuration is sent that contains information about some deprecated fields in order to produce 
correct diff we need to align the API response with given config.

### Description

This PR aims to align the configs by doing two things:
1. Adding: `ClearUnmatchingDeprecations`
2. Modifying: `fillConfigRecord`

More details can be found in the functions documentation.

### Important changes:

- `nil` values are preserved and not changed when `fillConfigRecord` is run. Previously a config `cluster_max_redirections: null` would be "filled" with `cluster_max_redirections: 5` if `cluster_max_redirections` had a default value of 5 defined. Right now sending explicit  null preserves that. This reverts the change introduced in: https://github.com/Kong/go-kong/pull/309/files#diff-af8350ebad15aeeb0a2561433d1d0907140df8e5b8267a0d0f05bb53d0d53fcbR221-R249
- shorthand values are not backfilled. If a new config contains only new fields `fillConfigRecord` will not try to fill deprecated fields in that config
- if a deprecated field was defined `fillConfigRecord` will not populate the new fields that are linked to that deprecated field

### Related PRs:
- (next one) https://github.com/Kong/go-database-reconciler/pull/145

KAG-5577