### PR TITLE
feat(upstream): add StickySessionsCookie and StickySessionsCookiePath

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -50,6 +50,7 @@ jobs:
         exclude:
           - kong_version: '2.8'
             router_flavor: 'expressions'
+          - kong_version: '3.10'
         dbmode:
           - 'dbless'
           - 'postgres'

--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,8 @@ golangci-lint: mise yq ## Download golangci-lint locally if necessary.
 
 .PHONY: kong.supported-versions
 kong.supported-versions:
-	@echo ["3.8", "3.9"]
-
-# TODO(Jintao): disabled it temporarily, because it need some time to fix
-#               once the docs team fix the issue, we can enable it again.
-#	@curl -s https://docs.konghq.com/_api/gateway-versions.json | \
-#   jq '[.[] | select(.label == null) | select(.endOfLifeDate > (now | strftime("%Y-%m-%d")))] | [.[].tag]'
+	@curl -s https://developer.konghq.com/_api/gateway-versions.json | \
+	    jq '[.[] | select(.label == null) | select(.endOfLifeDate > (now | strftime("%Y-%m-%d")))] | [.[].tag]'
 
 # ------------------------------------------------------------------------------
 # Testing

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,12 @@ golangci-lint: mise yq ## Download golangci-lint locally if necessary.
 
 .PHONY: kong.supported-versions
 kong.supported-versions:
-	@curl -s https://docs.konghq.com/_api/gateway-versions.json | \
-		jq '[.[] | select(.label == null) | select(.endOfLifeDate > (now | strftime("%Y-%m-%d")))] | [.[].tag]'
+	@echo ["3.8", "3.9"]
+
+# TODO(Jintao): disabled it temporarily, because it need some time to fix
+#               once the docs team fix the issue, we can enable it again.
+#	@curl -s https://docs.konghq.com/_api/gateway-versions.json | \
+#   jq '[.[] | select(.label == null) | select(.endOfLifeDate > (now | strftime("%Y-%m-%d")))] | [.[].tag]'
 
 # ------------------------------------------------------------------------------
 # Testing

--- a/kong/rbac_user_service.go
+++ b/kong/rbac_user_service.go
@@ -96,6 +96,10 @@ func (s *RBACUserService) Update(ctx context.Context,
 		return nil, fmt.Errorf("ID and Name cannot both be nil for Update operation")
 	}
 
+	if user.UserTokenIdent != nil {
+		return nil, fmt.Errorf("UserTokenIdent cannot be set for Update operation")
+	}
+
 	endpoint := fmt.Sprintf("/rbac/users/%v", *user.ID)
 	req, err := s.client.NewRequest("PATCH", endpoint, nil, user)
 	if err != nil {

--- a/kong/rbac_user_service_test.go
+++ b/kong/rbac_user_service_test.go
@@ -33,6 +33,7 @@ func TestRBACUserService(T *testing.T) {
 	assert.NotNil(user)
 
 	user.Comment = String("new comment")
+	user.UserTokenIdent = nil
 	user, err = client.RBACUsers.Update(defaultCtx, user)
 	require.NoError(T, err)
 	assert.NotNil(user)
@@ -81,6 +82,7 @@ func TestRBACUserServiceWorkspace(T *testing.T) {
 	assert.NotNil(user)
 
 	user.Comment = String("new comment")
+	user.UserTokenIdent = nil
 	user, err = workspaceClient.RBACUsers.Update(defaultCtx, user)
 	require.NoError(T, err)
 	assert.NotNil(user)

--- a/kong/upstream.go
+++ b/kong/upstream.go
@@ -3,26 +3,28 @@ package kong
 // Upstream represents an Upstream in Kong.
 // +k8s:deepcopy-gen=true
 type Upstream struct {
-	ID                     *string      `json:"id,omitempty" yaml:"id,omitempty"`
-	Name                   *string      `json:"name,omitempty" yaml:"name,omitempty"`
-	HostHeader             *string      `json:"host_header,omitempty" yaml:"host_header,omitempty"`
-	ClientCertificate      *Certificate `json:"client_certificate,omitempty" yaml:"client_certificate,omitempty"`
-	Algorithm              *string      `json:"algorithm,omitempty" yaml:"algorithm,omitempty"`
-	Slots                  *int         `json:"slots,omitempty" yaml:"slots,omitempty"`
-	Healthchecks           *Healthcheck `json:"healthchecks,omitempty" yaml:"healthchecks,omitempty"`
-	CreatedAt              *int64       `json:"created_at,omitempty" yaml:"created_at,omitempty"`
-	HashOn                 *string      `json:"hash_on,omitempty" yaml:"hash_on,omitempty"`
-	HashFallback           *string      `json:"hash_fallback,omitempty" yaml:"hash_fallback,omitempty"`
-	HashOnHeader           *string      `json:"hash_on_header,omitempty" yaml:"hash_on_header,omitempty"`
-	HashFallbackHeader     *string      `json:"hash_fallback_header,omitempty" yaml:"hash_fallback_header,omitempty"`
-	HashOnCookie           *string      `json:"hash_on_cookie,omitempty" yaml:"hash_on_cookie,omitempty"`
-	HashOnCookiePath       *string      `json:"hash_on_cookie_path,omitempty" yaml:"hash_on_cookie_path,omitempty"`
-	HashOnQueryArg         *string      `json:"hash_on_query_arg,omitempty" yaml:"hash_on_query_arg,omitempty"`
-	HashFallbackQueryArg   *string      `json:"hash_fallback_query_arg,omitempty" yaml:"hash_fallback_query_arg,omitempty"` //nolint:lll
-	HashOnURICapture       *string      `json:"hash_on_uri_capture,omitempty" yaml:"hash_on_uri_capture,omitempty"`
-	HashFallbackURICapture *string      `json:"hash_fallback_uri_capture,omitempty" yaml:"hash_fallback_uri_capture,omitempty"` //nolint:lll
-	UseSrvName             *bool        `json:"use_srv_name,omitempty" yaml:"use_srv_name,omitempty"`
-	Tags                   []*string    `json:"tags,omitempty" yaml:"tags,omitempty"`
+	ID                       *string      `json:"id,omitempty" yaml:"id,omitempty"`
+	Name                     *string      `json:"name,omitempty" yaml:"name,omitempty"`
+	HostHeader               *string      `json:"host_header,omitempty" yaml:"host_header,omitempty"`
+	ClientCertificate        *Certificate `json:"client_certificate,omitempty" yaml:"client_certificate,omitempty"`
+	Algorithm                *string      `json:"algorithm,omitempty" yaml:"algorithm,omitempty"`
+	Slots                    *int         `json:"slots,omitempty" yaml:"slots,omitempty"`
+	Healthchecks             *Healthcheck `json:"healthchecks,omitempty" yaml:"healthchecks,omitempty"`
+	CreatedAt                *int64       `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	HashOn                   *string      `json:"hash_on,omitempty" yaml:"hash_on,omitempty"`
+	HashFallback             *string      `json:"hash_fallback,omitempty" yaml:"hash_fallback,omitempty"`
+	HashOnHeader             *string      `json:"hash_on_header,omitempty" yaml:"hash_on_header,omitempty"`
+	HashFallbackHeader       *string      `json:"hash_fallback_header,omitempty" yaml:"hash_fallback_header,omitempty"`
+	HashOnCookie             *string      `json:"hash_on_cookie,omitempty" yaml:"hash_on_cookie,omitempty"`
+	HashOnCookiePath         *string      `json:"hash_on_cookie_path,omitempty" yaml:"hash_on_cookie_path,omitempty"`
+	HashOnQueryArg           *string      `json:"hash_on_query_arg,omitempty" yaml:"hash_on_query_arg,omitempty"`
+	HashFallbackQueryArg     *string      `json:"hash_fallback_query_arg,omitempty" yaml:"hash_fallback_query_arg,omitempty"` //nolint:lll
+	HashOnURICapture         *string      `json:"hash_on_uri_capture,omitempty" yaml:"hash_on_uri_capture,omitempty"`
+	HashFallbackURICapture   *string      `json:"hash_fallback_uri_capture,omitempty" yaml:"hash_fallback_uri_capture,omitempty"` //nolint:lll
+	UseSrvName               *bool        `json:"use_srv_name,omitempty" yaml:"use_srv_name,omitempty"`
+	StickySessionsCookie     *string      `json:"sticky_sessions_cookie,omitempty" yaml:"sticky_sessions_cookie,omitempty"`
+	StickySessionsCookiePath *string      `json:"sticky_sessions_cookie_path,omitempty" yaml:"sticky_sessions_cookie_path,omitempty"` //nolint:lll
+	Tags                     []*string    `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 // Healthy configures thresholds and HTTP status codes

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -1305,6 +1305,98 @@ func TestFillUpstreamsDefaults(T *testing.T) {
 	}
 }
 
+func TestUpstreamStickySessionsFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		upstream *Upstream
+		expected *Upstream
+	}{
+		{
+			name: "sticky sessions cookie field is preserved",
+			upstream: &Upstream{
+				Name:                 String("test-upstream"),
+				StickySessionsCookie: String("session_id"),
+			},
+			expected: &Upstream{
+				Name:                 String("test-upstream"),
+				StickySessionsCookie: String("session_id"),
+			},
+		},
+		{
+			name: "sticky sessions cookie path field is preserved",
+			upstream: &Upstream{
+				Name:                     String("test-upstream"),
+				StickySessionsCookiePath: String("/api"),
+			},
+			expected: &Upstream{
+				Name:                     String("test-upstream"),
+				StickySessionsCookiePath: String("/api"),
+			},
+		},
+		{
+			name: "both sticky sessions fields are preserved",
+			upstream: &Upstream{
+				Name:                     String("test-upstream"),
+				StickySessionsCookie:     String("session_id"),
+				StickySessionsCookiePath: String("/api"),
+			},
+			expected: &Upstream{
+				Name:                     String("test-upstream"),
+				StickySessionsCookie:     String("session_id"),
+				StickySessionsCookiePath: String("/api"),
+			},
+		},
+		{
+			name: "sticky sessions fields work with nil values",
+			upstream: &Upstream{
+				Name:                     String("test-upstream"),
+				StickySessionsCookie:     nil,
+				StickySessionsCookiePath: nil,
+			},
+			expected: &Upstream{
+				Name:                     String("test-upstream"),
+				StickySessionsCookie:     nil,
+				StickySessionsCookiePath: nil,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test that the fields are correctly set and preserved
+			assert.Equal(t, tc.expected.Name, tc.upstream.Name)
+			assert.Equal(t, tc.expected.StickySessionsCookie, tc.upstream.StickySessionsCookie)
+			assert.Equal(t, tc.expected.StickySessionsCookiePath, tc.upstream.StickySessionsCookiePath)
+		})
+	}
+}
+
+func TestUpstreamStickySessionsJSONSerialization(t *testing.T) {
+	upstream := &Upstream{
+		Name:                     String("test-upstream"),
+		StickySessionsCookie:     String("session_id"),
+		StickySessionsCookiePath: String("/api"),
+	}
+
+	// Test JSON marshaling
+	jsonData, err := json.Marshal(upstream)
+	require.NoError(t, err)
+
+	// Verify the JSON contains the expected fields
+	assert.Contains(t, string(jsonData), `"sticky_sessions_cookie":"session_id"`)
+	assert.Contains(t, string(jsonData), `"sticky_sessions_cookie_path":"/api"`)
+
+	// Test JSON unmarshaling
+	var unmarshaledUpstream Upstream
+	err = json.Unmarshal(jsonData, &unmarshaledUpstream)
+	require.NoError(t, err)
+
+	// Verify the fields were correctly unmarshaled
+	assert.Equal(t, "test-upstream", *unmarshaledUpstream.Name)
+	assert.Equal(t, "session_id", *unmarshaledUpstream.StickySessionsCookie)
+	assert.Equal(t, "/api", *unmarshaledUpstream.StickySessionsCookiePath)
+}
+
 func getJSONSchemaFromFile(t *testing.T, filename string) Schema {
 	jsonFile, err := os.Open(filename)
 	require.NoError(t, err)

--- a/kong/workspace_service_test.go
+++ b/kong/workspace_service_test.go
@@ -110,6 +110,10 @@ func TestWorkspaceServiceList(T *testing.T) {
 	require.NoError(err)
 	assert.Nil(next)
 	assert.NotNil(workspaces)
+	// log the workspaces
+	for _, w := range workspaces {
+		T.Log(w.Name)
+	}
 	// Counts default workspace
 	assert.Len(workspaces, 3)
 

--- a/kong/zz_generated.deepcopy.go
+++ b/kong/zz_generated.deepcopy.go
@@ -2752,6 +2752,16 @@ func (in *Upstream) DeepCopyInto(out *Upstream) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.StickySessionsCookie != nil {
+		in, out := &in.StickySessionsCookie, &out.StickySessionsCookie
+		*out = new(string)
+		**out = **in
+	}
+	if in.StickySessionsCookiePath != nil {
+		in, out := &in.StickySessionsCookiePath, &out.StickySessionsCookiePath
+		*out = new(string)
+		**out = **in
+	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make([]*string, len(*in))


### PR DESCRIPTION
Kong Gateway upstream has added two new fields to support session stickiness in version 3.11 and later. This PR updates the Upstream entities in go-kong to match the Gateway upstream entity.
