### PR TITLE
Set default value of `config.throttling` field of RLA plugin in integration tests when Kong version >= 3.11

### DIFF
--- a/kong/test_utils.go
+++ b/kong/test_utils.go
@@ -45,7 +45,7 @@ func RunWhenKong(t *testing.T, versionRange string) {
 		t.Error(err)
 	}
 	if !r(currentVersion) {
-		t.Skipf("kong version %s not in range %s", currentVersion.String(), versionRange)
+		t.Skipf("kong version %s not in range %s", currentVersion, versionRange)
 	}
 }
 

--- a/kong/test_utils.go
+++ b/kong/test_utils.go
@@ -12,11 +12,8 @@ type RequiredFeatures struct {
 	RBAC   bool
 }
 
-// RunWhenKong skips the current test if the version of Kong doesn't
-// fall in the versionRange.
-// This helper function can be used in tests to write version specific
-// tests for Kong.
-func RunWhenKong(t *testing.T, versionRange string) {
+// GetVersionForTesting returns the semantic version of Kong.
+func GetVersionForTesting(t *testing.T) Version {
 	t.Helper()
 
 	client, err := NewTestClient(nil, nil)
@@ -32,12 +29,23 @@ func RunWhenKong(t *testing.T, versionRange string) {
 	if err != nil {
 		t.Error(err)
 	}
+	return currentVersion
+}
+
+// RunWhenKong skips the current test if the version of Kong doesn't
+// fall in the versionRange.
+// This helper function can be used in tests to write version specific
+// tests for Kong.
+func RunWhenKong(t *testing.T, versionRange string) {
+	t.Helper()
+
+	currentVersion := GetVersionForTesting(t)
 	r, err := NewRange(versionRange)
 	if err != nil {
 		t.Error(err)
 	}
 	if !r(currentVersion) {
-		t.Skipf("kong version %s not in range %s", version, versionRange)
+		t.Skipf("kong version %s not in range %s", currentVersion.String(), versionRange)
 	}
 }
 

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -4213,12 +4213,13 @@ func Test_FillPluginsDefaultsWithPartials(t *testing.T) {
 	// We need to add the default value of `throttling` when Kong version >= 3.11.0.
 	kongVersion := GetVersionForTesting(t)
 	rlaHasThrottlingVersionRange := MustNewRange(">=3.11.0")
-	defaultRLAThrotlling := Configuration{
+	defaultRLAThrotlling := map[string]any{
 		"enabled":         false,
 		"dictionary_name": "kong_rate_limiting_throttling",
-		"interval":        5,
-		"retry_times":     3,
-		"queue_limit":     3,
+		// Numbers are converted to `float64` type in `map[string]interface{}.
+		"interval":    float64(5),
+		"queue_limit": float64(5),
+		"retry_times": float64(3),
 	}
 
 	for _, tc := range tests {

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -4209,6 +4209,12 @@ func Test_FillPluginsDefaultsWithPartials(t *testing.T) {
 			errString: "no 'config' field found in schema",
 		},
 	}
+	// Kong Enterprise added `throttling` field and assigned default values since 3.11.
+	// We ignore the field here to be compatible with 3.10.
+	// TODO: set default value in the expected plugin configuration when Kong version >= 3.11?
+	ignoreThrottling := func(k string, _ any) bool {
+		return k == "throttling"
+	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -4223,7 +4229,7 @@ func Test_FillPluginsDefaultsWithPartials(t *testing.T) {
 
 			require.NoError(t, err)
 			opts := cmpopts.IgnoreFields(*tc.plugin, "Enabled", "Protocols")
-			if diff := cmp.Diff(tc.plugin, tc.expectedPlugin, opts); diff != "" {
+			if diff := cmp.Diff(tc.plugin, tc.expectedPlugin, opts, cmpopts.IgnoreMapEntries(ignoreThrottling)); diff != "" {
 				t.Errorf("unexpected diff:\n%s", diff)
 			}
 		})


### PR DESCRIPTION
Kong Enterprise added `throttling` field to the `rate-limiting-advanced` plugin and assigned default values for it: https://github.com/Kong/kong-ee/pull/12243

The PR sets the default value of `config.throttling` field of RLA plugin if the Kong version supports (>= 3.11).