### PR TITLE
Revert "Set default value of `config.throttling` field of RLA plugin in integration tests when Kong version >= 3.11"

### DIFF
--- a/kong/test_utils.go
+++ b/kong/test_utils.go
@@ -12,8 +12,11 @@ type RequiredFeatures struct {
 	RBAC   bool
 }
 
-// GetVersionForTesting returns the semantic version of Kong.
-func GetVersionForTesting(t *testing.T) Version {
+// RunWhenKong skips the current test if the version of Kong doesn't
+// fall in the versionRange.
+// This helper function can be used in tests to write version specific
+// tests for Kong.
+func RunWhenKong(t *testing.T, versionRange string) {
 	t.Helper()
 
 	client, err := NewTestClient(nil, nil)
@@ -29,23 +32,12 @@ func GetVersionForTesting(t *testing.T) Version {
 	if err != nil {
 		t.Error(err)
 	}
-	return currentVersion
-}
-
-// RunWhenKong skips the current test if the version of Kong doesn't
-// fall in the versionRange.
-// This helper function can be used in tests to write version specific
-// tests for Kong.
-func RunWhenKong(t *testing.T, versionRange string) {
-	t.Helper()
-
-	currentVersion := GetVersionForTesting(t)
 	r, err := NewRange(versionRange)
 	if err != nil {
 		t.Error(err)
 	}
 	if !r(currentVersion) {
-		t.Skipf("kong version %s not in range %s", currentVersion, versionRange)
+		t.Skipf("kong version %s not in range %s", version, versionRange)
 	}
 }
 

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -4209,18 +4209,6 @@ func Test_FillPluginsDefaultsWithPartials(t *testing.T) {
 			errString: "no 'config' field found in schema",
 		},
 	}
-	// Kong Enterprise added `throttling` field and assigned default values since 3.11.
-	// We need to add the default value of `throttling` when Kong version >= 3.11.0.
-	kongVersion := GetVersionForTesting(t)
-	rlaHasThrottlingVersionRange := MustNewRange(">=3.11.0")
-	defaultRLAThrotlling := map[string]any{
-		"enabled":         false,
-		"dictionary_name": "kong_rate_limiting_throttling",
-		// Numbers are converted to `float64` type in `map[string]interface{}.
-		"interval":    float64(5),
-		"queue_limit": float64(5),
-		"retry_times": float64(3),
-	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -4234,10 +4222,6 @@ func Test_FillPluginsDefaultsWithPartials(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			// Add the default value of `throttling` to the expected configuration of plugin.
-			if rlaHasThrottlingVersionRange(kongVersion) {
-				tc.expectedPlugin.Config["throttling"] = defaultRLAThrotlling
-			}
 			opts := cmpopts.IgnoreFields(*tc.plugin, "Enabled", "Protocols")
 			if diff := cmp.Diff(tc.plugin, tc.expectedPlugin, opts); diff != "" {
 				t.Errorf("unexpected diff:\n%s", diff)


### PR DESCRIPTION
Reverts Kong/go-kong#543 as throttling feature is moved to 3.12