### PR TITLE
Add Failover parameter to Target

### DIFF
--- a/kong/target.go
+++ b/kong/target.go
@@ -9,6 +9,7 @@ type Target struct {
 	Upstream  *Upstream `json:"upstream,omitempty" yaml:"upstream,omitempty"`
 	Weight    *int      `json:"weight,omitempty" yaml:"weight,omitempty"`
 	Tags      []*string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Failover  *bool     `json:"failover,omitempty" yaml:"failover,omitempty"`
 }
 
 // FriendlyName returns the endpoint key name or ID.

--- a/kong/target_service_test.go
+++ b/kong/target_service_test.go
@@ -167,7 +167,6 @@ func TestTargetWithTags(T *testing.T) {
 
 func TestTargetWithFailover(T *testing.T) {
 	RunWhenKong(T, ">=3.12.0")
-	assert := assert.New(T)
 	require := require.New(T)
 
 	client, err := NewTestClient(nil, nil)
@@ -178,6 +177,9 @@ func TestTargetWithFailover(T *testing.T) {
 		Name: String("vhost.com"),
 	})
 	require.NoError(err)
+	T.Cleanup(func() {
+		require.NoError(client.Upstreams.Delete(defaultCtx, fixtureUpstream.ID))
+	})
 
 	createdTarget, err := client.Targets.Create(defaultCtx,
 		fixtureUpstream.ID, &Target{
@@ -186,10 +188,7 @@ func TestTargetWithFailover(T *testing.T) {
 		})
 	require.NoError(err)
 	require.NotNil(createdTarget)
-	assert.True(*createdTarget.Failover)
-
-	err = client.Upstreams.Delete(defaultCtx, fixtureUpstream.ID)
-	require.NoError(err)
+	require.True(*createdTarget.Failover)
 }
 
 func TestTargetWithFailoverDefault(T *testing.T) {
@@ -205,6 +204,9 @@ func TestTargetWithFailoverDefault(T *testing.T) {
 		Name: String("vhost.com"),
 	})
 	require.NoError(err)
+	T.Cleanup(func() {
+		require.NoError(client.Upstreams.Delete(defaultCtx, fixtureUpstream.ID))
+	})
 
 	createdTarget, err := client.Targets.Create(defaultCtx,
 		fixtureUpstream.ID, &Target{
@@ -213,9 +215,6 @@ func TestTargetWithFailoverDefault(T *testing.T) {
 	require.NoError(err)
 	require.NotNil(createdTarget)
 	assert.False(*createdTarget.Failover)
-
-	err = client.Upstreams.Delete(defaultCtx, fixtureUpstream.ID)
-	require.NoError(err)
 }
 
 func TestTargetListEndpoint(T *testing.T) {

--- a/kong/target_service_test.go
+++ b/kong/target_service_test.go
@@ -165,6 +165,59 @@ func TestTargetWithTags(T *testing.T) {
 	require.NoError(err)
 }
 
+func TestTargetWithFailover(T *testing.T) {
+	RunWhenKong(T, ">=3.12.0")
+	assert := assert.New(T)
+	require := require.New(T)
+
+	client, err := NewTestClient(nil, nil)
+	require.NoError(err)
+	require.NotNil(client)
+
+	fixtureUpstream, err := client.Upstreams.Create(defaultCtx, &Upstream{
+		Name: String("vhost.com"),
+	})
+	require.NoError(err)
+
+	createdTarget, err := client.Targets.Create(defaultCtx,
+		fixtureUpstream.ID, &Target{
+			Target:   String("10.0.0.1:80"),
+			Failover: Bool(true),
+		})
+	require.NoError(err)
+	require.NotNil(createdTarget)
+	assert.True(*createdTarget.Failover)
+
+	err = client.Upstreams.Delete(defaultCtx, fixtureUpstream.ID)
+	require.NoError(err)
+}
+
+func TestTargetWithFailoverDefault(T *testing.T) {
+	RunWhenKong(T, ">=3.12.0")
+	assert := assert.New(T)
+	require := require.New(T)
+
+	client, err := NewTestClient(nil, nil)
+	require.NoError(err)
+	require.NotNil(client)
+
+	fixtureUpstream, err := client.Upstreams.Create(defaultCtx, &Upstream{
+		Name: String("vhost.com"),
+	})
+	require.NoError(err)
+
+	createdTarget, err := client.Targets.Create(defaultCtx,
+		fixtureUpstream.ID, &Target{
+			Target: String("10.0.0.1:80"),
+		})
+	require.NoError(err)
+	require.NotNil(createdTarget)
+	assert.False(*createdTarget.Failover)
+
+	err = client.Upstreams.Delete(defaultCtx, fixtureUpstream.ID)
+	require.NoError(err)
+}
+
 func TestTargetListEndpoint(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
 

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -1148,6 +1148,9 @@ func TestFillTargetDefaults(T *testing.T) {
 		},
 	}
 
+	kongVersion := GetVersionForTesting(T)
+	hasFailoverVersionRange := MustNewRange(">=3.12.0")
+
 	for _, tc := range tests {
 		T.Run(tc.name, func(t *testing.T) {
 			target := tc.target
@@ -1155,6 +1158,11 @@ func TestFillTargetDefaults(T *testing.T) {
 			require.NoError(T, err)
 			assert.NotNil(fullSchema)
 			require.NoError(t, FillEntityDefaults(target, fullSchema))
+
+			if hasFailoverVersionRange(kongVersion) {
+				tc.expected.Failover = Bool(false)
+			}
+
 			if diff := cmp.Diff(target, tc.expected); diff != "" {
 				t.Errorf("unexpected diff:\n%s", diff)
 			}

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -1150,16 +1150,19 @@ func TestFillTargetDefaults(T *testing.T) {
 
 	kongVersion := GetVersionForTesting(T)
 	hasFailoverVersionRange := MustNewRange(">=3.12.0")
+	shouldContainFailover := hasFailoverVersionRange(kongVersion)
 
 	for _, tc := range tests {
 		T.Run(tc.name, func(t *testing.T) {
 			target := tc.target
 			fullSchema, err := client.Schemas.Get(defaultCtx, "targets")
-			require.NoError(T, err)
-			assert.NotNil(fullSchema)
+			require.NoError(t, err)
+			require.NotNil(t, fullSchema)
 			require.NoError(t, FillEntityDefaults(target, fullSchema))
 
-			if hasFailoverVersionRange(kongVersion) {
+			// Gateway 3.12 added a new Failover field to targets
+			// which has a default of False
+			if shouldContainFailover {
 				tc.expected.Failover = Bool(false)
 			}
 

--- a/kong/zz_generated.deepcopy.go
+++ b/kong/zz_generated.deepcopy.go
@@ -2600,6 +2600,11 @@ func (in *Target) DeepCopyInto(out *Target) {
 			}
 		}
 	}
+	if in.Failover != nil {
+		in, out := &in.Failover, &out.Failover
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Added in Gateway 3.12

You can set `failover: true` to indicate that a Target should be used as a failover (backup) Target in case the other, regular targets (`failover: false`) associated with an Upstream are unhealthy. The failover Target is only used when all regular Targets are unhealthy. You can set one or multiple failover Targets for an Upstream.