### PR TITLE
ci: use a default workflow timeout fallback value

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   analyze:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     name: Analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   golangci:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/integration-test-enterprise-nightly.yaml
+++ b/.github/workflows/integration-test-enterprise-nightly.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   secret-available:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     outputs:
       ok: ${{ steps.exists.outputs.ok }}
     runs-on: ubuntu-latest
@@ -32,7 +32,7 @@ jobs:
         fi
 
   test-enterprise:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     strategy:
       matrix:
         router_flavor:

--- a/.github/workflows/integration-test-enterprise.yaml
+++ b/.github/workflows/integration-test-enterprise.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   secret-available:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     outputs:
       ok: ${{ steps.exists.outputs.ok }}
     runs-on: ubuntu-latest
@@ -37,7 +37,7 @@ jobs:
   # in the supported versions would block a PR from merging.
   # This is still better than maintaining the hardcoded matrix of versions in the workflow itself.
   supported-kong-versions:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     outputs:
       result: ${{ steps.result.outputs.versions }}
     runs-on: ubuntu-latest
@@ -54,7 +54,7 @@ jobs:
         echo "Kong versions: ${{ steps.result.outputs.versions }}"
 
   test-enterprise:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     continue-on-error: true
     needs:
     - secret-available
@@ -110,7 +110,7 @@ jobs:
           fail_ci_if_error: true
 
   test-enterprise-passed:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     runs-on: ubuntu-latest
     needs: test-enterprise
     if: always()

--- a/.github/workflows/integration-test-nightly.yaml
+++ b/.github/workflows/integration-test-nightly.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     strategy:
       matrix:
         dbmode:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -22,7 +22,7 @@ jobs:
   # in the supported versions would block a PR from merging.
   # This is still better than maintaining the hardcoded matrix of versions in the workflow itself.
   supported-kong-versions:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     outputs:
       result: ${{ steps.result.outputs.versions }}
     runs-on: ubuntu-latest
@@ -39,7 +39,7 @@ jobs:
         echo "Kong versions: ${{ steps.result.outputs.versions }}"
 
   test:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     needs:
     - supported-kong-versions
     strategy:
@@ -84,7 +84,7 @@ jobs:
           fail_ci_if_error: true
 
   test-passed:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     runs-on: ubuntu-latest
     needs: test
     if: always()


### PR DESCRIPTION
This allows the PRs that run in fork context to fall back to this introduced value (10).