### PR TITLE
fix: moved from patch to put endpoint for consumer group update

### DIFF
--- a/kong/consumer_group_service.go
+++ b/kong/consumer_group_service.go
@@ -110,7 +110,7 @@ func (s *ConsumerGroupService) Update(ctx context.Context,
 	}
 
 	endpoint := fmt.Sprintf("/consumer_groups/%v", *consumerGroup.ID)
-	req, err := s.client.NewRequest("PATCH", endpoint, nil, consumerGroup)
+	req, err := s.client.NewRequest("PUT", endpoint, nil, consumerGroup)
 	if err != nil {
 		return nil, err
 	}

--- a/kong/consumer_group_service.go
+++ b/kong/consumer_group_service.go
@@ -108,9 +108,12 @@ func (s *ConsumerGroupService) Update(ctx context.Context,
 	if isEmptyString(consumerGroup.ID) {
 		return nil, fmt.Errorf("ID cannot be nil for Update operation")
 	}
-
+	method := "PATCH"
+	if s.client.isKonnect {
+		method = "PUT"
+	}
 	endpoint := fmt.Sprintf("/consumer_groups/%v", *consumerGroup.ID)
-	req, err := s.client.NewRequest("PUT", endpoint, nil, consumerGroup)
+	req, err := s.client.NewRequest(method, endpoint, nil, consumerGroup)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
GH: https://github.com/Kong/deck/issues/2048

Summary:
We got an issue where consumer groups were not working with konnect workspaces, because in decK we were using some old endpoint for konnect-consumer-group, after a detailed discussion([slack thread](https://kongstrong.slack.com/archives/C09PFG2R1R8/p1777559350151019)), we have got to know that now konnect is also supporting same endpoints as kong on-prem.

As we know, Konnect support PUT for update operation instead of PATCH, I have added this change to accommodate both flows.