### PR TITLE
tests: skip wasm-related tests when wasm is not enabled

### DIFF
--- a/kong/filter_chain_service_test.go
+++ b/kong/filter_chain_service_test.go
@@ -8,12 +8,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFilterChainsService(T *testing.T) {
-	T.Skip("Skipping until https://github.com/Kong/go-kong/issues/531 is resolved")
+func runWhenWasmIsAvailable(t *testing.T) {
+	t.Helper()
+	RunWhenDBMode(t, "postgres")
+	SkipWhenKongRouterFlavor(t, Expressions)
 
-	RunWhenDBMode(T, "postgres")
-	RunWhenKong(T, ">=3.4.0")
-	SkipWhenKongRouterFlavor(T, Expressions)
+	RunWhenKong(t, ">=3.4.0 <3.11.0")
+
+	// 3.10 was the last release with wasm, but this check is still needed for
+	// nightly images that haven't been updated to 3.11 yet
+	RunWhenKongConfigEnabled(t, "wasm")
+}
+
+func TestFilterChainsService(T *testing.T) {
+	runWhenWasmIsAvailable(T)
 
 	assert := assert.New(T)
 	require := require.New(T)
@@ -198,10 +206,7 @@ func TestFilterChainsService(T *testing.T) {
 }
 
 func TestFilterChainWithTags(T *testing.T) {
-	T.Skip("Skipping until https://github.com/Kong/go-kong/issues/531 is resolved")
-
-	RunWhenDBMode(T, "postgres")
-	RunWhenKong(T, ">=3.4.0")
+	runWhenWasmIsAvailable(T)
 
 	require := require.New(T)
 
@@ -245,8 +250,7 @@ func TestFilterChainWithTags(T *testing.T) {
 }
 
 func TestUnknownFilterChain(T *testing.T) {
-	RunWhenDBMode(T, "postgres")
-	RunWhenKong(T, ">=3.4.0")
+	runWhenWasmIsAvailable(T)
 
 	assert := assert.New(T)
 
@@ -286,10 +290,7 @@ func TestUnknownFilterChain(T *testing.T) {
 }
 
 func TestFilterChainListEndpoint(T *testing.T) {
-	T.Skip("Skipping until https://github.com/Kong/go-kong/issues/531 is resolved")
-
-	RunWhenDBMode(T, "postgres")
-	RunWhenKong(T, ">=3.4.0")
+	runWhenWasmIsAvailable(T)
 
 	assert := assert.New(T)
 
@@ -394,11 +395,7 @@ func TestFilterChainListEndpoint(T *testing.T) {
 }
 
 func TestFilterChainListAllForEntityEndpoint(T *testing.T) {
-	T.Skip("Skipping until https://github.com/Kong/go-kong/issues/531 is resolved")
-
-	RunWhenDBMode(T, "postgres")
-	RunWhenKong(T, ">=3.4.0")
-	SkipWhenKongRouterFlavor(T, Expressions)
+	runWhenWasmIsAvailable(T)
 
 	assert := assert.New(T)
 

--- a/kong/plugin_service_test.go
+++ b/kong/plugin_service_test.go
@@ -404,8 +404,6 @@ func TestPluginListEndpoint(T *testing.T) {
 }
 
 func TestPluginListAllForEntityEndpoint(T *testing.T) {
-	T.Skip("Skipping until https://github.com/Kong/go-kong/issues/531 is resolved")
-
 	RunWhenDBMode(T, "postgres")
 	SkipWhenKongRouterFlavor(T, Expressions)
 

--- a/kong/route_service_test.go
+++ b/kong/route_service_test.go
@@ -194,8 +194,6 @@ func TestCreateExpressionRoutes(T *testing.T) {
 }
 
 func TestCreateInRoute(T *testing.T) {
-	T.Skip("Skipping until https://github.com/Kong/go-kong/issues/531 is resolved")
-
 	RunWhenDBMode(T, "postgres")
 	SkipWhenKongRouterFlavor(T, Expressions)
 
@@ -237,8 +235,6 @@ func TestCreateInRoute(T *testing.T) {
 }
 
 func TestRouteListEndpoint(T *testing.T) {
-	T.Skip("Skipping until https://github.com/Kong/go-kong/issues/531 is resolved")
-
 	RunWhenDBMode(T, "postgres")
 	SkipWhenKongRouterFlavor(T, Expressions)
 

--- a/kong/service_service_test.go
+++ b/kong/service_service_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 func TestServicesService(T *testing.T) {
-	T.Skip("Skipping until https://github.com/Kong/go-kong/issues/531 is resolved")
-
 	RunWhenDBMode(T, "postgres")
 	SkipWhenKongRouterFlavor(T, Expressions)
 
@@ -114,8 +112,6 @@ func TestServiceWithTags(T *testing.T) {
 }
 
 func TestServiceListEndpoint(T *testing.T) {
-	T.Skip("Skipping until https://github.com/Kong/go-kong/issues/531 is resolved")
-
 	RunWhenDBMode(T, "postgres")
 
 	assert := assert.New(T)


### PR DESCRIPTION
Wasm has been removed from Kong master/nightly images. Normally a version range would do the trick to target and skip these tests (since we can assume versions >3.10 should therefore be skipped), but as of this writing the version metadata has not been updated in master.

I still updated the version range, but to catch the nightly case I added an explicit configuration check.

fixes: #531