### PR TITLE
fix: Used PUT instead of PATCH for Update in target_service

### DIFF
--- a/kong/target_service.go
+++ b/kong/target_service.go
@@ -232,7 +232,7 @@ func (s *TargetService) Update(ctx context.Context,
 	}
 
 	endpoint := fmt.Sprintf("/upstreams/%v/targets/%v", *upstreamNameOrID, *targetOrID)
-	req, err := s.client.NewRequest("PATCH", endpoint, nil, target)
+	req, err := s.client.NewRequest("PUT", endpoint, nil, target)
 	if err != nil {
 		return nil, err
 	}

--- a/kong/target_service.go
+++ b/kong/target_service.go
@@ -23,7 +23,7 @@ type AbstractTargetService interface {
 	// Kong's load balancer.
 	MarkUnhealthy(ctx context.Context, upstreamNameOrID *string, target *Target) error
 	// Update updates a Target in Kong under upstreamID.
-	// Note: The update is performed using the "PATCH" method.
+	// Note: The update is performed using the "PUT" method.
 	Update(ctx context.Context, upstreamNameOrID *string, targetOrID *string, target *Target) (*Target, error)
 	// ListAllTargets fetches a list of Targets in Kong using the global `/targets` endpoint.
 	ListAllTargets(ctx context.Context, opt *ListOpt) ([]*Target, *ListOpt, error)

--- a/kong/target_service_test.go
+++ b/kong/target_service_test.go
@@ -301,7 +301,7 @@ func TestTargetListEndpoint(T *testing.T) {
 	require.NoError(client.Upstreams.Delete(defaultCtx, createdUpstream.ID))
 }
 
-func TestTargetsUpdatePatch(T *testing.T) {
+func TestTargetsUpdatePut(T *testing.T) {
 	RunWhenDBMode(T, "postgres")
 
 	assert := assert.New(T)


### PR DESCRIPTION
Issue: https://github.com/Kong/deck/issues/1894

Summary:
decK sync was failing when modifying upstream target weights in Konnect because the update operation in target CRUD used the PATCH endpoint, which is not supported by Konnect. This has been fixed by switching the update operation to use PUT instead.