### PR TITLE
fix: do not fill auto fields with FillPluginsDefaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Table of Contents
 
+- [v0.76.2](#v0762)
+- [v0.76.1](#v0761)
 - [v0.76.0](#v0760)
 - [v0.75.1](#v0751)
 - [v0.75.0](#v0750)
@@ -95,6 +97,17 @@
 - [0.3.0](#030)
 - [0.2.0](#020)
 - [0.1.0](#010)
+
+## [v0.76.2]
+
+> Release date: 2026/06/19
+
+- Do not fill auto fields with `FillPluginsDefaults`.
+  Those fields are meant to be set by Kong.
+  Filling them might cause issues, for example: filling in the namespace field
+  in rate-limiting-advanced plugin (setting it it to nil) will cause the config
+  to be rejected by Kong as the namespace field is required to be set to a non-nil value.
+  [#623](https://github.com/Kong/go-kong/pull/623)
 
 ## [v0.76.1]
 
@@ -1184,6 +1197,8 @@ authentication credentials in Kong.
   releases of Kong since every release of Kong is introducing breaking changes
   to the Admin API.
 
+[v0.76.2]: https://github.com/Kong/go-kong/compare/v0.76.1...v0.76.2
+[v0.76.1]: https://github.com/Kong/go-kong/compare/v0.76.0...v0.76.1
 [v0.76.0]: https://github.com/Kong/go-kong/compare/v0.75.1...v0.76.0
 [v0.75.1]: https://github.com/Kong/go-kong/compare/v0.75.0...v0.75.1
 [v0.75.0]: https://github.com/Kong/go-kong/compare/v0.74.0...v0.75.0

--- a/kong/utils.go
+++ b/kong/utils.go
@@ -1039,7 +1039,11 @@ func fillConfigRecordWithPartialsConfig(plugin *Plugin, pluginSchema map[string]
 func FillPluginsDefaults(plugin *Plugin, schema Schema) error {
 	return fillConfigRecordDefaultsAutoFields(plugin, schema, nil, FillRecordOptions{
 		FillDefaults: true,
-		FillAuto:     true,
+		// Do not fill auto fields as they are meant to be set by Kong.
+		// Filling them might cause issues, for example: filling in the namespace field
+		// in rate-limiting-advanced plugin (setting it it to nil) will cause the config
+		// to be rejected by Kong as the namespace field is required to be set to a non-nil value.
+		FillAuto: false,
 	})
 }
 

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -2356,6 +2356,49 @@ const fillConfigRecordTestSchemaWithAutoFields = `{
 }
 `
 
+const fillPluginsDefaultsRateLimitingAdvancedSchema = `{
+	"fields": [
+		{
+			"config": {
+				"type": "record",
+				"fields": [
+					{
+						"dictionary_name": {
+							"type": "string",
+							"default": "kong_rate_limiting_counters"
+						}
+					},
+					{
+						"identifier": {
+							"type": "string",
+							"default": "consumer"
+						}
+					},
+					{
+						"window_size": {
+							"type": "array",
+							"elements": [
+								{
+									"type": "number"
+								}
+							],
+							"required": true
+						}
+					},
+					{
+						"namespace": {
+							"type": "string",
+							"auto": true,
+							"required": true
+						}
+					}
+				]
+			}
+		}
+	]
+}
+`
+
 const fillConfigRecordTestSchemaWithRecord = `{
 	"fields": {
 		"config": {
@@ -2698,6 +2741,21 @@ func Test_FillPluginsDefaults(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_FillPluginsDefaults_SkipsAutoFields(t *testing.T) {
+	var fullSchema map[string]any
+	err := json.Unmarshal([]byte(fillPluginsDefaultsRateLimitingAdvancedSchema), &fullSchema)
+	require.NoError(t, err)
+	require.NotNil(t, fullSchema)
+
+	plugin := &Plugin{
+		Config: Configuration{},
+	}
+
+	require.NoError(t, FillPluginsDefaults(plugin, fullSchema))
+	require.Equal(t, "kong_rate_limiting_counters", plugin.Config["dictionary_name"])
+	require.NotContains(t, plugin.Config, "namespace")
 }
 
 func Test_FillPluginsDefaults_RequestTransformer(t *testing.T) {


### PR DESCRIPTION
Setting auto fields with KIC produced errors where, e.g. rate-limiting-advanced namespace field was set to `nil` which caused:

```
invalid config.namespace: required field missing
```

errors.

This change disables, filling auto fields in `FillPluginsDefaults` to prevent that.