### PR TITLE
fix: preserve json plugin config values

### DIFF
--- a/kong/utils.go
+++ b/kong/utils.go
@@ -483,6 +483,16 @@ func fillConfigRecord(
 
 		ftype := value.Get(fname + ".type")
 		frequired := value.Get(fname + ".required")
+		// A field of type "json" holds an opaque JSON value (object or array).
+		// It never needs recursive default-filling. When a value is already
+		// provided in the config, keep it as-is; otherwise the fall-through
+		// below would overwrite a JSON object (which arrives as a
+		// map[string]interface{} and is not matched by the earlier switch)
+		// with nil for lack of a default. A JSON array value is preserved by
+		// the []interface{} switch case above, but objects reach here.
+		if ftype.String() == "json" && config[fname] != nil {
+			return true
+		}
 		// Recursively fill defaults only if the field is either required or a subconfig is provided
 		if ftype.String() == "record" && (config[fname] != nil || (frequired.Exists() && frequired.Bool())) {
 			var fieldConfig Configuration

--- a/kong/utils_test.go
+++ b/kong/utils_test.go
@@ -2217,6 +2217,49 @@ func Test_fillConfigRecord(t *testing.T) {
 				"empty_record": map[string]any{},
 			},
 		},
+		{
+			// A field of type "json" holding a JSON object (e.g. ai-mcp-proxy's
+			// tool.request_body / tool.responses) must be preserved as-is and
+			// never overwritten with nil while filling defaults.
+			name:   "preserves json-typed field holding an object",
+			schema: gjson.Parse(fillConfigRecordTestSchemaWithJSONField),
+			config: Configuration{
+				"request_body": map[string]any{
+					"content": map[string]any{
+						"application/json": map[string]any{
+							"schema": map[string]any{"type": "object"},
+						},
+					},
+				},
+			},
+			expected: Configuration{
+				"enabled": true,
+				"request_body": map[string]any{
+					"content": map[string]any{
+						"application/json": map[string]any{
+							"schema": map[string]any{"type": "object"},
+						},
+					},
+				},
+			},
+		},
+		{
+			// A field of type "json" holding a JSON array (e.g. ai-mcp-proxy's
+			// tool.parameters) must likewise be preserved as-is.
+			name:   "preserves json-typed field holding an array",
+			schema: gjson.Parse(fillConfigRecordTestSchemaWithJSONField),
+			config: Configuration{
+				"request_body": []any{
+					map[string]any{"name": "updateHistory", "in": "query"},
+				},
+			},
+			expected: Configuration{
+				"enabled": true,
+				"request_body": []any{
+					map[string]any{"name": "updateHistory", "in": "query"},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -2234,6 +2277,30 @@ func Test_fillConfigRecord(t *testing.T) {
 		})
 	}
 }
+
+const fillConfigRecordTestSchemaWithJSONField = `{
+	"fields": {
+		"config": {
+			"type": "record",
+			"fields": [
+				{
+					"enabled": {
+						"type": "boolean",
+						"default": true,
+						"required": true
+					}
+				},
+				{
+					"request_body": {
+						"type": "json",
+						"required": false
+					}
+				}
+			]
+		}
+	}
+}
+`
 
 const fillConfigRecordTestSchemaWithShorthandFields = `{
 	"fields": {


### PR DESCRIPTION
Some plugins have JSON-typed fields that contain the actual configurations in use, and we need to keep them.

Fix:  https://konghq.atlassian.net/browse/FTI-7795

```
KIC nulls the ai-mcp-proxy tool's request_body because go-kong's "fill defaults from schema" step does not handle json-typed fields containing a JSON object, overwriting them with nil before the configuration is synced to the Gateway.
```

Fixes: https://github.com/Kong/go-kong/issues/524

