### PR TITLE
Add GetByID interface for credentials - such as ACL, basic auth etc

### DIFF
--- a/kong/acl_service.go
+++ b/kong/acl_service.go
@@ -11,8 +11,8 @@ type AbstractACLService interface {
 	Create(ctx context.Context, consumerUsernameOrID *string, aclGroup *ACLGroup) (*ACLGroup, error)
 	// Get fetches an ACL group for a consumer in Kong.
 	Get(ctx context.Context, consumerUsernameOrID, groupOrID *string) (*ACLGroup, error)
-	// GetById fetches an ACL group by ID.
-	GetById(ctx context.Context, ID *string) (*ACLGroup, error)
+	// GetByID fetches an ACL group by ID.
+	GetByID(ctx context.Context, ID *string) (*ACLGroup, error)
 	// Update updates an ACL group for a consumer in Kong
 	Update(ctx context.Context, consumerUsernameOrID *string, aclGroup *ACLGroup) (*ACLGroup, error)
 	// Delete deletes an ACL group association for a consumer in Kong
@@ -70,11 +70,11 @@ func (s *ACLService) Get(ctx context.Context,
 	return &aclGroup, nil
 }
 
-// GetById fetches an ACL group for a consumer in Kong.
-func (s *ACLService) GetById(ctx context.Context,
+// GetByID fetches an ACL group using its ID
+func (s *ACLService) GetByID(ctx context.Context,
 	ID *string,
 ) (*ACLGroup, error) {
-	cred, err := s.client.credentials.GetById(ctx, "acl",
+	cred, err := s.client.credentials.GetByID(ctx, "acl",
 		ID)
 	if err != nil {
 		return nil, err

--- a/kong/acl_service.go
+++ b/kong/acl_service.go
@@ -11,6 +11,8 @@ type AbstractACLService interface {
 	Create(ctx context.Context, consumerUsernameOrID *string, aclGroup *ACLGroup) (*ACLGroup, error)
 	// Get fetches an ACL group for a consumer in Kong.
 	Get(ctx context.Context, consumerUsernameOrID, groupOrID *string) (*ACLGroup, error)
+	// GetById fetches an ACL group by ID.
+	GetById(ctx context.Context, ID *string) (*ACLGroup, error)
 	// Update updates an ACL group for a consumer in Kong
 	Update(ctx context.Context, consumerUsernameOrID *string, aclGroup *ACLGroup) (*ACLGroup, error)
 	// Delete deletes an ACL group association for a consumer in Kong
@@ -55,6 +57,25 @@ func (s *ACLService) Get(ctx context.Context,
 ) (*ACLGroup, error) {
 	cred, err := s.client.credentials.Get(ctx, "acl",
 		consumerUsernameOrID, groupOrID)
+	if err != nil {
+		return nil, err
+	}
+
+	var aclGroup ACLGroup
+	err = json.Unmarshal(cred, &aclGroup)
+	if err != nil {
+		return nil, err
+	}
+
+	return &aclGroup, nil
+}
+
+// GetById fetches an ACL group for a consumer in Kong.
+func (s *ACLService) GetById(ctx context.Context,
+	ID *string,
+) (*ACLGroup, error) {
+	cred, err := s.client.credentials.GetById(ctx, "acl",
+		ID)
 	if err != nil {
 		return nil, err
 	}

--- a/kong/acl_service.go
+++ b/kong/acl_service.go
@@ -12,7 +12,7 @@ type AbstractACLService interface {
 	// Get fetches an ACL group for a consumer in Kong.
 	Get(ctx context.Context, consumerUsernameOrID, groupOrID *string) (*ACLGroup, error)
 	// GetByID fetches an ACL group by ID.
-	GetByID(ctx context.Context, ID *string) (*ACLGroup, error)
+	GetByID(ctx context.Context, id *string) (*ACLGroup, error)
 	// Update updates an ACL group for a consumer in Kong
 	Update(ctx context.Context, consumerUsernameOrID *string, aclGroup *ACLGroup) (*ACLGroup, error)
 	// Delete deletes an ACL group association for a consumer in Kong
@@ -72,10 +72,10 @@ func (s *ACLService) Get(ctx context.Context,
 
 // GetByID fetches an ACL group using its ID
 func (s *ACLService) GetByID(ctx context.Context,
-	ID *string,
+	id *string,
 ) (*ACLGroup, error) {
 	cred, err := s.client.credentials.GetByID(ctx, "acl",
-		ID)
+		id)
 	if err != nil {
 		return nil, err
 	}

--- a/kong/acl_service_test.go
+++ b/kong/acl_service_test.go
@@ -137,7 +137,7 @@ func TestACLGroupGet(T *testing.T) {
 	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
-func TestACLGroupGetById(T *testing.T) {
+func TestACLGroupGetByID(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
 
 	assert := assert.New(T)
@@ -166,15 +166,15 @@ func TestACLGroupGetById(T *testing.T) {
 	require.NoError(err)
 	assert.NotNil(createdACL)
 
-	aclGroup, err := client.ACLs.GetById(defaultCtx, acl.ID)
+	aclGroup, err := client.ACLs.GetByID(defaultCtx, acl.ID)
 	require.NoError(err)
 	assert.Equal("my-group", *aclGroup.Group)
 
-	aclGroup, err = client.ACLs.GetById(defaultCtx, String("does-not-exist"))
+	aclGroup, err = client.ACLs.GetByID(defaultCtx, String("does-not-exist"))
 	assert.Nil(aclGroup)
 	require.Error(err)
 
-	aclGroup, err = client.ACLs.GetById(defaultCtx, String(""))
+	aclGroup, err = client.ACLs.GetByID(defaultCtx, String(""))
 	assert.Nil(aclGroup)
 	require.Error(err)
 

--- a/kong/acl_service_test.go
+++ b/kong/acl_service_test.go
@@ -137,6 +137,50 @@ func TestACLGroupGet(T *testing.T) {
 	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
+func TestACLGroupGetById(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
+	assert := assert.New(T)
+	require := require.New(T)
+
+	client, err := NewTestClient(nil, nil)
+	require.NoError(err)
+	assert.NotNil(client)
+
+	uuid := uuid.NewString()
+	acl := &ACLGroup{
+		ID:    String(uuid),
+		Group: String("my-group"),
+	}
+
+	// consumer for the ACLGroup
+	consumer := &Consumer{
+		Username: String("foo"),
+	}
+
+	consumer, err = client.Consumers.Create(defaultCtx, consumer)
+	require.NoError(err)
+	require.NotNil(consumer)
+
+	createdACL, err := client.ACLs.Create(defaultCtx, consumer.ID, acl)
+	require.NoError(err)
+	assert.NotNil(createdACL)
+
+	aclGroup, err := client.ACLs.GetById(defaultCtx, acl.ID)
+	require.NoError(err)
+	assert.Equal("my-group", *aclGroup.Group)
+
+	aclGroup, err = client.ACLs.GetById(defaultCtx, String("does-not-exist"))
+	assert.Nil(aclGroup)
+	require.Error(err)
+
+	aclGroup, err = client.ACLs.GetById(defaultCtx, String(""))
+	assert.Nil(aclGroup)
+	require.Error(err)
+
+	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
+}
+
 func TestACLGroupUpdate(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
 

--- a/kong/acl_service_test.go
+++ b/kong/acl_service_test.go
@@ -137,14 +137,12 @@ func TestACLGroupGet(T *testing.T) {
 	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
-func TestACLGroupGetByID(T *testing.T) {
-	RunWhenDBMode(T, "postgres")
-
-	require := require.New(T)
+func TestACLGroupGetByID(t *testing.T) {
+	RunWhenDBMode(t, "postgres")
 
 	client, err := NewTestClient(nil, nil)
-	require.NoError(err)
-	require.NotNil(client)
+	require.NoError(t, err)
+	require.NotNil(t, client)
 
 	uuid := uuid.NewString()
 	acl := &ACLGroup{
@@ -158,34 +156,34 @@ func TestACLGroupGetByID(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	require.NoError(err)
-	require.NotNil(consumer)
+	require.NoError(t, err)
+	require.NotNil(t, consumer)
 
 	createdACL, err := client.ACLs.Create(defaultCtx, consumer.ID, acl)
-	require.NoError(err)
-	require.NotNil(createdACL)
+	require.NoError(t, err)
+	require.NotNil(t, createdACL)
 
-	T.Cleanup(func() {
-		require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
+	t.Cleanup(func() {
+		require.NoError(t, client.Consumers.Delete(defaultCtx, consumer.ID))
 	})
 
-	T.Run("successful ACL retrieval by ID", func(_ *testing.T) {
+	t.Run("successful ACL retrieval by ID", func(_ *testing.T) {
 		aclGroup, err := client.ACLs.GetByID(defaultCtx, acl.ID)
-		require.NoError(err)
-		require.NotNil(aclGroup)
-		require.Equal("my-group", *aclGroup.Group)
+		require.NoError(t, err)
+		require.NotNil(t, aclGroup)
+		require.Equal(t, "my-group", *aclGroup.Group)
 	})
 
-	T.Run("unsuccessful ACL retrieval using invalid ID", func(_ *testing.T) {
+	t.Run("unsuccessful ACL retrieval using invalid ID", func(_ *testing.T) {
 		aclGroup, err := client.ACLs.GetByID(defaultCtx, String("does-not-exist"))
-		require.Nil(aclGroup)
-		require.Error(err)
+		require.Nil(t, aclGroup)
+		require.Error(t, err)
 	})
 
-	T.Run("unsuccessful ACL retrieval using empty string", func(_ *testing.T) {
+	t.Run("unsuccessful ACL retrieval using empty string", func(_ *testing.T) {
 		aclGroup, err := client.ACLs.GetByID(defaultCtx, String(""))
-		require.Nil(aclGroup)
-		require.Error(err)
+		require.Nil(t, aclGroup)
+		require.Error(t, err)
 	})
 }
 

--- a/kong/acl_service_test.go
+++ b/kong/acl_service_test.go
@@ -167,20 +167,20 @@ func TestACLGroupGetByID(t *testing.T) {
 		require.NoError(t, client.Consumers.Delete(defaultCtx, consumer.ID))
 	})
 
-	t.Run("successful ACL retrieval by ID", func(_ *testing.T) {
+	t.Run("successful ACL retrieval by ID", func(t *testing.T) {
 		aclGroup, err := client.ACLs.GetByID(defaultCtx, acl.ID)
 		require.NoError(t, err)
 		require.NotNil(t, aclGroup)
 		require.Equal(t, "my-group", *aclGroup.Group)
 	})
 
-	t.Run("unsuccessful ACL retrieval using invalid ID", func(_ *testing.T) {
+	t.Run("unsuccessful ACL retrieval using invalid ID", func(t *testing.T) {
 		aclGroup, err := client.ACLs.GetByID(defaultCtx, String("does-not-exist"))
 		require.Nil(t, aclGroup)
 		require.Error(t, err)
 	})
 
-	t.Run("unsuccessful ACL retrieval using empty string", func(_ *testing.T) {
+	t.Run("unsuccessful ACL retrieval using empty string", func(t *testing.T) {
 		aclGroup, err := client.ACLs.GetByID(defaultCtx, String(""))
 		require.Nil(t, aclGroup)
 		require.Error(t, err)

--- a/kong/basic_auth_service.go
+++ b/kong/basic_auth_service.go
@@ -12,8 +12,8 @@ type AbstractBasicAuthService interface {
 	Create(ctx context.Context, consumerUsernameOrID *string, basicAuth *BasicAuth) (*BasicAuth, error)
 	// Get fetches a basic-auth credential from Kong.
 	Get(ctx context.Context, consumerUsernameOrID, usernameOrID *string) (*BasicAuth, error)
-	// GetById fetches a basic-auth credential from Kong using basicAuthIdentifier.
-	GetById(ctx context.Context, usernameOrID *string) (*BasicAuth, error)
+	// GetByID fetches a basic-auth credential from Kong using ID.
+	GetByID(ctx context.Context, ID *string) (*BasicAuth, error)
 	// Update updates a basic-auth credential in Kong
 	Update(ctx context.Context, consumerUsernameOrID *string, basicAuth *BasicAuth) (*BasicAuth, error)
 	// Delete deletes a basic-auth credential in Kong
@@ -71,12 +71,12 @@ func (s *BasicAuthService) Get(ctx context.Context,
 	return &basicAuth, nil
 }
 
-// GetById fetches a basic-auth credential from Kong using basicAuthIdentifier.
-func (s *BasicAuthService) GetById(ctx context.Context,
-	usernameOrID *string,
+// GetByID fetches a basic-auth credential from Kong using ID.
+func (s *BasicAuthService) GetByID(ctx context.Context,
+	ID *string,
 ) (*BasicAuth, error) {
-	cred, err := s.client.credentials.GetById(ctx, "basic-auth",
-		usernameOrID)
+	cred, err := s.client.credentials.GetByID(ctx, "basic-auth",
+		ID)
 	if err != nil {
 		return nil, err
 	}

--- a/kong/basic_auth_service.go
+++ b/kong/basic_auth_service.go
@@ -12,6 +12,8 @@ type AbstractBasicAuthService interface {
 	Create(ctx context.Context, consumerUsernameOrID *string, basicAuth *BasicAuth) (*BasicAuth, error)
 	// Get fetches a basic-auth credential from Kong.
 	Get(ctx context.Context, consumerUsernameOrID, usernameOrID *string) (*BasicAuth, error)
+	// GetById fetches a basic-auth credential from Kong using basicAuthIdentifier.
+	GetById(ctx context.Context, usernameOrID *string) (*BasicAuth, error)
 	// Update updates a basic-auth credential in Kong
 	Update(ctx context.Context, consumerUsernameOrID *string, basicAuth *BasicAuth) (*BasicAuth, error)
 	// Delete deletes a basic-auth credential in Kong
@@ -56,6 +58,25 @@ func (s *BasicAuthService) Get(ctx context.Context,
 ) (*BasicAuth, error) {
 	cred, err := s.client.credentials.Get(ctx, "basic-auth",
 		consumerUsernameOrID, usernameOrID)
+	if err != nil {
+		return nil, err
+	}
+
+	var basicAuth BasicAuth
+	err = json.Unmarshal(cred, &basicAuth)
+	if err != nil {
+		return nil, err
+	}
+
+	return &basicAuth, nil
+}
+
+// GetById fetches a basic-auth credential from Kong using basicAuthIdentifier.
+func (s *BasicAuthService) GetById(ctx context.Context,
+	usernameOrID *string,
+) (*BasicAuth, error) {
+	cred, err := s.client.credentials.GetById(ctx, "basic-auth",
+		usernameOrID)
 	if err != nil {
 		return nil, err
 	}

--- a/kong/basic_auth_service.go
+++ b/kong/basic_auth_service.go
@@ -13,7 +13,7 @@ type AbstractBasicAuthService interface {
 	// Get fetches a basic-auth credential from Kong.
 	Get(ctx context.Context, consumerUsernameOrID, usernameOrID *string) (*BasicAuth, error)
 	// GetByID fetches a basic-auth credential from Kong using ID.
-	GetByID(ctx context.Context, ID *string) (*BasicAuth, error)
+	GetByID(ctx context.Context, id *string) (*BasicAuth, error)
 	// Update updates a basic-auth credential in Kong
 	Update(ctx context.Context, consumerUsernameOrID *string, basicAuth *BasicAuth) (*BasicAuth, error)
 	// Delete deletes a basic-auth credential in Kong
@@ -73,10 +73,10 @@ func (s *BasicAuthService) Get(ctx context.Context,
 
 // GetByID fetches a basic-auth credential from Kong using ID.
 func (s *BasicAuthService) GetByID(ctx context.Context,
-	ID *string,
+	id *string,
 ) (*BasicAuth, error) {
 	cred, err := s.client.credentials.GetByID(ctx, "basic-auth",
-		ID)
+		id)
 	if err != nil {
 		return nil, err
 	}

--- a/kong/basic_auth_service_test.go
+++ b/kong/basic_auth_service_test.go
@@ -155,14 +155,12 @@ func TestBasicAuthGet(T *testing.T) {
 	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
-func TestBasicAuthGetByID(T *testing.T) {
-	RunWhenDBMode(T, "postgres")
-
-	require := require.New(T)
+func TestBasicAuthGetByID(t *testing.T) {
+	RunWhenDBMode(t, "postgres")
 
 	client, err := NewTestClient(nil, nil)
-	require.NoError(err)
-	require.NotNil(client)
+	require.NoError(t, err)
+	require.NotNil(t, client)
 
 	uuid := uuid.NewString()
 	basicAuth := &BasicAuth{
@@ -177,35 +175,35 @@ func TestBasicAuthGetByID(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	require.NoError(err)
-	require.NotNil(consumer)
+	require.NoError(t, err)
+	require.NotNil(t, consumer)
 
 	createdBasicAuth, err := client.BasicAuths.Create(defaultCtx,
 		consumer.ID, basicAuth)
-	require.NoError(err)
-	require.NotNil(createdBasicAuth)
+	require.NoError(t, err)
+	require.NotNil(t, createdBasicAuth)
 
-	T.Cleanup(func() {
-		require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
+	t.Cleanup(func() {
+		require.NoError(t, client.Consumers.Delete(defaultCtx, consumer.ID))
 	})
 
-	T.Run("successful basic-auth retrieval by ID", func(_ *testing.T) {
+	t.Run("successful basic-auth retrieval by ID", func(_ *testing.T) {
 		basicAuth, err = client.BasicAuths.GetByID(defaultCtx, basicAuth.ID)
-		require.NoError(err)
-		require.NotNil(basicAuth)
-		require.Equal("my-username", *basicAuth.Username)
+		require.NoError(t, err)
+		require.NotNil(t, basicAuth)
+		require.Equal(t, "my-username", *basicAuth.Username)
 	})
 
-	T.Run("unsuccessful basic-auth retrieval using invalid ID", func(_ *testing.T) {
+	t.Run("unsuccessful basic-auth retrieval using invalid ID", func(_ *testing.T) {
 		basicAuth, err = client.BasicAuths.GetByID(defaultCtx, String("does-not-exist"))
-		require.Nil(basicAuth)
-		require.Error(err)
+		require.Nil(t, basicAuth)
+		require.Error(t, err)
 	})
 
-	T.Run("unsuccessful basic-auth retrieval using empty string as ID", func(_ *testing.T) {
+	t.Run("unsuccessful basic-auth retrieval using empty string as ID", func(_ *testing.T) {
 		basicAuth, err = client.BasicAuths.GetByID(defaultCtx, String(""))
-		require.Nil(basicAuth)
-		require.Error(err)
+		require.Nil(t, basicAuth)
+		require.Error(t, err)
 	})
 }
 

--- a/kong/basic_auth_service_test.go
+++ b/kong/basic_auth_service_test.go
@@ -155,6 +155,52 @@ func TestBasicAuthGet(T *testing.T) {
 	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
+func TestBasicAuthGetById(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
+	assert := assert.New(T)
+	require := require.New(T)
+
+	client, err := NewTestClient(nil, nil)
+	require.NoError(err)
+	assert.NotNil(client)
+
+	uuid := uuid.NewString()
+	basicAuth := &BasicAuth{
+		ID:       String(uuid),
+		Username: String("my-username"),
+		Password: String("my-password"),
+	}
+
+	// consumer for the basic-auth:
+	consumer := &Consumer{
+		Username: String("foo"),
+	}
+
+	consumer, err = client.Consumers.Create(defaultCtx, consumer)
+	require.NoError(err)
+	require.NotNil(consumer)
+
+	createdBasicAuth, err := client.BasicAuths.Create(defaultCtx,
+		consumer.ID, basicAuth)
+	require.NoError(err)
+	assert.NotNil(createdBasicAuth)
+
+	basicAuth, err = client.BasicAuths.GetById(defaultCtx, basicAuth.ID)
+	require.NoError(err)
+	assert.Equal("my-username", *basicAuth.Username)
+
+	basicAuth, err = client.BasicAuths.GetById(defaultCtx, String("does-not-exist"))
+	assert.Nil(basicAuth)
+	require.Error(err)
+
+	basicAuth, err = client.BasicAuths.GetById(defaultCtx, String(""))
+	assert.Nil(basicAuth)
+	require.Error(err)
+
+	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
+}
+
 func TestBasicAuthUpdate(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
 

--- a/kong/basic_auth_service_test.go
+++ b/kong/basic_auth_service_test.go
@@ -187,20 +187,20 @@ func TestBasicAuthGetByID(t *testing.T) {
 		require.NoError(t, client.Consumers.Delete(defaultCtx, consumer.ID))
 	})
 
-	t.Run("successful basic-auth retrieval by ID", func(_ *testing.T) {
+	t.Run("successful basic-auth retrieval by ID", func(t *testing.T) {
 		basicAuth, err = client.BasicAuths.GetByID(defaultCtx, basicAuth.ID)
 		require.NoError(t, err)
 		require.NotNil(t, basicAuth)
 		require.Equal(t, "my-username", *basicAuth.Username)
 	})
 
-	t.Run("unsuccessful basic-auth retrieval using invalid ID", func(_ *testing.T) {
+	t.Run("unsuccessful basic-auth retrieval using invalid ID", func(t *testing.T) {
 		basicAuth, err = client.BasicAuths.GetByID(defaultCtx, String("does-not-exist"))
 		require.Nil(t, basicAuth)
 		require.Error(t, err)
 	})
 
-	t.Run("unsuccessful basic-auth retrieval using empty string as ID", func(_ *testing.T) {
+	t.Run("unsuccessful basic-auth retrieval using empty string as ID", func(t *testing.T) {
 		basicAuth, err = client.BasicAuths.GetByID(defaultCtx, String(""))
 		require.Nil(t, basicAuth)
 		require.Error(t, err)

--- a/kong/basic_auth_service_test.go
+++ b/kong/basic_auth_service_test.go
@@ -155,7 +155,7 @@ func TestBasicAuthGet(T *testing.T) {
 	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
-func TestBasicAuthGetById(T *testing.T) {
+func TestBasicAuthGetByID(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
 
 	assert := assert.New(T)
@@ -186,15 +186,15 @@ func TestBasicAuthGetById(T *testing.T) {
 	require.NoError(err)
 	assert.NotNil(createdBasicAuth)
 
-	basicAuth, err = client.BasicAuths.GetById(defaultCtx, basicAuth.ID)
+	basicAuth, err = client.BasicAuths.GetByID(defaultCtx, basicAuth.ID)
 	require.NoError(err)
 	assert.Equal("my-username", *basicAuth.Username)
 
-	basicAuth, err = client.BasicAuths.GetById(defaultCtx, String("does-not-exist"))
+	basicAuth, err = client.BasicAuths.GetByID(defaultCtx, String("does-not-exist"))
 	assert.Nil(basicAuth)
 	require.Error(err)
 
-	basicAuth, err = client.BasicAuths.GetById(defaultCtx, String(""))
+	basicAuth, err = client.BasicAuths.GetByID(defaultCtx, String(""))
 	assert.Nil(basicAuth)
 	require.Error(err)
 

--- a/kong/credentials_service.go
+++ b/kong/credentials_service.go
@@ -12,9 +12,11 @@ type abstractCredentialService interface {
 	// Create creates a credential in Kong of type credType.
 	Create(ctx context.Context, credType string, consumerUsernameOrID *string,
 		credential interface{}) (json.RawMessage, error)
-	// Get fetches a credential of credType with credIdentifier from Kong.
+	// Get fetches a credential of credType with consumerIdentifier and credIdentifier from Kong.
 	Get(ctx context.Context, credType string, consumerUsernameOrID *string,
 		credIdentifier *string) (json.RawMessage, error)
+	// Get fetches a credential of credType with credIdentifier from Kong.
+	GetById(ctx context.Context, credType string, credIdentifier *string) (json.RawMessage, error)
 	// Update updates credential in Kong
 	Update(ctx context.Context, credType string, consumerUsernameOrID *string,
 		credential interface{}) (json.RawMessage, error)
@@ -33,6 +35,16 @@ var credPath = map[string]string{
 	"acl":        "acls",
 	"oauth2":     "oauth2",
 	"mtls-auth":  "mtls-auth",
+}
+
+var credPathAsParentResource = map[string]string{
+	"key-auth":   "key-auths",
+	"basic-auth": "basic-auths",
+	"hmac-auth":  "hmac-auths",
+	"jwt-auth":   "jwts",
+	"acl":        "acls",
+	"oauth2":     "oauth2",
+	"mtls-auth":  "mtls-auths",
 }
 
 // Create creates a credential in Kong of type credType.
@@ -78,7 +90,7 @@ func (s *credentialService) Create(ctx context.Context, credType string,
 	return createdCredential, nil
 }
 
-// Get fetches a credential of credType with credIdentifier from Kong.
+// Get fetches a credential of credType with credIdentifier and consumerIdentifier from Kong.
 func (s *credentialService) Get(ctx context.Context, credType string,
 	consumerUsernameOrID *string,
 	credIdentifier *string,
@@ -95,6 +107,32 @@ func (s *credentialService) Get(ctx context.Context, credType string,
 		return nil, fmt.Errorf("unknown credential type: %v", credType)
 	}
 	endpoint := "/consumers/" + *consumerUsernameOrID + "/" +
+		subPath + "/" + *credIdentifier
+	req, err := s.client.NewRequest("GET", endpoint, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var cred json.RawMessage
+	_, err = s.client.Do(ctx, req, &cred)
+	if err != nil {
+		return nil, err
+	}
+	return cred, nil
+}
+
+// GetById fetches a credential of credType with credIdentifier from Kong.
+func (s *credentialService) GetById(ctx context.Context, credType string, credIdentifier *string,
+) (json.RawMessage, error) {
+	if isEmptyString(credIdentifier) {
+		return nil, fmt.Errorf("credIdentifier cannot be nil for GetById operation")
+	}
+
+	subPath, ok := credPathAsParentResource[credType]
+	if !ok {
+		return nil, fmt.Errorf("unknown credential type: %v", credType)
+	}
+	endpoint := "/" +
 		subPath + "/" + *credIdentifier
 	req, err := s.client.NewRequest("GET", endpoint, nil, nil)
 	if err != nil {

--- a/kong/credentials_service.go
+++ b/kong/credentials_service.go
@@ -15,8 +15,8 @@ type abstractCredentialService interface {
 	// Get fetches a credential of credType with consumerIdentifier and credIdentifier from Kong.
 	Get(ctx context.Context, credType string, consumerUsernameOrID *string,
 		credIdentifier *string) (json.RawMessage, error)
-	// Get fetches a credential of credType with credIdentifier from Kong.
-	GetById(ctx context.Context, credType string, credIdentifier *string) (json.RawMessage, error)
+	// GetByID fetches a credential of credType with ID from Kong.
+	GetByID(ctx context.Context, credType string, credIdentifier *string) (json.RawMessage, error)
 	// Update updates credential in Kong
 	Update(ctx context.Context, credType string, consumerUsernameOrID *string,
 		credential interface{}) (json.RawMessage, error)
@@ -121,11 +121,11 @@ func (s *credentialService) Get(ctx context.Context, credType string,
 	return cred, nil
 }
 
-// GetById fetches a credential of credType with credIdentifier from Kong.
-func (s *credentialService) GetById(ctx context.Context, credType string, credIdentifier *string,
+// GetByID fetches a credential of credType with ID from Kong.
+func (s *credentialService) GetByID(ctx context.Context, credType string, credIdentifier *string,
 ) (json.RawMessage, error) {
 	if isEmptyString(credIdentifier) {
-		return nil, fmt.Errorf("credIdentifier cannot be nil for GetById operation")
+		return nil, fmt.Errorf("credIdentifier cannot be nil for GetByID operation")
 	}
 
 	subPath, ok := credPathAsParentResource[credType]

--- a/kong/hmac_auth_service.go
+++ b/kong/hmac_auth_service.go
@@ -11,8 +11,8 @@ type AbstractHMACAuthService interface {
 	Create(ctx context.Context, consumerUsernameOrID *string, hmacAuth *HMACAuth) (*HMACAuth, error)
 	// Get fetches a hmac-auth credential from Kong.
 	Get(ctx context.Context, consumerUsernameOrID, usernameOrID *string) (*HMACAuth, error)
-	// GetById fetches a hmac-auth credential from Kong using hmac-auth-identifier.
-	GetById(ctx context.Context, usernameOrID *string) (*HMACAuth, error)
+	// GetByID fetches a hmac-auth credential from Kong using hmac-auth ID.
+	GetByID(ctx context.Context, ID *string) (*HMACAuth, error)
 	// Update updates a hmac-auth credential in Kong
 	Update(ctx context.Context, consumerUsernameOrID *string, hmacAuth *HMACAuth) (*HMACAuth, error)
 	// Delete deletes a hmac-auth credential in Kong
@@ -70,11 +70,11 @@ func (s *HMACAuthService) Get(ctx context.Context,
 	return &hmacAuth, nil
 }
 
-// GetById fetches a hmac-auth credential from Kong using ID.
-func (s *HMACAuthService) GetById(ctx context.Context,
+// GetByID fetches a hmac-auth credential from Kong using ID.
+func (s *HMACAuthService) GetByID(ctx context.Context,
 	ID *string,
 ) (*HMACAuth, error) {
-	cred, err := s.client.credentials.GetById(ctx, "hmac-auth", ID)
+	cred, err := s.client.credentials.GetByID(ctx, "hmac-auth", ID)
 	if err != nil {
 		return nil, err
 	}

--- a/kong/hmac_auth_service.go
+++ b/kong/hmac_auth_service.go
@@ -12,7 +12,7 @@ type AbstractHMACAuthService interface {
 	// Get fetches a hmac-auth credential from Kong.
 	Get(ctx context.Context, consumerUsernameOrID, usernameOrID *string) (*HMACAuth, error)
 	// GetByID fetches a hmac-auth credential from Kong using hmac-auth ID.
-	GetByID(ctx context.Context, ID *string) (*HMACAuth, error)
+	GetByID(ctx context.Context, id *string) (*HMACAuth, error)
 	// Update updates a hmac-auth credential in Kong
 	Update(ctx context.Context, consumerUsernameOrID *string, hmacAuth *HMACAuth) (*HMACAuth, error)
 	// Delete deletes a hmac-auth credential in Kong
@@ -72,9 +72,9 @@ func (s *HMACAuthService) Get(ctx context.Context,
 
 // GetByID fetches a hmac-auth credential from Kong using ID.
 func (s *HMACAuthService) GetByID(ctx context.Context,
-	ID *string,
+	id *string,
 ) (*HMACAuth, error) {
-	cred, err := s.client.credentials.GetByID(ctx, "hmac-auth", ID)
+	cred, err := s.client.credentials.GetByID(ctx, "hmac-auth", id)
 	if err != nil {
 		return nil, err
 	}

--- a/kong/hmac_auth_service.go
+++ b/kong/hmac_auth_service.go
@@ -11,6 +11,8 @@ type AbstractHMACAuthService interface {
 	Create(ctx context.Context, consumerUsernameOrID *string, hmacAuth *HMACAuth) (*HMACAuth, error)
 	// Get fetches a hmac-auth credential from Kong.
 	Get(ctx context.Context, consumerUsernameOrID, usernameOrID *string) (*HMACAuth, error)
+	// GetById fetches a hmac-auth credential from Kong using hmac-auth-identifier.
+	GetById(ctx context.Context, usernameOrID *string) (*HMACAuth, error)
 	// Update updates a hmac-auth credential in Kong
 	Update(ctx context.Context, consumerUsernameOrID *string, hmacAuth *HMACAuth) (*HMACAuth, error)
 	// Delete deletes a hmac-auth credential in Kong
@@ -55,6 +57,24 @@ func (s *HMACAuthService) Get(ctx context.Context,
 ) (*HMACAuth, error) {
 	cred, err := s.client.credentials.Get(ctx, "hmac-auth",
 		consumerUsernameOrID, usernameOrID)
+	if err != nil {
+		return nil, err
+	}
+
+	var hmacAuth HMACAuth
+	err = json.Unmarshal(cred, &hmacAuth)
+	if err != nil {
+		return nil, err
+	}
+
+	return &hmacAuth, nil
+}
+
+// GetById fetches a hmac-auth credential from Kong using ID.
+func (s *HMACAuthService) GetById(ctx context.Context,
+	ID *string,
+) (*HMACAuth, error) {
+	cred, err := s.client.credentials.GetById(ctx, "hmac-auth", ID)
 	if err != nil {
 		return nil, err
 	}

--- a/kong/hmac_auth_service_test.go
+++ b/kong/hmac_auth_service_test.go
@@ -144,6 +144,51 @@ func TestHMACAuthGet(T *testing.T) {
 	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
+func TestHMACAuthGetById(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
+	assert := assert.New(T)
+	require := require.New(T)
+
+	client, err := NewTestClient(nil, nil)
+	require.NoError(err)
+	assert.NotNil(client)
+
+	uuid := uuid.NewString()
+	hmacAuth := &HMACAuth{
+		ID:       String(uuid),
+		Username: String("my-username"),
+	}
+
+	// consumer for the hmac-auth:
+	consumer := &Consumer{
+		Username: String("foo"),
+	}
+
+	consumer, err = client.Consumers.Create(defaultCtx, consumer)
+	require.NoError(err)
+	require.NotNil(consumer)
+
+	createdHMACAuth, err := client.HMACAuths.Create(defaultCtx,
+		consumer.ID, hmacAuth)
+	require.NoError(err)
+	assert.NotNil(createdHMACAuth)
+
+	hmacAuth, err = client.HMACAuths.GetById(defaultCtx, hmacAuth.ID)
+	require.NoError(err)
+	assert.Equal("my-username", *hmacAuth.Username)
+
+	hmacAuth, err = client.HMACAuths.GetById(defaultCtx, String("does-not-exist"))
+	assert.Nil(hmacAuth)
+	require.Error(err)
+
+	hmacAuth, err = client.HMACAuths.GetById(defaultCtx, String(""))
+	assert.Nil(hmacAuth)
+	require.Error(err)
+
+	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
+}
+
 func TestHMACAuthUpdate(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
 

--- a/kong/hmac_auth_service_test.go
+++ b/kong/hmac_auth_service_test.go
@@ -144,7 +144,7 @@ func TestHMACAuthGet(T *testing.T) {
 	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
-func TestHMACAuthGetById(T *testing.T) {
+func TestHMACAuthGetByID(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
 
 	assert := assert.New(T)
@@ -174,15 +174,15 @@ func TestHMACAuthGetById(T *testing.T) {
 	require.NoError(err)
 	assert.NotNil(createdHMACAuth)
 
-	hmacAuth, err = client.HMACAuths.GetById(defaultCtx, hmacAuth.ID)
+	hmacAuth, err = client.HMACAuths.GetByID(defaultCtx, hmacAuth.ID)
 	require.NoError(err)
 	assert.Equal("my-username", *hmacAuth.Username)
 
-	hmacAuth, err = client.HMACAuths.GetById(defaultCtx, String("does-not-exist"))
+	hmacAuth, err = client.HMACAuths.GetByID(defaultCtx, String("does-not-exist"))
 	assert.Nil(hmacAuth)
 	require.Error(err)
 
-	hmacAuth, err = client.HMACAuths.GetById(defaultCtx, String(""))
+	hmacAuth, err = client.HMACAuths.GetByID(defaultCtx, String(""))
 	assert.Nil(hmacAuth)
 	require.Error(err)
 

--- a/kong/hmac_auth_service_test.go
+++ b/kong/hmac_auth_service_test.go
@@ -144,14 +144,12 @@ func TestHMACAuthGet(T *testing.T) {
 	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
-func TestHMACAuthGetByID(T *testing.T) {
-	RunWhenDBMode(T, "postgres")
-
-	require := require.New(T)
+func TestHMACAuthGetByID(t *testing.T) {
+	RunWhenDBMode(t, "postgres")
 
 	client, err := NewTestClient(nil, nil)
-	require.NoError(err)
-	require.NotNil(client)
+	require.NoError(t, err)
+	require.NotNil(t, client)
 
 	uuid := uuid.NewString()
 	hmacAuth := &HMACAuth{
@@ -165,35 +163,35 @@ func TestHMACAuthGetByID(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	require.NoError(err)
-	require.NotNil(consumer)
+	require.NoError(t, err)
+	require.NotNil(t, consumer)
 
 	createdHMACAuth, err := client.HMACAuths.Create(defaultCtx,
 		consumer.ID, hmacAuth)
-	require.NoError(err)
-	require.NotNil(createdHMACAuth)
+	require.NoError(t, err)
+	require.NotNil(t, createdHMACAuth)
 
-	T.Cleanup(func() {
-		require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
+	t.Cleanup(func() {
+		require.NoError(t, client.Consumers.Delete(defaultCtx, consumer.ID))
 	})
 
-	T.Run("successful hmac-auth retrieval by ID", func(_ *testing.T) {
+	t.Run("successful hmac-auth retrieval by ID", func(_ *testing.T) {
 		hmacAuth, err = client.HMACAuths.GetByID(defaultCtx, hmacAuth.ID)
-		require.NoError(err)
-		require.NotNil(hmacAuth)
-		require.Equal("my-username", *hmacAuth.Username)
+		require.NoError(t, err)
+		require.NotNil(t, hmacAuth)
+		require.Equal(t, "my-username", *hmacAuth.Username)
 	})
 
-	T.Run("unsuccessful hmac-auth retrieval by ID", func(_ *testing.T) {
+	t.Run("unsuccessful hmac-auth retrieval by ID", func(_ *testing.T) {
 		hmacAuth, err = client.HMACAuths.GetByID(defaultCtx, String("does-not-exist"))
-		require.Nil(hmacAuth)
-		require.Error(err)
+		require.Nil(t, hmacAuth)
+		require.Error(t, err)
 	})
 
-	T.Run("unsuccessful hmac-auth retrieval when empty string is passed", func(_ *testing.T) {
+	t.Run("unsuccessful hmac-auth retrieval when empty string is passed", func(_ *testing.T) {
 		hmacAuth, err = client.HMACAuths.GetByID(defaultCtx, String(""))
-		require.Nil(hmacAuth)
-		require.Error(err)
+		require.Nil(t, hmacAuth)
+		require.Error(t, err)
 	})
 }
 

--- a/kong/hmac_auth_service_test.go
+++ b/kong/hmac_auth_service_test.go
@@ -175,20 +175,20 @@ func TestHMACAuthGetByID(t *testing.T) {
 		require.NoError(t, client.Consumers.Delete(defaultCtx, consumer.ID))
 	})
 
-	t.Run("successful hmac-auth retrieval by ID", func(_ *testing.T) {
+	t.Run("successful hmac-auth retrieval by ID", func(t *testing.T) {
 		hmacAuth, err = client.HMACAuths.GetByID(defaultCtx, hmacAuth.ID)
 		require.NoError(t, err)
 		require.NotNil(t, hmacAuth)
 		require.Equal(t, "my-username", *hmacAuth.Username)
 	})
 
-	t.Run("unsuccessful hmac-auth retrieval by ID", func(_ *testing.T) {
+	t.Run("unsuccessful hmac-auth retrieval by ID", func(t *testing.T) {
 		hmacAuth, err = client.HMACAuths.GetByID(defaultCtx, String("does-not-exist"))
 		require.Nil(t, hmacAuth)
 		require.Error(t, err)
 	})
 
-	t.Run("unsuccessful hmac-auth retrieval when empty string is passed", func(_ *testing.T) {
+	t.Run("unsuccessful hmac-auth retrieval when empty string is passed", func(t *testing.T) {
 		hmacAuth, err = client.HMACAuths.GetByID(defaultCtx, String(""))
 		require.Nil(t, hmacAuth)
 		require.Error(t, err)

--- a/kong/jwt_auth_service.go
+++ b/kong/jwt_auth_service.go
@@ -11,6 +11,8 @@ type AbstractJWTAuthService interface {
 	Create(ctx context.Context, consumerUsernameOrID *string, jwtAuth *JWTAuth) (*JWTAuth, error)
 	// Get fetches a JWT credential from Kong.
 	Get(ctx context.Context, consumerUsernameOrID, keyOrID *string) (*JWTAuth, error)
+	// GetById fetches a JWT credential from Kong.
+	GetById(ctx context.Context, ID *string) (*JWTAuth, error)
 	// Update updates a JWT credential in Kong
 	Update(ctx context.Context, consumerUsernameOrID *string, jwtAuth *JWTAuth) (*JWTAuth, error)
 	// Delete deletes a JWT credential in Kong
@@ -55,6 +57,25 @@ func (s *JWTAuthService) Get(ctx context.Context,
 ) (*JWTAuth, error) {
 	cred, err := s.client.credentials.Get(ctx, "jwt-auth",
 		consumerUsernameOrID, keyOrID)
+	if err != nil {
+		return nil, err
+	}
+
+	var jwtAuth JWTAuth
+	err = json.Unmarshal(cred, &jwtAuth)
+	if err != nil {
+		return nil, err
+	}
+
+	return &jwtAuth, nil
+}
+
+// GetById fetches a JWT credential from Kong using ID.
+func (s *JWTAuthService) GetById(ctx context.Context,
+	ID *string,
+) (*JWTAuth, error) {
+	cred, err := s.client.credentials.GetById(ctx, "jwt-auth",
+		ID)
 	if err != nil {
 		return nil, err
 	}

--- a/kong/jwt_auth_service.go
+++ b/kong/jwt_auth_service.go
@@ -11,8 +11,8 @@ type AbstractJWTAuthService interface {
 	Create(ctx context.Context, consumerUsernameOrID *string, jwtAuth *JWTAuth) (*JWTAuth, error)
 	// Get fetches a JWT credential from Kong.
 	Get(ctx context.Context, consumerUsernameOrID, keyOrID *string) (*JWTAuth, error)
-	// GetById fetches a JWT credential from Kong.
-	GetById(ctx context.Context, ID *string) (*JWTAuth, error)
+	// GetByID fetches a JWT credential from Kong using ID.
+	GetByID(ctx context.Context, ID *string) (*JWTAuth, error)
 	// Update updates a JWT credential in Kong
 	Update(ctx context.Context, consumerUsernameOrID *string, jwtAuth *JWTAuth) (*JWTAuth, error)
 	// Delete deletes a JWT credential in Kong
@@ -70,11 +70,11 @@ func (s *JWTAuthService) Get(ctx context.Context,
 	return &jwtAuth, nil
 }
 
-// GetById fetches a JWT credential from Kong using ID.
-func (s *JWTAuthService) GetById(ctx context.Context,
+// GetByID fetches a JWT credential from Kong using ID.
+func (s *JWTAuthService) GetByID(ctx context.Context,
 	ID *string,
 ) (*JWTAuth, error) {
-	cred, err := s.client.credentials.GetById(ctx, "jwt-auth",
+	cred, err := s.client.credentials.GetByID(ctx, "jwt-auth",
 		ID)
 	if err != nil {
 		return nil, err

--- a/kong/jwt_auth_service.go
+++ b/kong/jwt_auth_service.go
@@ -12,7 +12,7 @@ type AbstractJWTAuthService interface {
 	// Get fetches a JWT credential from Kong.
 	Get(ctx context.Context, consumerUsernameOrID, keyOrID *string) (*JWTAuth, error)
 	// GetByID fetches a JWT credential from Kong using ID.
-	GetByID(ctx context.Context, ID *string) (*JWTAuth, error)
+	GetByID(ctx context.Context, id *string) (*JWTAuth, error)
 	// Update updates a JWT credential in Kong
 	Update(ctx context.Context, consumerUsernameOrID *string, jwtAuth *JWTAuth) (*JWTAuth, error)
 	// Delete deletes a JWT credential in Kong
@@ -72,10 +72,10 @@ func (s *JWTAuthService) Get(ctx context.Context,
 
 // GetByID fetches a JWT credential from Kong using ID.
 func (s *JWTAuthService) GetByID(ctx context.Context,
-	ID *string,
+	id *string,
 ) (*JWTAuth, error) {
 	cred, err := s.client.credentials.GetByID(ctx, "jwt-auth",
-		ID)
+		id)
 	if err != nil {
 		return nil, err
 	}

--- a/kong/jwt_auth_service_test.go
+++ b/kong/jwt_auth_service_test.go
@@ -143,14 +143,12 @@ func TestJWTGet(T *testing.T) {
 	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
-func TestJWTGetByID(T *testing.T) {
-	RunWhenDBMode(T, "postgres")
-
-	require := require.New(T)
+func TestJWTGetByID(t *testing.T) {
+	RunWhenDBMode(t, "postgres")
 
 	client, err := NewTestClient(nil, nil)
-	require.NoError(err)
-	require.NotNil(client)
+	require.NoError(t, err)
+	require.NotNil(t, client)
 
 	uuid := uuid.NewString()
 	jwt := &JWTAuth{
@@ -163,35 +161,35 @@ func TestJWTGetByID(T *testing.T) {
 		Username: String("foo"),
 	}
 
-	T.Cleanup(func() {
-		require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
+	t.Cleanup(func() {
+		require.NoError(t, client.Consumers.Delete(defaultCtx, consumer.ID))
 	})
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	require.NoError(err)
-	require.NotNil(consumer)
+	require.NoError(t, err)
+	require.NotNil(t, consumer)
 
 	createdJWT, err := client.JWTAuths.Create(defaultCtx, consumer.ID, jwt)
-	require.NoError(err)
-	require.NotNil(createdJWT)
+	require.NoError(t, err)
+	require.NotNil(t, createdJWT)
 
-	T.Run("successful jwt-auth retrieval by ID", func(_ *testing.T) {
+	t.Run("successful jwt-auth retrieval by ID", func(_ *testing.T) {
 		jwt, err = client.JWTAuths.GetByID(defaultCtx, jwt.ID)
-		require.NoError(err)
-		require.NotNil(jwt)
-		require.Equal("my-key", *jwt.Key)
+		require.NoError(t, err)
+		require.NotNil(t, jwt)
+		require.Equal(t, "my-key", *jwt.Key)
 	})
 
-	T.Run("unsuccessful jwt-auth retrieval by ID", func(_ *testing.T) {
+	t.Run("unsuccessful jwt-auth retrieval by ID", func(_ *testing.T) {
 		jwt, err = client.JWTAuths.GetByID(defaultCtx, String("does-not-exist"))
-		require.Nil(jwt)
-		require.Error(err)
+		require.Nil(t, jwt)
+		require.Error(t, err)
 	})
 
-	T.Run("unsuccessful jwt-auth retrieval using empty string", func(_ *testing.T) {
+	t.Run("unsuccessful jwt-auth retrieval using empty string", func(_ *testing.T) {
 		jwt, err = client.JWTAuths.GetByID(defaultCtx, String(""))
-		require.Nil(jwt)
-		require.Error(err)
+		require.Nil(t, jwt)
+		require.Error(t, err)
 	})
 }
 

--- a/kong/jwt_auth_service_test.go
+++ b/kong/jwt_auth_service_test.go
@@ -173,20 +173,20 @@ func TestJWTGetByID(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, createdJWT)
 
-	t.Run("successful jwt-auth retrieval by ID", func(_ *testing.T) {
+	t.Run("successful jwt-auth retrieval by ID", func(t *testing.T) {
 		jwt, err = client.JWTAuths.GetByID(defaultCtx, jwt.ID)
 		require.NoError(t, err)
 		require.NotNil(t, jwt)
 		require.Equal(t, "my-key", *jwt.Key)
 	})
 
-	t.Run("unsuccessful jwt-auth retrieval by ID", func(_ *testing.T) {
+	t.Run("unsuccessful jwt-auth retrieval by ID", func(t *testing.T) {
 		jwt, err = client.JWTAuths.GetByID(defaultCtx, String("does-not-exist"))
 		require.Nil(t, jwt)
 		require.Error(t, err)
 	})
 
-	t.Run("unsuccessful jwt-auth retrieval using empty string", func(_ *testing.T) {
+	t.Run("unsuccessful jwt-auth retrieval using empty string", func(t *testing.T) {
 		jwt, err = client.JWTAuths.GetByID(defaultCtx, String(""))
 		require.Nil(t, jwt)
 		require.Error(t, err)

--- a/kong/jwt_auth_service_test.go
+++ b/kong/jwt_auth_service_test.go
@@ -143,6 +143,50 @@ func TestJWTGet(T *testing.T) {
 	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
+func TestJWTGetById(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
+	assert := assert.New(T)
+	require := require.New(T)
+
+	client, err := NewTestClient(nil, nil)
+	require.NoError(err)
+	assert.NotNil(client)
+
+	uuid := uuid.NewString()
+	jwt := &JWTAuth{
+		ID:  String(uuid),
+		Key: String("my-key"),
+	}
+
+	// consumer for the jwt
+	consumer := &Consumer{
+		Username: String("foo"),
+	}
+
+	consumer, err = client.Consumers.Create(defaultCtx, consumer)
+	require.NoError(err)
+	require.NotNil(consumer)
+
+	createdJWT, err := client.JWTAuths.Create(defaultCtx, consumer.ID, jwt)
+	require.NoError(err)
+	assert.NotNil(createdJWT)
+
+	jwt, err = client.JWTAuths.GetById(defaultCtx, jwt.ID)
+	require.NoError(err)
+	assert.Equal("my-key", *jwt.Key)
+
+	jwt, err = client.JWTAuths.GetById(defaultCtx, String("does-not-exist"))
+	assert.Nil(jwt)
+	require.Error(err)
+
+	jwt, err = client.JWTAuths.GetById(defaultCtx, String(""))
+	assert.Nil(jwt)
+	require.Error(err)
+
+	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
+}
+
 func TestJWTUpdate(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
 

--- a/kong/jwt_auth_service_test.go
+++ b/kong/jwt_auth_service_test.go
@@ -143,7 +143,7 @@ func TestJWTGet(T *testing.T) {
 	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
-func TestJWTGetById(T *testing.T) {
+func TestJWTGetByID(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
 
 	assert := assert.New(T)
@@ -172,15 +172,15 @@ func TestJWTGetById(T *testing.T) {
 	require.NoError(err)
 	assert.NotNil(createdJWT)
 
-	jwt, err = client.JWTAuths.GetById(defaultCtx, jwt.ID)
+	jwt, err = client.JWTAuths.GetByID(defaultCtx, jwt.ID)
 	require.NoError(err)
 	assert.Equal("my-key", *jwt.Key)
 
-	jwt, err = client.JWTAuths.GetById(defaultCtx, String("does-not-exist"))
+	jwt, err = client.JWTAuths.GetByID(defaultCtx, String("does-not-exist"))
 	assert.Nil(jwt)
 	require.Error(err)
 
-	jwt, err = client.JWTAuths.GetById(defaultCtx, String(""))
+	jwt, err = client.JWTAuths.GetByID(defaultCtx, String(""))
 	assert.Nil(jwt)
 	require.Error(err)
 

--- a/kong/key_auth_service.go
+++ b/kong/key_auth_service.go
@@ -11,6 +11,8 @@ type AbstractKeyAuthService interface {
 	Create(ctx context.Context, consumerUsernameOrID *string, keyAuth *KeyAuth) (*KeyAuth, error)
 	// Get fetches a key-auth credential from Kong.
 	Get(ctx context.Context, consumerUsernameOrID, keyOrID *string) (*KeyAuth, error)
+	// GetById fetches a key-auth credential from Kong using credentialIdentifier
+	GetById(ctx context.Context, keyID *string) (*KeyAuth, error)
 	// Update updates a key-auth credential in Kong
 	Update(ctx context.Context, consumerUsernameOrID *string, keyAuth *KeyAuth) (*KeyAuth, error)
 	// Delete deletes a key-auth credential in Kong
@@ -54,6 +56,24 @@ func (s *KeyAuthService) Get(ctx context.Context,
 ) (*KeyAuth, error) {
 	cred, err := s.client.credentials.Get(ctx, "key-auth",
 		consumerUsernameOrID, keyOrID)
+	if err != nil {
+		return nil, err
+	}
+
+	var keyAuth KeyAuth
+	err = json.Unmarshal(cred, &keyAuth)
+	if err != nil {
+		return nil, err
+	}
+
+	return &keyAuth, nil
+}
+
+// GetById fetches a key-auth credential from Kong using ID.
+func (s *KeyAuthService) GetById(ctx context.Context, keyID *string,
+) (*KeyAuth, error) {
+	cred, err := s.client.credentials.GetById(ctx, "key-auth",
+		keyID)
 	if err != nil {
 		return nil, err
 	}

--- a/kong/key_auth_service.go
+++ b/kong/key_auth_service.go
@@ -11,8 +11,8 @@ type AbstractKeyAuthService interface {
 	Create(ctx context.Context, consumerUsernameOrID *string, keyAuth *KeyAuth) (*KeyAuth, error)
 	// Get fetches a key-auth credential from Kong.
 	Get(ctx context.Context, consumerUsernameOrID, keyOrID *string) (*KeyAuth, error)
-	// GetById fetches a key-auth credential from Kong using credentialIdentifier
-	GetById(ctx context.Context, keyID *string) (*KeyAuth, error)
+	// GetByID fetches a key-auth credential from Kong using ID
+	GetByID(ctx context.Context, ID *string) (*KeyAuth, error)
 	// Update updates a key-auth credential in Kong
 	Update(ctx context.Context, consumerUsernameOrID *string, keyAuth *KeyAuth) (*KeyAuth, error)
 	// Delete deletes a key-auth credential in Kong
@@ -69,11 +69,11 @@ func (s *KeyAuthService) Get(ctx context.Context,
 	return &keyAuth, nil
 }
 
-// GetById fetches a key-auth credential from Kong using ID.
-func (s *KeyAuthService) GetById(ctx context.Context, keyID *string,
+// GetByID fetches a key-auth credential from Kong using ID.
+func (s *KeyAuthService) GetByID(ctx context.Context, ID *string,
 ) (*KeyAuth, error) {
-	cred, err := s.client.credentials.GetById(ctx, "key-auth",
-		keyID)
+	cred, err := s.client.credentials.GetByID(ctx, "key-auth",
+		ID)
 	if err != nil {
 		return nil, err
 	}

--- a/kong/key_auth_service.go
+++ b/kong/key_auth_service.go
@@ -12,7 +12,7 @@ type AbstractKeyAuthService interface {
 	// Get fetches a key-auth credential from Kong.
 	Get(ctx context.Context, consumerUsernameOrID, keyOrID *string) (*KeyAuth, error)
 	// GetByID fetches a key-auth credential from Kong using ID
-	GetByID(ctx context.Context, ID *string) (*KeyAuth, error)
+	GetByID(ctx context.Context, id *string) (*KeyAuth, error)
 	// Update updates a key-auth credential in Kong
 	Update(ctx context.Context, consumerUsernameOrID *string, keyAuth *KeyAuth) (*KeyAuth, error)
 	// Delete deletes a key-auth credential in Kong
@@ -70,10 +70,10 @@ func (s *KeyAuthService) Get(ctx context.Context,
 }
 
 // GetByID fetches a key-auth credential from Kong using ID.
-func (s *KeyAuthService) GetByID(ctx context.Context, ID *string,
+func (s *KeyAuthService) GetByID(ctx context.Context, id *string,
 ) (*KeyAuth, error) {
 	cred, err := s.client.credentials.GetByID(ctx, "key-auth",
-		ID)
+		id)
 	if err != nil {
 		return nil, err
 	}

--- a/kong/key_auth_service_test.go
+++ b/kong/key_auth_service_test.go
@@ -141,6 +141,51 @@ func TestKeyAuthGet(T *testing.T) {
 	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
+func TestKeyAuthGetById(T *testing.T) {
+	RunWhenDBMode(T, "postgres")
+
+	assert := assert.New(T)
+	require := require.New(T)
+
+	client, err := NewTestClient(nil, nil)
+	require.NoError(err)
+	assert.NotNil(client)
+
+	uuid := uuid.NewString()
+	keyAuth := &KeyAuth{
+		ID:  String(uuid),
+		Key: String("my-apikey"),
+	}
+
+	// consumer for the key-auth:
+	consumer := &Consumer{
+		Username: String("foo"),
+	}
+
+	consumer, err = client.Consumers.Create(defaultCtx, consumer)
+	require.NoError(err)
+	require.NotNil(consumer)
+
+	createdKeyAuth, err := client.KeyAuths.Create(defaultCtx,
+		consumer.ID, keyAuth)
+	require.NoError(err)
+	assert.NotNil(createdKeyAuth)
+
+	searchKeyAuth, err := client.KeyAuths.GetById(defaultCtx, keyAuth.ID)
+	require.NoError(err)
+	assert.Equal("my-apikey", *searchKeyAuth.Key)
+
+	searchKeyAuth, err = client.KeyAuths.GetById(defaultCtx, String("does-not-exist"))
+	assert.Nil(searchKeyAuth)
+	require.Error(err)
+
+	searchKeyAuth, err = client.KeyAuths.GetById(defaultCtx, String(""))
+	assert.Nil(searchKeyAuth)
+	require.Error(err)
+
+	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
+}
+
 func TestKeyAuthUpdate(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
 

--- a/kong/key_auth_service_test.go
+++ b/kong/key_auth_service_test.go
@@ -141,14 +141,12 @@ func TestKeyAuthGet(T *testing.T) {
 	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
-func TestKeyAuthGetByID(T *testing.T) {
-	RunWhenDBMode(T, "postgres")
-
-	require := require.New(T)
+func TestKeyAuthGetByID(t *testing.T) {
+	RunWhenDBMode(t, "postgres")
 
 	client, err := NewTestClient(nil, nil)
-	require.NoError(err)
-	require.NotNil(client)
+	require.NoError(t, err)
+	require.NotNil(t, client)
 
 	uuid := uuid.NewString()
 	keyAuth := &KeyAuth{
@@ -162,35 +160,35 @@ func TestKeyAuthGetByID(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	require.NoError(err)
-	require.NotNil(consumer)
+	require.NoError(t, err)
+	require.NotNil(t, consumer)
 
 	createdKeyAuth, err := client.KeyAuths.Create(defaultCtx,
 		consumer.ID, keyAuth)
-	require.NoError(err)
-	require.NotNil(createdKeyAuth)
+	require.NoError(t, err)
+	require.NotNil(t, createdKeyAuth)
 
-	T.Cleanup(func() {
-		require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
+	t.Cleanup(func() {
+		require.NoError(t, client.Consumers.Delete(defaultCtx, consumer.ID))
 	})
 
-	T.Run("successful key-auth retrieval by ID", func(_ *testing.T) {
+	t.Run("successful key-auth retrieval by ID", func(_ *testing.T) {
 		searchKeyAuth, err := client.KeyAuths.GetByID(defaultCtx, keyAuth.ID)
-		require.NoError(err)
-		require.NotNil(searchKeyAuth)
-		require.Equal("my-apikey", *searchKeyAuth.Key)
+		require.NoError(t, err)
+		require.NotNil(t, searchKeyAuth)
+		require.Equal(t, "my-apikey", *searchKeyAuth.Key)
 	})
 
-	T.Run("unsuccessful key-auth retrieval by ID", func(_ *testing.T) {
+	t.Run("unsuccessful key-auth retrieval by ID", func(_ *testing.T) {
 		searchKeyAuth, err := client.KeyAuths.GetByID(defaultCtx, String("does-not-exist"))
-		require.Nil(searchKeyAuth)
-		require.Error(err)
+		require.Nil(t, searchKeyAuth)
+		require.Error(t, err)
 	})
 
-	T.Run("unsuccessful key-auth retrieval using empty string", func(_ *testing.T) {
+	t.Run("unsuccessful key-auth retrieval using empty string", func(_ *testing.T) {
 		searchKeyAuth, err := client.KeyAuths.GetByID(defaultCtx, String(""))
-		require.Nil(searchKeyAuth)
-		require.Error(err)
+		require.Nil(t, searchKeyAuth)
+		require.Error(t, err)
 	})
 }
 

--- a/kong/key_auth_service_test.go
+++ b/kong/key_auth_service_test.go
@@ -141,7 +141,7 @@ func TestKeyAuthGet(T *testing.T) {
 	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
-func TestKeyAuthGetById(T *testing.T) {
+func TestKeyAuthGetByID(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
 
 	assert := assert.New(T)
@@ -171,15 +171,15 @@ func TestKeyAuthGetById(T *testing.T) {
 	require.NoError(err)
 	assert.NotNil(createdKeyAuth)
 
-	searchKeyAuth, err := client.KeyAuths.GetById(defaultCtx, keyAuth.ID)
+	searchKeyAuth, err := client.KeyAuths.GetByID(defaultCtx, keyAuth.ID)
 	require.NoError(err)
 	assert.Equal("my-apikey", *searchKeyAuth.Key)
 
-	searchKeyAuth, err = client.KeyAuths.GetById(defaultCtx, String("does-not-exist"))
+	searchKeyAuth, err = client.KeyAuths.GetByID(defaultCtx, String("does-not-exist"))
 	assert.Nil(searchKeyAuth)
 	require.Error(err)
 
-	searchKeyAuth, err = client.KeyAuths.GetById(defaultCtx, String(""))
+	searchKeyAuth, err = client.KeyAuths.GetByID(defaultCtx, String(""))
 	assert.Nil(searchKeyAuth)
 	require.Error(err)
 

--- a/kong/key_auth_service_test.go
+++ b/kong/key_auth_service_test.go
@@ -172,20 +172,20 @@ func TestKeyAuthGetByID(t *testing.T) {
 		require.NoError(t, client.Consumers.Delete(defaultCtx, consumer.ID))
 	})
 
-	t.Run("successful key-auth retrieval by ID", func(_ *testing.T) {
+	t.Run("successful key-auth retrieval by ID", func(t *testing.T) {
 		searchKeyAuth, err := client.KeyAuths.GetByID(defaultCtx, keyAuth.ID)
 		require.NoError(t, err)
 		require.NotNil(t, searchKeyAuth)
 		require.Equal(t, "my-apikey", *searchKeyAuth.Key)
 	})
 
-	t.Run("unsuccessful key-auth retrieval by ID", func(_ *testing.T) {
+	t.Run("unsuccessful key-auth retrieval by ID", func(t *testing.T) {
 		searchKeyAuth, err := client.KeyAuths.GetByID(defaultCtx, String("does-not-exist"))
 		require.Nil(t, searchKeyAuth)
 		require.Error(t, err)
 	})
 
-	t.Run("unsuccessful key-auth retrieval using empty string", func(_ *testing.T) {
+	t.Run("unsuccessful key-auth retrieval using empty string", func(t *testing.T) {
 		searchKeyAuth, err := client.KeyAuths.GetByID(defaultCtx, String(""))
 		require.Nil(t, searchKeyAuth)
 		require.Error(t, err)

--- a/kong/oauth2_auth_service.go
+++ b/kong/oauth2_auth_service.go
@@ -11,8 +11,8 @@ type AbstractOauth2Service interface {
 	Create(ctx context.Context, consumerUsernameOrID *string, oauth2Cred *Oauth2Credential) (*Oauth2Credential, error)
 	// Get fetches an oauth2 credential from Kong.
 	Get(ctx context.Context, consumerUsernameOrID, clientIDorID *string) (*Oauth2Credential, error)
-	// GetById fetches an oauth2 credential from Kong using ID.
-	GetById(ctx context.Context, ID *string) (*Oauth2Credential, error)
+	// GetByID fetches an oauth2 credential from Kong using ID.
+	GetByID(ctx context.Context, ID *string) (*Oauth2Credential, error)
 	// Update updates an oauth2 credential in Kong.
 	Update(ctx context.Context, consumerUsernameOrID *string, oauth2Cred *Oauth2Credential) (*Oauth2Credential, error)
 	// Delete deletes an oauth2 credential in Kong.
@@ -71,11 +71,11 @@ func (s *Oauth2Service) Get(ctx context.Context,
 	return &oauth2Cred, nil
 }
 
-// GetById fetches an oauth2 credential from Kong using ID.
-func (s *Oauth2Service) GetById(ctx context.Context,
+// GetByID fetches an oauth2 credential from Kong using ID.
+func (s *Oauth2Service) GetByID(ctx context.Context,
 	ID *string,
 ) (*Oauth2Credential, error) {
-	cred, err := s.client.credentials.GetById(ctx, "oauth2",
+	cred, err := s.client.credentials.GetByID(ctx, "oauth2",
 		ID)
 	if err != nil {
 		return nil, err

--- a/kong/oauth2_auth_service.go
+++ b/kong/oauth2_auth_service.go
@@ -11,6 +11,8 @@ type AbstractOauth2Service interface {
 	Create(ctx context.Context, consumerUsernameOrID *string, oauth2Cred *Oauth2Credential) (*Oauth2Credential, error)
 	// Get fetches an oauth2 credential from Kong.
 	Get(ctx context.Context, consumerUsernameOrID, clientIDorID *string) (*Oauth2Credential, error)
+	// GetById fetches an oauth2 credential from Kong using ID.
+	GetById(ctx context.Context, ID *string) (*Oauth2Credential, error)
 	// Update updates an oauth2 credential in Kong.
 	Update(ctx context.Context, consumerUsernameOrID *string, oauth2Cred *Oauth2Credential) (*Oauth2Credential, error)
 	// Delete deletes an oauth2 credential in Kong.
@@ -56,6 +58,25 @@ func (s *Oauth2Service) Get(ctx context.Context,
 ) (*Oauth2Credential, error) {
 	cred, err := s.client.credentials.Get(ctx, "oauth2",
 		consumerUsernameOrID, clientIDorID)
+	if err != nil {
+		return nil, err
+	}
+
+	var oauth2Cred Oauth2Credential
+	err = json.Unmarshal(cred, &oauth2Cred)
+	if err != nil {
+		return nil, err
+	}
+
+	return &oauth2Cred, nil
+}
+
+// GetById fetches an oauth2 credential from Kong using ID.
+func (s *Oauth2Service) GetById(ctx context.Context,
+	ID *string,
+) (*Oauth2Credential, error) {
+	cred, err := s.client.credentials.GetById(ctx, "oauth2",
+		ID)
 	if err != nil {
 		return nil, err
 	}

--- a/kong/oauth2_auth_service.go
+++ b/kong/oauth2_auth_service.go
@@ -12,7 +12,7 @@ type AbstractOauth2Service interface {
 	// Get fetches an oauth2 credential from Kong.
 	Get(ctx context.Context, consumerUsernameOrID, clientIDorID *string) (*Oauth2Credential, error)
 	// GetByID fetches an oauth2 credential from Kong using ID.
-	GetByID(ctx context.Context, ID *string) (*Oauth2Credential, error)
+	GetByID(ctx context.Context, id *string) (*Oauth2Credential, error)
 	// Update updates an oauth2 credential in Kong.
 	Update(ctx context.Context, consumerUsernameOrID *string, oauth2Cred *Oauth2Credential) (*Oauth2Credential, error)
 	// Delete deletes an oauth2 credential in Kong.
@@ -73,10 +73,10 @@ func (s *Oauth2Service) Get(ctx context.Context,
 
 // GetByID fetches an oauth2 credential from Kong using ID.
 func (s *Oauth2Service) GetByID(ctx context.Context,
-	ID *string,
+	id *string,
 ) (*Oauth2Credential, error) {
 	cred, err := s.client.credentials.GetByID(ctx, "oauth2",
-		ID)
+		id)
 	if err != nil {
 		return nil, err
 	}

--- a/kong/oauth2_auth_service_test.go
+++ b/kong/oauth2_auth_service_test.go
@@ -219,20 +219,20 @@ func TestOauth2CredentialGetByID(t *testing.T) {
 		require.NoError(t, client.Consumers.Delete(defaultCtx, consumer.ID))
 	})
 
-	t.Run("successful oauth retrieval by ID", func(_ *testing.T) {
+	t.Run("successful oauth retrieval by ID", func(t *testing.T) {
 		oauth2Cred, err = client.Oauth2Credentials.GetByID(defaultCtx, oauth2Cred.ID)
 		require.NoError(t, err)
 		require.NotNil(t, oauth2Cred)
 		require.Equal(t, "foo-clientid", *oauth2Cred.ClientID)
 	})
 
-	t.Run("unsuccessful oauth retrieval by ID", func(_ *testing.T) {
+	t.Run("unsuccessful oauth retrieval by ID", func(t *testing.T) {
 		oauth2Cred, err = client.Oauth2Credentials.GetByID(defaultCtx, String("does-not-exist"))
 		require.Nil(t, oauth2Cred)
 		require.Error(t, err)
 	})
 
-	t.Run("unsuccessful oauth retrieval using empty string", func(_ *testing.T) {
+	t.Run("unsuccessful oauth retrieval using empty string", func(t *testing.T) {
 		oauth2Cred, err = client.Oauth2Credentials.GetByID(defaultCtx, String(""))
 		require.Nil(t, oauth2Cred)
 		require.Error(t, err)

--- a/kong/oauth2_auth_service_test.go
+++ b/kong/oauth2_auth_service_test.go
@@ -186,7 +186,7 @@ func TestOauth2CredentialGet(T *testing.T) {
 	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
-func TestOauth2CredentialGetById(T *testing.T) {
+func TestOauth2CredentialGetByID(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
 
 	assert := assert.New(T)
@@ -218,15 +218,15 @@ func TestOauth2CredentialGetById(T *testing.T) {
 	require.NoError(err)
 	assert.NotNil(createdOauth2Credential)
 
-	oauth2Cred, err = client.Oauth2Credentials.GetById(defaultCtx, oauth2Cred.ID)
+	oauth2Cred, err = client.Oauth2Credentials.GetByID(defaultCtx, oauth2Cred.ID)
 	require.NoError(err)
 	assert.Equal("foo-clientid", *oauth2Cred.ClientID)
 
-	oauth2Cred, err = client.Oauth2Credentials.GetById(defaultCtx, String("does-not-exist"))
+	oauth2Cred, err = client.Oauth2Credentials.GetByID(defaultCtx, String("does-not-exist"))
 	assert.Nil(oauth2Cred)
 	require.Error(err)
 
-	oauth2Cred, err = client.Oauth2Credentials.GetById(defaultCtx, String(""))
+	oauth2Cred, err = client.Oauth2Credentials.GetByID(defaultCtx, String(""))
 	assert.Nil(oauth2Cred)
 	require.Error(err)
 

--- a/kong/oauth2_auth_service_test.go
+++ b/kong/oauth2_auth_service_test.go
@@ -186,14 +186,12 @@ func TestOauth2CredentialGet(T *testing.T) {
 	require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
 }
 
-func TestOauth2CredentialGetByID(T *testing.T) {
-	RunWhenDBMode(T, "postgres")
-
-	require := require.New(T)
+func TestOauth2CredentialGetByID(t *testing.T) {
+	RunWhenDBMode(t, "postgres")
 
 	client, err := NewTestClient(nil, nil)
-	require.NoError(err)
-	require.NotNil(client)
+	require.NoError(t, err)
+	require.NotNil(t, client)
 
 	uuid := uuid.NewString()
 	oauth2Cred := &Oauth2Credential{
@@ -209,35 +207,35 @@ func TestOauth2CredentialGetByID(T *testing.T) {
 	}
 
 	consumer, err = client.Consumers.Create(defaultCtx, consumer)
-	require.NoError(err)
-	require.NotNil(consumer)
+	require.NoError(t, err)
+	require.NotNil(t, consumer)
 
 	createdOauth2Credential, err := client.Oauth2Credentials.Create(defaultCtx,
 		consumer.ID, oauth2Cred)
-	require.NoError(err)
-	require.NotNil(createdOauth2Credential)
+	require.NoError(t, err)
+	require.NotNil(t, createdOauth2Credential)
 
-	T.Cleanup(func() {
-		require.NoError(client.Consumers.Delete(defaultCtx, consumer.ID))
+	t.Cleanup(func() {
+		require.NoError(t, client.Consumers.Delete(defaultCtx, consumer.ID))
 	})
 
-	T.Run("successful oauth retrieval by ID", func(_ *testing.T) {
+	t.Run("successful oauth retrieval by ID", func(_ *testing.T) {
 		oauth2Cred, err = client.Oauth2Credentials.GetByID(defaultCtx, oauth2Cred.ID)
-		require.NoError(err)
-		require.NotNil(oauth2Cred)
-		require.Equal("foo-clientid", *oauth2Cred.ClientID)
+		require.NoError(t, err)
+		require.NotNil(t, oauth2Cred)
+		require.Equal(t, "foo-clientid", *oauth2Cred.ClientID)
 	})
 
-	T.Run("unsuccessful oauth retrieval by ID", func(_ *testing.T) {
+	t.Run("unsuccessful oauth retrieval by ID", func(_ *testing.T) {
 		oauth2Cred, err = client.Oauth2Credentials.GetByID(defaultCtx, String("does-not-exist"))
-		require.Nil(oauth2Cred)
-		require.Error(err)
+		require.Nil(t, oauth2Cred)
+		require.Error(t, err)
 	})
 
-	T.Run("unsuccessful oauth retrieval using empty string", func(_ *testing.T) {
+	t.Run("unsuccessful oauth retrieval using empty string", func(_ *testing.T) {
 		oauth2Cred, err = client.Oauth2Credentials.GetByID(defaultCtx, String(""))
-		require.Nil(oauth2Cred)
-		require.Error(err)
+		require.Nil(t, oauth2Cred)
+		require.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
These changes are being made to support the fix for https://github.com/Kong/deck/issues/1543.

Changes made:
- GetByID function added to the credential service, and each credential
- Tests

https://kongstrong.slack.com/archives/CQK8J4VN3/p1741703868872269

Skipped mtls auth - gateway does not seem to support Get By ID endpoint.
