### PR TITLE
chore(ci): add 3.9 to test matrix

### DIFF
--- a/.github/workflows/integration-test-enterprise.yaml
+++ b/.github/workflows/integration-test-enterprise.yaml
@@ -77,6 +77,7 @@ jobs:
         - '3.6'
         - '3.7'
         - '3.8'
+        - '3.9'
     env:
       KONG_ROUTER_FLAVOR: ${{ matrix.router_flavor }}
       KONG_IMAGE_TAG: ${{ matrix.kong_version }}

--- a/.github/workflows/integration-test-enterprise.yaml
+++ b/.github/workflows/integration-test-enterprise.yaml
@@ -43,30 +43,12 @@ jobs:
         # since expressions router is supported for Kong >= 3.0.
         # Option router_flavor is ignored for Kong < 3.0.
         exclude:
-          - kong_version: '2.2'
-            router_flavor: 'expressions'
-          - kong_version: '2.3'
-            router_flavor: 'expressions'
-          - kong_version: '2.4'
-            router_flavor: 'expressions'
-          - kong_version: '2.5'
-            router_flavor: 'expressions'
-          - kong_version: '2.6'
-            router_flavor: 'expressions'
-          - kong_version: '2.7'
-            router_flavor: 'expressions'
           - kong_version: '2.8'
             router_flavor: 'expressions'
         router_flavor:
           - 'traditional_compatible'
           - 'expressions'
         kong_version:
-        - '2.2'
-        - '2.3'
-        - '2.4'
-        - '2.5'
-        - '2.6'
-        - '2.7'
         - '2.8'
         - '3.0'
         - '3.1'

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -24,22 +24,6 @@ jobs:
         # since expressions router is supported for Kong >= 3.0.
         # Option router_flavor is ignored for Kong < 3.0.
         exclude:
-          - kong_version: '2.1'
-            router_flavor: 'expressions'
-          - kong_version: '2.2'
-            router_flavor: 'expressions'
-          - kong_version: '2.2'
-            router_flavor: 'expressions'
-          - kong_version: '2.3'
-            router_flavor: 'expressions'
-          - kong_version: '2.4'
-            router_flavor: 'expressions'
-          - kong_version: '2.5'
-            router_flavor: 'expressions'
-          - kong_version: '2.6'
-            router_flavor: 'expressions'
-          - kong_version: '2.7'
-            router_flavor: 'expressions'
           - kong_version: '2.8'
             router_flavor: 'expressions'
         dbmode:
@@ -49,13 +33,6 @@ jobs:
           - 'traditional_compatible'
           - 'expressions'
         kong_version:
-          - '2.1'
-          - '2.2'
-          - '2.3'
-          - '2.4'
-          - '2.5'
-          - '2.6'
-          - '2.7'
           - '2.8'
           - '3.0'
           - '3.1'

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -66,6 +66,7 @@ jobs:
           - '3.6'
           - '3.7'
           - '3.8'
+          - '3.9'
     env:
       KONG_ROUTER_FLAVOR: ${{ matrix.router_flavor }}
       KONG_IMAGE_TAG: ${{ matrix.kong_version }}


### PR DESCRIPTION
This PR adds 3.9 and removes unsupported 2.x versions from the test matrix.