### PR TITLE
feat: Added CreateWithID func and test for graphql_rate_limiting_cost_decoration_service

### DIFF
--- a/kong/graphql_rate_limiting_cost_decoration_service.go
+++ b/kong/graphql_rate_limiting_cost_decoration_service.go
@@ -9,6 +9,8 @@ import (
 type AbstractGraphqlRateLimitingCostDecorationService interface {
 	// Creates a cost decoration for the GraphQL rate-limiting plugin in Kong.
 	Create(ctx context.Context, costDeco *GraphqlRateLimitingCostDecoration) (*GraphqlRateLimitingCostDecoration, error)
+	// Creates a cost decoration with a specified ID for the GraphQL rate-limiting plugin in Kong.
+	CreateWithID(ctx context.Context, costDeco *GraphqlRateLimitingCostDecoration) (*GraphqlRateLimitingCostDecoration, error)
 	// Fetches a cost decoration for the GraphQL rate-limiting plugin from Kong.
 	Get(ctx context.Context, ID *string) (*GraphqlRateLimitingCostDecoration, error)
 	// UPdates a cost decoration for the GraphQL rate-limiting plugin in Kong.
@@ -33,6 +35,32 @@ func (s *GraphqlRateLimitingCostDecorationService) Create(
 	if costDeco.ID != nil {
 		return nil, fmt.Errorf("can't specify an ID for creating new Cost Decoration")
 	}
+	req, err := s.client.NewRequest("POST", queryPath, nil, costDeco)
+	if err != nil {
+		return nil, err
+	}
+
+	var createdCostDeco GraphqlRateLimitingCostDecoration
+	err = ErrorOrResponseError(s.client.Do(ctx, req, &createdCostDeco))
+	if err != nil {
+		return nil, err
+	}
+
+	return &createdCostDeco, nil
+}
+
+// CreateWithID creates a CostDecoration item in Kong for the GraphQL rate limiting advanced plugin
+// with a specified ID.
+func (s *GraphqlRateLimitingCostDecorationService) CreateWithID(
+	ctx context.Context,
+	costDeco *GraphqlRateLimitingCostDecoration,
+) (*GraphqlRateLimitingCostDecoration, error) {
+	if isEmptyString(costDeco.ID) {
+		return nil, fmt.Errorf("ID cannot be nil for CreateWithID operation")
+	}
+
+	const queryPath = "/graphql-rate-limiting-advanced/costs"
+
 	req, err := s.client.NewRequest("POST", queryPath, nil, costDeco)
 	if err != nil {
 		return nil, err

--- a/kong/graphql_rate_limiting_cost_decoration_service.go
+++ b/kong/graphql_rate_limiting_cost_decoration_service.go
@@ -10,7 +10,8 @@ type AbstractGraphqlRateLimitingCostDecorationService interface {
 	// Creates a cost decoration for the GraphQL rate-limiting plugin in Kong.
 	Create(ctx context.Context, costDeco *GraphqlRateLimitingCostDecoration) (*GraphqlRateLimitingCostDecoration, error)
 	// Creates a cost decoration with a specified ID for the GraphQL rate-limiting plugin in Kong.
-	CreateWithID(ctx context.Context, costDeco *GraphqlRateLimitingCostDecoration) (*GraphqlRateLimitingCostDecoration, error)
+	CreateWithID(ctx context.Context, costDeco *GraphqlRateLimitingCostDecoration) (
+		*GraphqlRateLimitingCostDecoration, error)
 	// Fetches a cost decoration for the GraphQL rate-limiting plugin from Kong.
 	Get(ctx context.Context, ID *string) (*GraphqlRateLimitingCostDecoration, error)
 	// UPdates a cost decoration for the GraphQL rate-limiting plugin in Kong.

--- a/kong/graphql_rate_limiting_cost_decoration_service_test.go
+++ b/kong/graphql_rate_limiting_cost_decoration_service_test.go
@@ -66,15 +66,18 @@ func TestGraphqlRateLimitingCostDecorationService(t *testing.T) {
 		createdDeco, err := client.GraphqlRateLimitingCostDecorations.CreateWithID(defaultCtx, deco)
 		require.NoError(t, err)
 		require.NotNil(t, createdDeco)
+		require.Equal(t, id, *createdDeco.ID)
 
 		deco, err = client.GraphqlRateLimitingCostDecorations.Get(defaultCtx, createdDeco.ID)
 		require.NoError(t, err)
 		require.NotNil(t, deco)
+		require.Equal(t, id, *deco.ID)
 
 		deco.TypePath = String("car.designation")
 		deco, err = client.GraphqlRateLimitingCostDecorations.Update(defaultCtx, deco)
 		require.NoError(t, err)
 		require.NotNil(t, deco)
+		require.Equal(t, id, *deco.ID)
 		require.Equal(t, "car.designation", *deco.TypePath)
 
 		err = client.GraphqlRateLimitingCostDecorations.Delete(defaultCtx, createdDeco.ID)

--- a/kong/graphql_rate_limiting_cost_decoration_service_test.go
+++ b/kong/graphql_rate_limiting_cost_decoration_service_test.go
@@ -53,4 +53,43 @@ func TestGraphqlRateLimitingCostDecorationService(t *testing.T) {
 		require.Error(t, err, "can't specify an ID for creating new Cost Decoration")
 		require.Nil(t, createdDeco)
 	})
+
+	t.Run("CreateWithID create/get/update/delete cycle", func(t *testing.T) {
+		id := uuid.NewString()
+		deco := &GraphqlRateLimitingCostDecoration{
+			ID:           String(id),
+			TypePath:     String("Vehicle.name"),
+			AddConstant:  Float64(8),
+			MulArguments: []*string{String("first")},
+		}
+
+		createdDeco, err := client.GraphqlRateLimitingCostDecorations.CreateWithID(defaultCtx, deco)
+		require.NoError(t, err)
+		require.NotNil(t, createdDeco)
+
+		deco, err = client.GraphqlRateLimitingCostDecorations.Get(defaultCtx, createdDeco.ID)
+		require.NoError(t, err)
+		require.NotNil(t, deco)
+
+		deco.TypePath = String("car.designation")
+		deco, err = client.GraphqlRateLimitingCostDecorations.Update(defaultCtx, deco)
+		require.NoError(t, err)
+		require.NotNil(t, deco)
+		require.Equal(t, "car.designation", *deco.TypePath)
+
+		err = client.GraphqlRateLimitingCostDecorations.Delete(defaultCtx, createdDeco.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("Can't CreateWithID Cost Decoration without ID", func(t *testing.T) {
+		deco := &GraphqlRateLimitingCostDecoration{
+			TypePath:     String("car.name"),
+			AddConstant:  Float64(8),
+			MulArguments: []*string{String("first")},
+		}
+
+		createdDeco, err := client.GraphqlRateLimitingCostDecorations.CreateWithID(defaultCtx, deco)
+		require.Error(t, err, "ID cannot be nil for CreateWithID operation")
+		require.Nil(t, createdDeco)
+	})
 }


### PR DESCRIPTION
https://konghq.atlassian.net/browse/FTI-7307
https://github.com/Kong/deck/issues/1909

Summary:

1. Introduced a new method CreateWithID in AbstractGraphqlRateLimitingCostDecorationService to allow creating CostDecoration entities in Kong with a specified ID.
2. This change was required because the existing Create method does not allow specifying an ID, whereas decK supports user-defined IDs during resource creation.