### PR TITLE
fix: normalize Kong versions used by integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ kong.supported-versions:
 .PHONY: kong.supported-versions.oss
 kong.supported-versions.oss:
 	@curl -s https://developer.konghq.com/_api/gateway-versions.json | \
-		jq '[.[] | select(.label == null) | select(.endOfLifeDate > (now | strftime("%Y-%m-%d"))) | select(.tag | split(".") | .[1] | tonumber <= 9)] | [.[].tag]'
+		jq '[.[] | select(.label == null) | select(.endOfLifeDate > (now | strftime("%Y-%m-%d"))) | select(.tag | split(".") | .[1] | tonumber <= 9)] | [.[].tag | split(".") | .[0:2] | join(".")] | unique'
 
 # ------------------------------------------------------------------------------
 # Testing


### PR DESCRIPTION
Backports the Kong version normalization from commit `8263d16` to the `release/0.72.x` branch.

The Gateway versions API now returns package versions such as `3.4.3.28`, which are not valid `kong` Docker image tags. Normalize these to unique major/minor image tags such as `3.4` before building the Community integration-test matrix.

Only the Makefile CI fix is backported; unrelated changes from the original commit are excluded.

Validation:
- `make kong.supported-versions.oss` returns `["3.4"]`
- `docker manifest inspect kong:3.4` succeeds