### PR TITLE
fix: consumer group consumer create request body to align with API spec

### DIFF
--- a/kong/consumer_group.go
+++ b/kong/consumer_group.go
@@ -25,6 +25,11 @@ type ConsumerGroupConsumer struct {
 	CreatedAt     *int64         `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 }
 
+// Represents the request body to add a Consumer to a Consumer Group in Kong.
+type consumerGroupConsumerRequestBody struct {
+	Consumer *string `json:"consumer,omitempty" yaml:"consumer,omitempty"`
+}
+
 // ConsumerGroupRLA represents a ConsumerGroupRLA in Kong.
 // +k8s:deepcopy-gen=true
 type ConsumerGroupRLA struct {

--- a/kong/consumer_group_consumer_service.go
+++ b/kong/consumer_group_consumer_service.go
@@ -3,7 +3,6 @@ package kong
 import (
 	"context"
 	"fmt"
-	"net/url"
 )
 
 // AbstractConsumerGroupConsumerService handles ConsumerGroups' Consumers in Kong.
@@ -34,11 +33,9 @@ func (s *ConsumerGroupConsumerService) Create(ctx context.Context,
 	}
 
 	queryPath := "/consumer_groups/" + *consumerGroupNameOrID + "/consumers"
+	consumerGroupConsumerReq := &consumerGroupConsumerRequestBody{Consumer: consumerNameOrID}
 
-	data := url.Values{}
-	data.Set("consumer", *consumerNameOrID)
-
-	req, err := s.client.NewRequest("POST", queryPath, nil, data)
+	req, err := s.client.NewRequest("POST", queryPath, nil, consumerGroupConsumerReq)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR fixes the request body sent while creating a consumer group consumer - we were sending an array of UUIDs in `consumer` field while according to API spec we should be sending a single UUID.
Fixes https://konghq.atlassian.net/browse/APIOPS-121

API spec for reference: https://docs.konghq.com/gateway/api/admin-ee/latest/#/operations/post-consumer_groups-group_name_or_id-consumers_with_workspace

Haven't added additional tests since there is already one - https://github.com/Kong/go-kong/blob/main/kong/consumer_group_consumer_test.go#L36
I have tested this on deck through integration and manual tests.