### PR TITLE
docs: add changelog for v0.72.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [v0.74.0](#v0740)
 - [v0.73.1](#v0731)
 - [v0.73.0](#v0730)
+- [v0.72.2](#v0722)
 - [v0.72.1](#v0721)
 - [v0.72.0](#v0720)
 - [v0.71.0](#v0710)
@@ -161,6 +162,15 @@
 - Added new `CreateWithId` method to the `GraphqlRateLimitingCostDecorationService` using the `POST` operation, enabling
   creation of `GraphqlRateLimitingCostDecoration` with specific ID.
   [#606](https://github.com/Kong/go-kong/pull/606)
+
+## [v0.72.2]
+
+> Release date: 2026/07/30
+
+- Fixed `FillPluginsDefaults` overwriting user-provided values of plugin
+  config fields of type `json` with `nil`. JSON object values are now
+  preserved as-is.
+  [#625](https://github.com/Kong/go-kong/pull/625)
 
 ## [v0.72.1]
 
@@ -1212,6 +1222,7 @@ authentication credentials in Kong.
 [v0.74.0]: https://github.com/Kong/go-kong/compare/v0.73.1...v0.74.0
 [v0.73.1]: https://github.com/Kong/go-kong/compare/v0.73.0...v0.73.1
 [v0.73.0]: https://github.com/Kong/go-kong/compare/v0.72.1...v0.73.0
+[v0.72.2]: https://github.com/Kong/go-kong/compare/v0.72.1...v0.72.2
 [v0.72.1]: https://github.com/Kong/go-kong/compare/v0.72.0...v0.72.1
 [v0.72.0]: https://github.com/Kong/go-kong/compare/v0.71.0...v0.72.0
 [v0.71.0]: https://github.com/Kong/go-kong/compare/v0.70.0...v0.71.0


### PR DESCRIPTION
Add the released `v0.72.2` changelog entry from `release/0.72.x` to the main changelog.

Includes:
- the table-of-contents entry
- the release date and fix description linking to #625
- the `v0.72.1...v0.72.2` comparison link