### PR TITLE
Remove @Kong/team-cloud from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Kong/k8s-maintainers @Kong/team-cloud @Kong/apiops-maintainers
+* @Kong/k8s-maintainers @Kong/apiops-maintainers


### PR DESCRIPTION
We don't have anything to do with this repo anymore so removing us from CODEOWNERS to avoid getting emails for PRs