### PR TITLE
feat: Implement FillID method for plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,12 @@
 - [0.2.0](#020)
 - [0.1.0](#010)
 
+## Unreleased
+
+- Implement `FillID` method for plugins. It generates ID by plugin's name,
+  instance name, service, route, consumer, and consumer group (if exists).
+  [#542](https://github.com/Kong/go-kong/pull/542)
+
 ## [v0.65.1]
 
 > Release date: 2025/04/09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@
 ## Unreleased
 
 - Implement `FillID` method for plugins. It generates ID by plugin's name,
-  instance name, service, route, consumer, and consumer group (if exists).
+  service, route, consumer, and consumer group (if exists).
   [#542](https://github.com/Kong/go-kong/pull/542)
 
 ## [v0.65.1]

--- a/kong/ids.go
+++ b/kong/ids.go
@@ -128,6 +128,49 @@ func (v *Vault) FillID(workspace string) error {
 	return nil
 }
 
+// FillID fills the ID of an entity. It is a no-op if the entity already has an ID.
+// ID is generated in a deterministic way using UUIDv5.
+// The UUIDv5 namespace being used for generation is separate from other namespaces used for generating IDs for other types.
+// The name used to generate the ID for plugins is the combination of:
+// plugin.Name, plugin.InstanceName, name of plugin.Service, plugin.Route, plugin.Consumer, and plugin.ConsumerGroup.
+func (p *Plugin) FillID(workspace string) error {
+	if p == nil {
+		return fmt.Errorf("plugin is nil")
+	}
+	if p.ID != nil && len(*p.ID) > 0 {
+		// ID already set, do nothing.
+		return nil
+	}
+	if p.Name == nil || len(*p.Name) == 0 {
+		return fmt.Errorf("plugin name is required")
+	}
+
+	toHash := *p.Name
+	if p.InstanceName != nil && len(*p.InstanceName) > 0 {
+		toHash = toHash + ":instance_name/" + *p.InstanceName
+	}
+	if p.Service != nil {
+		toHash = toHash + ":service/" + p.Service.FriendlyName()
+	}
+	if p.Route != nil {
+		toHash = toHash + ":route/" + p.Route.FriendlyName()
+	}
+	if p.Consumer != nil {
+		toHash = toHash + ":consumer/" + p.Consumer.FriendlyName()
+	}
+	if p.ConsumerGroup != nil {
+		toHash = toHash + ":consumer_group/" + p.ConsumerGroup.FriendlyName()
+	}
+
+	gen, err := idGeneratorFor(p)
+	if err != nil {
+		return fmt.Errorf("could not get id generator: %w", err)
+	}
+
+	p.ID = gen.buildIDFor(workspace, toHash)
+	return nil
+}
+
 var (
 	// _kongEntitiesNamespace is the UUIDv5 namespace used to generate IDs for Kong entities.
 	_kongEntitiesNamespace = uuid.MustParse("fd02801f-0957-4a15-a55a-c8d9606f30b5")
@@ -142,6 +185,7 @@ var (
 		reflect.TypeOf(Consumer{}):      newIDGeneratorFor("consumers"),
 		reflect.TypeOf(ConsumerGroup{}): newIDGeneratorFor("consumergroups"),
 		reflect.TypeOf(Vault{}):         newIDGeneratorFor("vaults"),
+		reflect.TypeOf(Plugin{}):        newIDGeneratorFor("plugins"),
 	}
 )
 

--- a/kong/ids.go
+++ b/kong/ids.go
@@ -146,9 +146,6 @@ func (p *Plugin) FillID(workspace string) error {
 	}
 
 	toHash := *p.Name
-	if p.InstanceName != nil && len(*p.InstanceName) > 0 {
-		toHash = toHash + ":instance_name/" + *p.InstanceName
-	}
 	if p.Service != nil {
 		toHash = toHash + ":service/" + p.Service.FriendlyName()
 	}

--- a/kong/ids_test.go
+++ b/kong/ids_test.go
@@ -179,6 +179,98 @@ func TestFillEntityID(t *testing.T) {
 				require.Equal(t, expectedID, *v.ID, "ID should be deterministic")
 			},
 		},
+		// Plugin
+		{
+			name:      "plugin with nil pointer",
+			entity:    (*kong.Plugin)(nil),
+			expectErr: true,
+		},
+		{
+			name: "plugin with empty name",
+			entity: &kong.Plugin{
+				Name: kong.String(""),
+			},
+			expectErr: true,
+		},
+		{
+			name: "plugin with id should not be modified",
+			entity: &kong.Plugin{
+				Name: kong.String("rate-limiting"),
+				ID:   kong.String("abcd1234-5678-abcd-0123-abcdeffedcba"),
+			},
+			assertEntity: func(t *testing.T, e kong.IDFillable) {
+				p := e.(*kong.Plugin)
+				require.NotNil(t, p.ID)
+
+				const expectedID = "abcd1234-5678-abcd-0123-abcdeffedcba"
+				require.Equal(t, expectedID, *p.ID, "ID should not be changed")
+			},
+		},
+		{
+			name: "plugin with name",
+			entity: &kong.Plugin{
+				Name: kong.String("rate-limiting"),
+			},
+			assertEntity: func(t *testing.T, e kong.IDFillable) {
+				p := e.(*kong.Plugin)
+				require.NotNil(t, p.ID)
+
+				const expectedID = "f0f8012b-f709-5685-9812-0130e5d83c5a"
+				require.Equal(t, expectedID, *p.ID, "ID should be deterministic")
+			},
+		},
+		{
+			name: "plugin with name and service",
+			entity: &kong.Plugin{
+				Name: kong.String("rate-limiting"),
+				Service: &kong.Service{
+					Name: kong.String("service-1"),
+				},
+			},
+			assertEntity: func(t *testing.T, e kong.IDFillable) {
+				p := e.(*kong.Plugin)
+				require.NotNil(t, p.ID)
+
+				const expectedID = "b0df9683-8b2f-5557-8b66-204b1529ed7f"
+				require.Equal(t, expectedID, *p.ID, "ID should be deterministic")
+			},
+		},
+		{
+			name: "plugin with with name, route and consumer",
+			entity: &kong.Plugin{
+				Name: kong.String("rate-limiting"),
+				Route: &kong.Route{
+					Name: kong.String("route-1"),
+				},
+				Consumer: &kong.Consumer{
+					Username: kong.String("consumer-1"),
+				},
+			},
+			assertEntity: func(t *testing.T, e kong.IDFillable) {
+				p := e.(*kong.Plugin)
+				require.NotNil(t, p.ID)
+
+				const expectedID = "d6a8d8fd-f156-5809-a2d0-c75b23db07a5"
+				require.Equal(t, expectedID, *p.ID, "ID should be deterministic")
+			},
+		},
+		{
+			name: "plugin with name, instance name and consumer group",
+			entity: &kong.Plugin{
+				Name:         kong.String("rate-limiting"),
+				InstanceName: kong.String("rl-1"),
+				ConsumerGroup: &kong.ConsumerGroup{
+					Name: kong.String("group-1"),
+				},
+			},
+			assertEntity: func(t *testing.T, e kong.IDFillable) {
+				p := e.(*kong.Plugin)
+				require.NotNil(t, p.ID)
+
+				const expectedID = "cb94463c-cbc2-5573-9b4c-226cc91c3873"
+				require.Equal(t, expectedID, *p.ID, "ID should be deterministic")
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/kong/ids_test.go
+++ b/kong/ids_test.go
@@ -267,7 +267,7 @@ func TestFillEntityID(t *testing.T) {
 				p := e.(*kong.Plugin)
 				require.NotNil(t, p.ID)
 
-				const expectedID = "cb94463c-cbc2-5573-9b4c-226cc91c3873"
+				const expectedID = "01af8dbc-e3e8-5ccd-b20d-d55227c15cbf"
 				require.Equal(t, expectedID, *p.ID, "ID should be deterministic")
 			},
 		},


### PR DESCRIPTION
Implement `FillID` method for Plugin for https://github.com/Kong/kubernetes-ingress-controller/issues/7394. 
Because GDR regards plugin with the same name, service, route, consumer, and consumer group as the same plugin, the method for generating ID takes them into account.