### PR TITLE
fix: added new method to fetch a consumer-group without consumers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v0.63.0](#v0630)
 - [v0.62.0](#v0620)
 - [v0.61.0](#v0610)
 - [v0.60.0](#v0600)
@@ -76,9 +77,9 @@
 - [0.2.0](#020)
 - [0.1.0](#010)
 
-## Unreleased
+## [v0.63.0]
 
-> Release date: TBA
+> Release date: 2025/01/10
 
 - Added `GetWithNoConsumers` function to AbstractConsumerGroupService
   to allow the fetching a consumer-group without listing its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1001,6 +1001,8 @@ authentication credentials in Kong.
   releases of Kong since every release of Kong is introducing breaking changes
   to the Admin API.
 
+[v0.61.0]: https://github.com/Kong/go-kong/compare/v0.62.0...v0.63.0
+[v0.61.0]: https://github.com/Kong/go-kong/compare/v0.61.0...v0.62.0
 [v0.61.0]: https://github.com/Kong/go-kong/compare/v0.60.0...v0.61.0
 [v0.60.0]: https://github.com/Kong/go-kong/compare/v0.59.1...v0.60.0
 [v0.59.1]: https://github.com/Kong/go-kong/compare/v0.59.0...v0.59.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v0.62.0](#v0620)
 - [v0.61.0](#v0610)
 - [v0.60.0](#v0600)
 - [v0.59.1](#v0591)
@@ -74,6 +75,17 @@
 - [0.3.0](#030)
 - [0.2.0](#020)
 - [0.1.0](#010)
+
+## Unreleased
+
+> Release date: TBA
+
+- Added `GetWithNoConsumers` function to AbstractConsumerGroupService
+  to allow the fetching a consumer-group without listing its
+  consumers. 
+- Reverted `GET /consumer_groups` to older way that lists consumers
+  along with consumer-group information.
+  [#494](https://github.com/Kong/go-kong/pull/494)
 
 ## [v0.62.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1001,8 +1001,8 @@ authentication credentials in Kong.
   releases of Kong since every release of Kong is introducing breaking changes
   to the Admin API.
 
-[v0.61.0]: https://github.com/Kong/go-kong/compare/v0.62.0...v0.63.0
-[v0.61.0]: https://github.com/Kong/go-kong/compare/v0.61.0...v0.62.0
+[v0.63.0]: https://github.com/Kong/go-kong/compare/v0.62.0...v0.63.0
+[v0.62.0]: https://github.com/Kong/go-kong/compare/v0.61.0...v0.62.0
 [v0.61.0]: https://github.com/Kong/go-kong/compare/v0.60.0...v0.61.0
 [v0.60.0]: https://github.com/Kong/go-kong/compare/v0.59.1...v0.60.0
 [v0.59.1]: https://github.com/Kong/go-kong/compare/v0.59.0...v0.59.1

--- a/kong/consumer_group_service.go
+++ b/kong/consumer_group_service.go
@@ -12,6 +12,8 @@ type AbstractConsumerGroupService interface {
 	Create(ctx context.Context, consumerGroup *ConsumerGroup) (*ConsumerGroup, error)
 	// Get fetches a ConsumerGroup from Kong.
 	Get(ctx context.Context, nameOrID *string) (*ConsumerGroupObject, error)
+	// GetWithNoConsumers fetches a ConsumerGroup with no consumers listed from Kong.
+	GetWithNoConsumers(ctx context.Context, nameOrID *string) (*ConsumerGroupObject, error)
 	// Update updates a ConsumerGroup in Kong
 	Update(ctx context.Context, consumerGroup *ConsumerGroup) (*ConsumerGroup, error)
 	// Delete deletes a ConsumerGroup in Kong
@@ -57,6 +59,28 @@ func (s *ConsumerGroupService) Create(ctx context.Context,
 
 // Get fetches a ConsumerGroup from Kong.
 func (s *ConsumerGroupService) Get(ctx context.Context,
+	nameOrID *string,
+) (*ConsumerGroupObject, error) {
+	if isEmptyString(nameOrID) {
+		return nil, fmt.Errorf("nameOrID cannot be nil for Get operation")
+	}
+
+	endpoint := fmt.Sprintf("/consumer_groups/%v", *nameOrID)
+	req, err := s.client.NewRequest("GET", endpoint, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var cg ConsumerGroupObject
+	_, err = s.client.Do(ctx, req, &cg)
+	if err != nil {
+		return nil, err
+	}
+	return &cg, nil
+}
+
+// Get fetches a ConsumerGroup from Kong, but skips the associated consumers.
+func (s *ConsumerGroupService) GetWithNoConsumers(ctx context.Context,
 	nameOrID *string,
 ) (*ConsumerGroupObject, error) {
 	if isEmptyString(nameOrID) {

--- a/kong/consumer_group_test.go
+++ b/kong/consumer_group_test.go
@@ -343,7 +343,7 @@ func TestConsumerGroupGetEndpointPostGW39(t *testing.T) {
 	assert.Equal(response.Consumers[0].Username, createdConsumer.Username)
 	assert.Equal(response.ConsumerGroup.ID, createdConsumerGroup.ID)
 
-	t.Run("Get", func(t *testing.T) {
+	t.Run("Get", func(_ *testing.T) {
 		consumerGroupFromKong, err := client.ConsumerGroups.Get(defaultCtx, createdConsumerGroup.ID)
 		require.NoError(err)
 		assert.NotNil(consumerGroupFromKong)
@@ -352,7 +352,7 @@ func TestConsumerGroupGetEndpointPostGW39(t *testing.T) {
 		assert.Len(consumerGroupFromKong.Consumers, 1, "consumers are listed")
 	})
 
-	t.Run("GetWithNoConsumers", func(t *testing.T) {
+	t.Run("GetWithNoConsumers", func(_ *testing.T) {
 		consumerGroupFromKong, err := client.ConsumerGroups.GetWithNoConsumers(defaultCtx, createdConsumerGroup.ID)
 		require.NoError(err)
 		assert.NotNil(consumerGroupFromKong)

--- a/kong/consumer_group_test.go
+++ b/kong/consumer_group_test.go
@@ -348,6 +348,15 @@ func TestConsumerGroupGetEndpointPostGW39(t *testing.T) {
 	require.NoError(err)
 	assert.NotNil(consumerGroupFromKong)
 	assert.Equal(consumerGroupFromKong.ConsumerGroup.ID, createdConsumerGroup.ID)
-	// Consumers are not listed in a get operation
+	// Consumers are listed
+	assert.NotNil(consumerGroupFromKong.Consumers)
+	assert.Len(consumerGroupFromKong.Consumers, 1)
+
+	// Check GetWithConsumers
+	consumerGroupFromKong, err = client.ConsumerGroups.GetWithNoConsumers(defaultCtx, createdConsumerGroup.ID)
+	require.NoError(err)
+	assert.NotNil(consumerGroupFromKong)
+	assert.Equal(consumerGroupFromKong.ConsumerGroup.ID, createdConsumerGroup.ID)
+	// Consumers are not listed
 	assert.Nil(consumerGroupFromKong.Consumers)
 }

--- a/kong/consumer_group_test.go
+++ b/kong/consumer_group_test.go
@@ -343,20 +343,20 @@ func TestConsumerGroupGetEndpointPostGW39(t *testing.T) {
 	assert.Equal(response.Consumers[0].Username, createdConsumer.Username)
 	assert.Equal(response.ConsumerGroup.ID, createdConsumerGroup.ID)
 
-	// Check get endpoint
-	consumerGroupFromKong, err := client.ConsumerGroups.Get(defaultCtx, createdConsumerGroup.ID)
-	require.NoError(err)
-	assert.NotNil(consumerGroupFromKong)
-	assert.Equal(consumerGroupFromKong.ConsumerGroup.ID, createdConsumerGroup.ID)
-	// Consumers are listed
-	assert.NotNil(consumerGroupFromKong.Consumers)
-	assert.Len(consumerGroupFromKong.Consumers, 1)
+	t.Run("Get", func(t *testing.T) {
+		consumerGroupFromKong, err := client.ConsumerGroups.Get(defaultCtx, createdConsumerGroup.ID)
+		require.NoError(err)
+		assert.NotNil(consumerGroupFromKong)
+		assert.Equal(consumerGroupFromKong.ConsumerGroup.ID, createdConsumerGroup.ID)
+		assert.NotNil(consumerGroupFromKong.Consumers)
+		assert.Len(consumerGroupFromKong.Consumers, 1, "consumers are listed")
+	})
 
-	// Check GetWithConsumers
-	consumerGroupFromKong, err = client.ConsumerGroups.GetWithNoConsumers(defaultCtx, createdConsumerGroup.ID)
-	require.NoError(err)
-	assert.NotNil(consumerGroupFromKong)
-	assert.Equal(consumerGroupFromKong.ConsumerGroup.ID, createdConsumerGroup.ID)
-	// Consumers are not listed
-	assert.Nil(consumerGroupFromKong.Consumers)
+	t.Run("GetWithNoConsumers", func(t *testing.T) {
+		consumerGroupFromKong, err := client.ConsumerGroups.GetWithNoConsumers(defaultCtx, createdConsumerGroup.ID)
+		require.NoError(err)
+		assert.NotNil(consumerGroupFromKong)
+		assert.Equal(consumerGroupFromKong.ConsumerGroup.ID, createdConsumerGroup.ID)
+		assert.Nil(consumerGroupFromKong.Consumers, "consumers should not be listed")
+	})
 }


### PR DESCRIPTION
Reverted the existing `Get` method to keep listing consumers and added a new one that uses the query
parameter `list_consumers=false` to skip listing
consumers for performance reasons.
This is done so as to fix dump errors coming in
deck when using gw 3.9+ where consumer-groups
do not show the associated consumers. We will
push the performant option behind a flag.

For: https://github.com/Kong/deck/issues/1483